### PR TITLE
Fix Side Navigation issues (toggle and on refresh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "ng serve --open",
     "prebuildfrontendtest": "node src/prebuild.cjs",
     "prebuildfrontend": "node src/prebuild.cjs",
+    "watchfrontenddev": "ng build --configuration development --optimization false --watch",
     "buildfrontendtest": "ng test --watch=false && ng build",
     "buildfrontend": "ng build --configuration production",
     "buildbackend": "tsc --project ./server/tsconfig.server.json",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -19,7 +19,7 @@
       <rtl-top-menu />
     </div>
   </mat-toolbar>
-  <mat-sidenav-container>
+  <mat-sidenav-container (backdropClick)="backdropClicked()">
     <mat-sidenav #sideNavigation class="sidenav mat-elevation-z6" [perfectScrollbar] [opened]="flgSideNavOpened && flgLoggedIn" [mode]="(flgSidenavPinned && !smallScreen) ? 'side' : 'over'">
       <rtl-side-navigation fxFlex="100" (ChildNavClicked)="onNavigationClicked($event)" />
     </mat-sidenav>
@@ -27,7 +27,7 @@
       <div class="inner-sidenav-content" fxLayout="column" fxFlex="100" fxLayoutAlign="start stretch">
         <router-outlet #outlet="outlet" />
       </div>
-    </mat-sidenav-content>>
+    </mat-sidenav-content>
   </mat-sidenav-container>
   <div *ngIf="!settings.themeColor" class="rtl-spinner">
     <mat-spinner color="accent" />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -159,7 +159,10 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    if (this.smallScreen || !this.flgLoggedIn) { this.sideNavigation.close(); }
+    if (this.smallScreen || !this.flgLoggedIn) {
+      this.flgSideNavOpened = !this.flgSideNavOpened;
+      this.sideNavigation.close();
+    }
     this.commonService.setContainerSize(this.sideNavContent.elementRef.nativeElement.clientWidth, this.sideNavContent.elementRef.nativeElement.clientHeight);
   }
 
@@ -170,6 +173,14 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onNavigationClicked(event: any) {
     if (this.smallScreen) {
+      this.flgSideNavOpened = !this.flgSideNavOpened;
+      this.sideNavigation.close();
+    }
+  }
+
+  backdropClicked() {
+    if (!this.flgSidenavPinned || this.smallScreen) {
+      this.flgSideNavOpened = !this.flgSideNavOpened;
       this.sideNavigation.close();
     }
   }


### PR DESCRIPTION
Toggling the sidenav had some issues (on mobile and desktop view), which I believe these changes will fix.

For example:
* The mobile view considers the sidenav to not be visible initially, although the default flag is set to true. Therefore the menu button needs to be clicked twice for the menu to appear.
* In the desktop view, upon refreshing the page, the sidebar becomes visible; however, the associated content does not reposition correctly and remains overlaid by the sidebar instead of being properly moved to the side.
* Added backdroup-clicked event handler based on Angular documentation

I also took the liberty to add a watch command (`npm run watchfrontenddev`) for the frontend to the `package.json`

This PR does not include the associated production build for clarity of code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a backdrop click feature for the side navigation panel.
- **Bug Fixes**
	- Fixed an issue where the side navigation state was not toggled correctly on certain events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->