### PR TITLE
rename 'Receive from Peer' to 'Send to channel'

### DIFF
--- a/src/app/lnd/peers-channels/channels/channel-rebalance-modal/channel-rebalance.component.html
+++ b/src/app/lnd/peers-channels/channels/channel-rebalance-modal/channel-rebalance.component.html
@@ -25,7 +25,7 @@
                   <mat-error *ngIf="inputFormGroup.controls.rebalanceAmount.errors?.max">Amount must be less than or equal to {{selChannel?.local_balance}}.</mat-error>
                 </mat-form-field>
                 <mat-form-field fxFlex="48" fxLayoutAlign="start end">
-                  <mat-select tabindex="2" formControlName="selRebalancePeer" placeholder="Receive from Peer" required>
+                  <mat-select tabindex="2" formControlName="selRebalancePeer" placeholder="Send to channel" required>
                     <mat-option *ngFor="let activeChannel of filteredActiveChannels" [value]="activeChannel">
                       {{activeChannel.remote_alias || activeChannel.chan_id}}
                     </mat-option>


### PR DESCRIPTION
As a new user & LN rookie,
'Receive from Peer' was confusing.
I thought it was trying to have me receive on the channel I clicked 'Circular rebalance'
but the balance limit on the `Amount` field implied the opposite (of course).
It caused a few brain cycles to spin.
I even did the opposite of what I wanted the first time.

Does 'Send to channel' make the choice more clear
that I'm sending From the channel I clicked on
To the channel I'm picking from,
to rebalance?

![image](https://user-images.githubusercontent.com/68125692/89431616-c9487a00-d705-11ea-96ba-fd8aeb4f1969.png)
