### PR TITLE
Check for authentication obj before delete operation #1415 (#1416)

### DIFF
--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -40,11 +40,13 @@ export class CommonService {
             return obj;
         };
         this.removeAuthSecureData = (node) => {
-            delete node.authentication.macaroonPath;
-            delete node.authentication.runePath;
-            delete node.authentication.runeValue;
-            delete node.authentication.lnApiPassword;
-            delete node.authentication.options;
+            if (node.authentication) {
+                delete node.authentication.macaroonPath;
+                delete node.authentication.runePath;
+                delete node.authentication.runeValue;
+                delete node.authentication.lnApiPassword;
+                delete node.authentication.options;
+            }
             return node;
         };
         this.removeSecureData = (config) => {

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -47,11 +47,13 @@ export class CommonService {
   };
 
   public removeAuthSecureData = (node: SelectedNode) => {
-    delete node.authentication.macaroonPath;
-    delete node.authentication.runePath;
-    delete node.authentication.runeValue;
-    delete node.authentication.lnApiPassword;
-    delete node.authentication.options;
+    if (node.authentication) {
+      delete node.authentication.macaroonPath;
+      delete node.authentication.runePath;
+      delete node.authentication.runeValue;
+      delete node.authentication.lnApiPassword;
+      delete node.authentication.options;
+    }
     return node;
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding a conditional check in the `removeAuthSecureData` method to ensure properties are only deleted if `node.authentication` exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->