### PR TITLE
Make RTL compatible with Eclair 0.10.0 new audit format

### DIFF
--- a/server/controllers/eclair/fees.ts
+++ b/server/controllers/eclair/fees.ts
@@ -13,22 +13,23 @@ export const arrangeFees = (selNode: CommonSelectedNode, body, current_time) => 
   let fee = 0;
   body.relayed.forEach((relayedEle) => {
     fee = Math.round((relayedEle.amountIn - relayedEle.amountOut) / 1000);
-    if (relayedEle.timestamp) {
-      if (relayedEle.timestamp.unix) {
-        if ((relayedEle.timestamp.unix * 1000) >= day_start_time) {
+    const relayedEleTimestamp = relayedEle.settledAt ? relayedEle.settledAt : relayedEle.timestamp;
+    if (relayedEleTimestamp) {
+      if (relayedEleTimestamp.unix) {
+        if ((relayedEleTimestamp.unix * 1000) >= day_start_time) {
           fees.daily_fee = fees.daily_fee + fee;
           fees.daily_txs = fees.daily_txs + 1;
         }
-        if ((relayedEle.timestamp.unix * 1000) >= week_start_time) {
+        if ((relayedEleTimestamp.unix * 1000) >= week_start_time) {
           fees.weekly_fee = fees.weekly_fee + fee;
           fees.weekly_txs = fees.weekly_txs + 1;
         }
       } else {
-        if (relayedEle.timestamp >= day_start_time) {
+        if (relayedEleTimestamp >= day_start_time) {
           fees.daily_fee = fees.daily_fee + fee;
           fees.daily_txs = fees.daily_txs + 1;
         }
-        if (relayedEle.timestamp >= week_start_time) {
+        if (relayedEleTimestamp >= week_start_time) {
           fees.weekly_fee = fees.weekly_fee + fee;
           fees.weekly_txs = fees.weekly_txs + 1;
         }
@@ -68,7 +69,10 @@ export const arrangePayments = (selNode: CommonSelectedNode, body) => {
     }
   });
   payments.relayed.forEach((relayedEle) => {
-    if (relayedEle.timestamp.unix) { relayedEle.timestamp = relayedEle.timestamp.unix * 1000; }
+    // Changing the timestamp value to keep the response backward compatible.
+    // ECL < 0.7.0 sent timestamp in unix milliseconds, then in {"iso", "unix"} object.
+    // From v0.10.0, it sends settledAt in {"iso", "unix"} object too.
+    relayedEle.timestamp = relayedEle.settledAt && relayedEle.settledAt.unix ? relayedEle.settledAt.unix * 1000 : relayedEle.timestamp && relayedEle.timestamp.unix ? relayedEle.timestamp.unix * 1000 : relayedEle.timestamp;
     if (relayedEle.amountIn) { relayedEle.amountIn = Math.round(relayedEle.amountIn / 1000); }
     if (relayedEle.amountOut) { relayedEle.amountOut = Math.round(relayedEle.amountOut / 1000); }
   });


### PR DESCRIPTION
This small change fixes the compatibility with the current release of Eclair (0.10.0) by using the settledAt instead of timestamp for the new version. It is also backwards compatible, so it will work on 0.9.0 and below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved accuracy in fee calculations by using more precise timestamp information when available.
- **Documentation**
	- Updated the hyperlink in an alert message within the `boltz-service-settings` component to point to the correct destination.
- **Refactor**
	- Restructured conditional blocks in `app.component.ts` for improved code readability and maintainability.
- **Style**
	- Updated the `main.js` script source in the `index.html` file.
- **Chores**
	- Added a process event listener for 'SIGINT' in `rtl.js`.
	- Updated the `VERSION` constant and added a new enum value in `consts-enums-functions.ts`.
- **New Features**
	- Enhanced the `ClipboardDirective` class to support different methods for copying text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->