### PR TITLE
[LND] Add advanced channel policy min/max_htlc_msat

### DIFF
--- a/server/controllers/lnd/channels.ts
+++ b/server/controllers/lnd/channels.ts
@@ -224,6 +224,9 @@ export const postChanPolicy = (req, res, next) => {
       base_fee_msat: req.body.baseFeeMsat,
       fee_rate: parseFloat((req.body.feeRate / 1000000).toString()),
       time_lock_delta: parseInt(req.body.timeLockDelta),
+      max_htlc_msat: req.body.max_htlc_msat,
+      min_htlc_msat: req.body.min_htlc_msat,
+      min_htlc_msat_specified: true,
       chan_point: { funding_txid_str: txid_str, output_index: parseInt(output_idx) }
     });
   }

--- a/src/app/lnd/graph/lookups/channel-lookup/channel-lookup.component.html
+++ b/src/app/lnd/graph/lookups/channel-lookup/channel-lookup.component.html
@@ -45,6 +45,11 @@
       </div>
       <mat-divider [inset]="true" class="my-1"></mat-divider>
       <div fxLayout="column" fxFlex="10">
+        <h4 class="font-bold-500">Max HTLC</h4>
+        <span class="foreground-secondary-text">{{lookupResult.node1_policy?.max_htlc_msat}}</span>
+      </div>
+      <mat-divider [inset]="true" class="my-1"></mat-divider>
+      <div fxLayout="column" fxFlex="10">
         <h4 class="font-bold-500">Fee Base Msat</h4>
         <span class="foreground-secondary-text">{{lookupResult.node1_policy?.fee_base_msat}}</span>
       </div>
@@ -78,6 +83,11 @@
       <div fxLayout="column" fxFlex="10">
         <h4 class="font-bold-500">Min HTLC</h4>
         <span class="foreground-secondary-text">{{lookupResult.node2_policy?.min_htlc}}</span>
+      </div>
+      <mat-divider [inset]="true" class="my-1"></mat-divider>
+      <div fxLayout="column" fxFlex="10">
+        <h4 class="font-bold-500">Max HTLC</h4>
+        <span class="foreground-secondary-text">{{lookupResult.node2_policy?.max_htlc_msat}}</span>
       </div>
       <mat-divider [inset]="true" class="my-1"></mat-divider>
       <div fxLayout="column" fxFlex="10">

--- a/src/app/lnd/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.ts
+++ b/src/app/lnd/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.ts
@@ -199,7 +199,7 @@ export class ChannelOpenTableComponent implements OnInit, AfterViewInit, OnDestr
           }
         });
     } else {
-      this.myChanPolicy = { fee_base_msat: 0, fee_rate_milli_msat: 0, time_lock_delta: 0 };
+      this.myChanPolicy = { fee_base_msat: 0, fee_rate_milli_msat: 0, time_lock_delta: 0, min_htlc_msat: 0, max_htlc_msat: 0 };
       this.store.dispatch(channelLookup({ payload: { uiMessage: UI_MESSAGES.GET_CHAN_POLICY, channelID: channelToUpdate.chan_id.toString() } }));
       this.lndEffects.setLookup.pipe(take(1)).subscribe((resLookup) => {
         if (resLookup.node1_pub === this.information.identity_pubkey) {
@@ -223,10 +223,13 @@ export class ChannelOpenTableComponent implements OnInit, AfterViewInit, OnDestr
                 yesBtnText: 'Update Channel',
                 message: confirmationMsg,
                 flgShowInput: true,
+                hasAdvanced: true,
                 getInputs: [
                   { placeholder: 'Base Fee (mSat)', inputType: DataTypeEnum.NUMBER.toLowerCase(), inputValue: (this.myChanPolicy.fee_base_msat === '') ? 0 : this.myChanPolicy.fee_base_msat, width: 32 },
                   { placeholder: 'Fee Rate (mili mSat)', inputType: DataTypeEnum.NUMBER.toLowerCase(), inputValue: this.myChanPolicy.fee_rate_milli_msat, min: 1, width: 32, hintFunction: this.percentHintFunction },
-                  { placeholder: 'Time Lock Delta', inputType: DataTypeEnum.NUMBER.toLowerCase(), inputValue: this.myChanPolicy.time_lock_delta, width: 32 }
+                  { placeholder: 'Time Lock Delta', inputType: DataTypeEnum.NUMBER.toLowerCase(), inputValue: this.myChanPolicy.time_lock_delta, width: 32 },
+                  { placeholder: 'Minimum HTLC (mSat)', inputType: DataTypeEnum.NUMBER.toLowerCase(), inputValue: (this.myChanPolicy.min_htlc === '') ? 0 : this.myChanPolicy.min_htlc, width: 32, advancedField: true },
+                  { placeholder: 'Maximum HTLC (mSat)', inputType: DataTypeEnum.NUMBER.toLowerCase(), inputValue: (this.myChanPolicy.max_htlc_msat === '') ? 0 : this.myChanPolicy.max_htlc_msat, width: 32, advancedField: true }
                 ]
               }
             }
@@ -240,7 +243,16 @@ export class ChannelOpenTableComponent implements OnInit, AfterViewInit, OnDestr
             const base_fee = confirmRes[0].inputValue;
             const fee_rate = confirmRes[1].inputValue;
             const time_lock_delta = confirmRes[2].inputValue;
-            this.store.dispatch(updateChannel({ payload: { baseFeeMsat: base_fee, feeRate: fee_rate, timeLockDelta: time_lock_delta, chanPoint: channelToUpdate.channel_point } }));
+            const min_htlc = confirmRes[3].inputValue;
+            const max_htlc_msat = confirmRes[4].inputValue;
+            this.store.dispatch(updateChannel({ payload: { 
+              baseFeeMsat: base_fee, 
+              feeRate: fee_rate, 
+              timeLockDelta: time_lock_delta,
+              minHtlcMsat: min_htlc,
+              maxHtlcMsat: max_htlc_msat,
+              chanPoint: channelToUpdate.channel_point 
+            } }));
           }
         });
     }

