### PR TITLE
upgrade nodejs to v22

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,14 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '18.x'
+          - '20.x'
+          - '22.x'
+          - '24.x'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -22,14 +30,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Cache node_modules
         uses: actions/cache@v4
         id: cache-npm-packages
         with:
           path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.OS }}-${{ matrix.node-version }}-build-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'
@@ -39,6 +47,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '18.x'
+          - '20.x'
+          - '22.x'
+          - '24.x'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -46,14 +62,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Cache node_modules
         uses: actions/cache@v4
         id: cache-npm-packages
         with:
           path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.OS }}-${{ matrix.node-version }}-build-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'
@@ -75,14 +91,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Cache node_modules
         uses: actions/cache@v4
         id: cache-npm-packages
         with:
           path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.OS }}-${{ matrix.node-version }}-build-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM dependencies
         if: steps.cache-npm-packages.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
 
       - name: Cache node_modules
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_DISTRO="node:20-alpine"
+ARG BASE_DISTRO="node:22-alpine"
 
 FROM --platform=${BUILDPLATFORM} ${BASE_DISTRO} AS builder
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@ngrx/store-devtools": "17.2.0",
         "@types/jasmine": "5.1.4",
-        "@types/node": "20.14.1",
+        "@types/node": "22.9.0",
         "@typescript-eslint/eslint-plugin": "7.12.0",
         "@typescript-eslint/parser": "7.12.0",
         "dotenv": "16.4.5",
@@ -5837,12 +5837,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
-      "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/node-forge": {
@@ -17239,10 +17240,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@ngrx/store-devtools": "17.2.0",
     "@types/jasmine": "5.1.4",
-    "@types/node": "20.14.1",
+    "@types/node": "22.9.0",
     "@typescript-eslint/eslint-plugin": "7.12.0",
     "@typescript-eslint/parser": "7.12.0",
     "dotenv": "16.4.5",


### PR DESCRIPTION
- Change docker base image nodejs from maintenance LTS (v20) to current LTS (v22)
- ci: run CI checks on nodejs versions 18,20,22,24
- ci: run build/publish on nodejs version 22 instead of 18
  - Node.js v18 is EoL as of 2025-04-30
    - https://en.wikipedia.org/wiki/Nodejs#Releases
    - https://nodejs.org/en/about/previous-releases
- chore: upgrade `@types/node` from v20 to v22

---

@coderabbitai ignore

(iffy privacy policy)