### PR TITLE
Add copy-to-clipboard fallback if navigator.clipboard is not available

### DIFF
--- a/src/app/shared/directive/clipboard.directive.ts
+++ b/src/app/shared/directive/clipboard.directive.ts
@@ -25,7 +25,7 @@ export class ClipboardDirective {
 
   private copyUsingFallbackMethod(): void {
     const input = document.createElement('textarea');
-    input.innerHTML = this.payload;
+    input.innerText = this.payload;
     document.body.appendChild(input);
     input.select();
 

--- a/src/app/shared/directive/clipboard.directive.ts
+++ b/src/app/shared/directive/clipboard.directive.ts
@@ -13,14 +13,37 @@ export class ClipboardDirective {
   @HostListener('click', ['$event'])
   public onClick(event: MouseEvent): void {
     event.preventDefault();
-    if (!this.payload || !navigator.clipboard) {
-      return;
+
+    if (!this.payload) return;
+
+    if (navigator.clipboard) {
+      this.copyUsingClipboardAPI();
+    } else {
+      this.copyUsingFallbackMethod();
     }
-    navigator.clipboard.writeText(this.payload.toString()).then(() => {
-      this.copied.emit(this.payload.toString());
-    }, (err) => {
-      this.copied.emit('Error could not copy text: ' + JSON.stringify(err));
-    });
   }
 
+  private copyUsingFallbackMethod(): void {
+    const input = document.createElement('textarea');
+    input.innerHTML = this.payload;
+    document.body.appendChild(input);
+    input.select();
+
+    try {
+      const result = document.execCommand('copy');
+      if (result) {
+        this.copied.emit(this.payload.toString());
+      } else {
+        this.copied.emit('Error could not copy text.');
+      }
+    } finally {
+      document.body.removeChild(input);
+    }
+  }
+
+  private copyUsingClipboardAPI(): void {
+    navigator.clipboard.writeText(this.payload.toString())
+      .then(() => this.copied.emit(this.payload.toString()))
+      .catch((error) => this.copied.emit('Error could not copy text: ' + JSON.stringify(error)));
+  }
 }


### PR DESCRIPTION
Refactored the onClick event for the `Copy To Clipboard` buttons. A fallback mechanism has been introduced using the deprecated `document.execCommand('copy')` method to address browsers that lack support for the new `navigator.clipboard` API (e.g., IE and Firefox Android).

Alternatively, if the decision is not to include this fallback mechanism, it's recommended not to display the "Copy To Clipboard" buttons at all. This avoids potential issues, such as providing a non-functioning button that could **unintentionally retain previously copied addresses**. Note that opting for this approach would involve more extensive code changes across multiple files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clipboard operations with better error handling and fallback methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->