--- a/src/app/lnd/store/lnd.effects.ts
+++ b/src/app/lnd/store/lnd.effects.ts
@@ -302,7 +302,12 @@ export class LNDEffects implements OnDestroy {
     mergeMap((action: { type: string, payload: any }) => {
       this.store.dispatch(openSpinner({ payload: UI_MESSAGES.UPDATE_CHAN_POLICY }));
       return this.httpClient.post(this.CHILD_API_URL + environment.CHANNELS_API + '/chanPolicy',
-        { baseFeeMsat: action.payload.baseFeeMsat, feeRate: action.payload.feeRate, timeLockDelta: action.payload.timeLockDelta, chanPoint: action.payload.chanPoint }
+        { baseFeeMsat: action.payload.baseFeeMsat, 
+          feeRate: action.payload.feeRate, 
+          timeLockDelta: action.payload.timeLockDelta, 
+          max_htlc_msat: action.payload.maxHtlcMsat,
+          min_htlc_msat: action.payload.minHtlcMsat,
+          chanPoint: action.payload.chanPoint }
       ).pipe(
         map((postRes: any) => {
           this.logger.info(postRes);

--- a/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.html
+++ b/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.html
@@ -41,16 +41,21 @@
         </div>
         <div *ngIf="flgShowInput" fxLayout="column" class="bordered-box my-2 p-2">
           <p *ngIf="data.titleMessage" fxLayoutAlign="start center" class="pb-1">{{data.titleMessage}}</p>
-          <div fxLayoutAlign="space-between center">
-            <mat-form-field *ngFor="let getInput of getInputs; index as i" [fxFlex]="getInput.width">
-              <input *ngIf="i === 0" autoFocus matInput [placeholder]="getInput.placeholder" name="input{{i}}" [min]="getInput.min" [step]="getInput.step" [type]="getInput.inputType | lowercase" [(ngModel)]="getInput.inputValue" [tabindex]="i+1" required>
-              <input *ngIf="i !== 0" matInput [placeholder]="getInput.placeholder" name="input{{i}}" [min]="getInput.min" [step]="getInput.step" [type]="getInput.inputType | lowercase" [(ngModel)]="getInput.inputValue" [tabindex]="i+1" required>
-              <mat-error *ngIf="!getInput.inputValue">{{getInput.placeholder}} is required.</mat-error>
-              <mat-hint>{{getInput.hintFunction ? getInput.hintFunction(getInput.inputValue) : getInput.hintText}}</mat-hint>
-            </mat-form-field>
+          <div [fxLayout]="showAdvanced ? 'column' : 'row'" [fxLayoutAlign]="showAdvanced ? 'start' : 'space-between center'">
+            <ng-container *ngFor="let getInput of getInputs; index as i">
+              <mat-form-field *ngIf="!getInput.advancedField || showAdvanced" [fxFlex]="getInput.width">                              
+                <input matInput [autoFocus]="i === 0" [placeholder]="getInput.placeholder" name="input{{i}}" [min]="getInput.min" [step]="getInput.step" [type]="getInput.inputType | lowercase" [(ngModel)]="getInput.inputValue" [tabindex]="i+1" required>
+                <mat-error *ngIf="!getInput.inputValue">{{getInput.placeholder}} is required.</mat-error>
+                <mat-hint>{{getInput.hintFunction ? getInput.hintFunction(getInput.inputValue) : getInput.hintText}}</mat-hint>
+              </mat-form-field>
+          </ng-container>
           </div>        
         </div>
         <div fxLayout="row" fxLayoutAlign="end center">
+          <button *ngIf="hasAdvanced" mat-button color="primary" type="button" class="mr-1" (click)="onShowAdvanced()" tabindex="1" >
+            <p *ngIf="!showAdvanced; else hideAdvancedText">Show Advanced</p>
+            <ng-template #hideAdvancedText><p>Hide Advanced</p></ng-template>
+          </button>
           <button mat-button color="primary" type="reset" class="mr-1" (click)="onClose(false)" tabindex="2">{{noBtnText}}</button>
           <button autoFocus *ngIf="flgShowInput" mat-button color="primary" type="submit" tabindex="3" (click)="onClose(getInputs)" default>{{yesBtnText}}</button>
           <button autoFocus *ngIf="!flgShowInput" mat-button color="primary" type="submit" tabindex="4" (click)="onClose(true)" default>{{yesBtnText}}</button>

--- a/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.ts
+++ b/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.ts
@@ -25,9 +25,12 @@ export class ConfirmationMessageComponent implements OnInit {
   public yesBtnText = 'Yes';
   public messageObjs = [];
   public flgShowInput = false;
+  public hasAdvanced = false;
   public alertTypeEnum = AlertTypeEnum;
   public dataTypeEnum = DataTypeEnum;
-  public getInputs: Array<InputData> = [{ placeholder: '', inputType: 'text', inputValue: '', hintText: '', hintFunction: null }];
+  public getInputs: Array<InputData> = [{ placeholder: '', inputType: 'text', inputValue: '', hintText: '', hintFunction: null, advancedField: false }];
+  
+  private showAdvanced = false;
 
   constructor(
     public dialogRef: MatDialogRef<ConfirmationMessageComponent>, @Inject(MAT_DIALOG_DATA) public data: ConfirmationData, private logger: LoggerService,
@@ -41,12 +44,17 @@ export class ConfirmationMessageComponent implements OnInit {
     this.getInputs = this.data.getInputs;
     this.noBtnText = (this.data.noBtnText) ? this.data.noBtnText : 'No';
     this.yesBtnText = (this.data.yesBtnText) ? this.data.yesBtnText : 'Yes';
+    this.hasAdvanced = (this.data.hasAdvanced) ? this.data.hasAdvanced : false;
     this.messageObjs = this.data.message;
     if (this.data.type === AlertTypeEnum.ERROR) {
       if (!this.data.message && !this.data.titleMessage && this.messageObjs.length <= 0) {
         this.data.titleMessage = 'Please Check Server Connection';
       }
     }
+  }
+  
+  onShowAdvanced() {
+    this.showAdvanced = !this.showAdvanced;
   }
 
   onClose(dialogRes: any): boolean | void {

--- a/src/app/shared/models/alertData.ts
+++ b/src/app/shared/models/alertData.ts
@@ -30,6 +30,7 @@ export interface InputData {
   width?: number;
   hintText?: string;
   hintFunction?: Function;
+  advancedField?: boolean;
 }
 
 export interface OnChainLabelUTXO {
@@ -197,6 +198,7 @@ export interface ConfirmationData {
   noBtnText?: string;
   yesBtnText?: string;
   flgShowInput?: boolean;
+  hasAdvanced?: boolean;
   getInputs?: Array<InputData>;
   component?: any;
 }

--- a/src/app/shared/models/lndModels.ts
+++ b/src/app/shared/models/lndModels.ts
@@ -168,6 +168,7 @@ export interface LightningNode {
 export interface RoutingPolicy {
   time_lock_delta?: number;
   min_htlc?: string;
+  max_htlc_msat?: string;
   fee_base_msat?: string;
   fee_rate_milli_msat?: string;
   disabled?: boolean;


### PR DESCRIPTION
This PR extends the 'Update Fee Policy' for a specific channel with an advanced options section that exposes the minimum_htlc_msat and maximum_htlc_msat channel policy parameters. 

From a user's perspective the change is minimal, as the additional parameters are not exposed and only visual difference is the presence of a 'Show Advanced' button at the bottom of the form: 
![Screenshot 2022-06-07 at 13 53 17](https://user-images.githubusercontent.com/1499454/172383785-489eda86-ac2d-4ffc-b145-798bbe18f03d.png)

After clicking the 'Show Advanced' button the layout is changed and the additional fields exposed:
![Screenshot 2022-06-07 at 13 53 29](https://user-images.githubusercontent.com/1499454/172383828-9282a018-ee48-4f4e-833d-d0912ad85425.png)

Tested with LND 0.14.2
