### PR TITLE
Exit gracefully on SIGINT

### DIFF
--- a/rtl.js
+++ b/rtl.js
@@ -5,10 +5,15 @@ import { Config } from './backend/utils/config.js'; // Follow sequence to set se
 import { WSServer } from './backend/utils/webSocketServer.js';
 import App from './backend/utils/app.js';
 
+
 const logger = Logger;
 const common = Common;
 const wsServer = WSServer;
 const app = new App();
+
+process.on('SIGINT', () => {
+  process.exit();
+});
 
 const onError = (error) => {
   if (error.syscall !== 'listen') { throw error; }


### PR DESCRIPTION
I am trying to run this in docker under systemd and was getting failures trying to restart the job. Before ctrl + c would not kill the task successfully when running under docker, this fixes that as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved process termination handling on user interrupt signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->