### PR TITLE
Fix `Unknown command` error when disabling Bolt12 offers on CLN

### DIFF
--- a/backend/controllers/cln/offers.js
+++ b/backend/controllers/cln/offers.js
@@ -83,7 +83,7 @@ export const disableOffer = (req, res, next) => {
     if (options.error) {
         return res.status(options.statusCode).json({ message: options.message, error: options.error });
     }
-    options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/disableOffer';
+    options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/disableoffer';
     options.body = req.body;
     request.post(options).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Offers', msg: 'Offer Disabled', data: body });

--- a/server/controllers/cln/offers.ts
+++ b/server/controllers/cln/offers.ts
@@ -82,7 +82,7 @@ export const disableOffer = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Offers', msg: 'Disabling Offer..' });
   options = common.getOptions(req);
   if (options.error) { return res.status(options.statusCode).json({ message: options.message, error: options.error }); }
-  options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/disableOffer';
+  options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/disableoffer';
   options.body = req.body;
   request.post(options).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Offers', msg: 'Offer Disabled', data: body });


### PR DESCRIPTION
Fixes a typo to change camel case to lowercase, match CLN's gRPC method name.

Fixes #1433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the URL for disabling offers to ensure proper request handling on the server.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->