### PR TITLE
Show invoice right state

### DIFF
--- a/src/app/lnd/transactions/invoices/lightning-invoices.component.html
+++ b/src/app/lnd/transactions/invoices/lightning-invoices.component.html
@@ -32,8 +32,10 @@
         <ng-container matColumnDef="creation_date">
           <th mat-header-cell *matHeaderCellDef mat-sort-header> Date Created </th>
           <td mat-cell *matCellDef="let invoice">
-            <span *ngIf="invoice.settled" class="dot green" matTooltip="Settled" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
-            <span *ngIf="!invoice.settled" class="dot yellow" matTooltip="Unsettled" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
+            <span *ngIf="invoice.state === 'OPEN'" class="dot gray" matTooltip="Open" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
+            <span *ngIf="invoice.state === 'SETTLED'" class="dot green" matTooltip="Settled" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
+            <span *ngIf="invoice.state === 'ACCEPTED'" class="dot yellow" matTooltip="Accepted" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
+            <span *ngIf="invoice.state === 'CANCELED'" class="dot red" matTooltip="Cancelled" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
             {{(invoice.creation_date * 1000) | date:'dd/MMM/YYYY HH:mm'}}</td>
         </ng-container>
         <ng-container matColumnDef="settle_date">


### PR DESCRIPTION
Invoice state is displayed in two indicator: settled or not settled.
This patch changes this to the right state: open (created), settled, accepted, canceled (timeout)