### PR TITLE
Changed default password from `changeme` to `password` in doc

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -39,8 +39,8 @@ $ docker-compose logs bitcoind lnd rtl
 
 Once the containers are running you can access the RTL UI at http://localhost:3000
 
- - Default password is `changeme`.
-  - Default host, port and password can be changed in `.env`.
+ - Default password is `password`.
+ - Default host, port and password can be changed in `.env`.
 
 When you are done you can destroy containers with:
 ```


### PR DESCRIPTION
Playing around with the latest version on docker hub here: https://hub.docker.com/r/shahanafarooqui/rtl - for the current version 0.10.1 'changeme' doesn't work, but 'password' does, I actually just guessed it as it doesn't seem to be documented anywhere...