### PR TITLE
Remove deprecated outgoing_chan_id from QueryRoutes

### DIFF
--- a/backend/controllers/lnd/graph.js
+++ b/backend/controllers/lnd/graph.js
@@ -79,9 +79,6 @@ export const getQueryRoutes = (req, res, next) => {
         return res.status(options.statusCode).json({ message: options.message, error: options.error });
     }
     options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/graph/routes/' + req.params.destPubkey + '/' + req.params.amount;
-    if (req.query.outgoing_chan_id) {
-        options.url = options.url + '?outgoing_chan_id=' + req.query.outgoing_chan_id;
-    }
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Graph', msg: 'Query Routes URL', data: options.url });
     request(options).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Graph', msg: 'Query Routes Received', data: body });

--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -120,6 +120,15 @@ this release should add its entry under the appropriate section below.
 
 ## Code Health
 
+- **LND: remove the deprecated `outgoing_chan_id` from QueryRoutes**
+  ([#1591](https://github.com/Ride-The-Lightning/RTL/pull/1591)).
+  LND deprecated the singular `outgoing_chan_id` query parameter on `QueryRoutes` as of
+  v0.20.0 in favor of the plural `outgoing_chan_ids`. The code path was already unreachable
+  in RTL — no caller of the `GetQueryRoutes` action ever populated `outgoingChanId`, so the
+  parameter was never sent — so this drops the unused model field, the effect's conditional
+  URL builder, and the server-side passthrough. The plural `outgoing_chan_ids` used by the
+  send-payment and rebalance flows is unaffected.
+
 - **LND: migrate `sat_per_byte` to `sat_per_vbyte` in node requests**
   ([#1592](https://github.com/Ride-The-Lightning/RTL/pull/1592)).
   LND's v0.21.0 release notes deprecate the `sat_per_byte` field, with removal planned in

--- a/server/controllers/lnd/graph.ts
+++ b/server/controllers/lnd/graph.ts
@@ -76,9 +76,6 @@ export const getQueryRoutes = (req, res, next) => {
   options = common.getOptions(req);
   if (options.error) { return res.status(options.statusCode).json({ message: options.message, error: options.error }); }
   options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/graph/routes/' + req.params.destPubkey + '/' + req.params.amount;
-  if (req.query.outgoing_chan_id) {
-    options.url = options.url + '?outgoing_chan_id=' + req.query.outgoing_chan_id;
-  }
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Graph', msg: 'Query Routes URL', data: options.url });
   request(options).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Graph', msg: 'Query Routes Received', data: body });

--- a/src/app/lnd/store/lnd.effects.ts
+++ b/src/app/lnd/store/lnd.effects.ts
@@ -874,10 +874,7 @@ export class LNDEffects implements OnDestroy {
   queryRoutesFetch = createEffect(() => this.actions.pipe(
     ofType(LNDActions.GET_QUERY_ROUTES_LND),
     mergeMap((action: { type: string, payload: GetQueryRoutes }) => {
-      let url = this.CHILD_API_URL + API_END_POINTS.NETWORK_API + '/routes/' + action.payload.destPubkey + '/' + action.payload.amount;
-      if (action.payload.outgoingChanId) {
-        url = url + '?outgoing_chan_id=' + action.payload.outgoingChanId;
-      }
+      const url = this.CHILD_API_URL + API_END_POINTS.NETWORK_API + '/routes/' + action.payload.destPubkey + '/' + action.payload.amount;
       return this.httpClient.get(url).pipe(
         map((qrRes: any) => {
           this.logger.info(qrRes);

--- a/src/app/shared/models/lndModels.ts
+++ b/src/app/shared/models/lndModels.ts
@@ -571,7 +571,6 @@ export interface GetNewAddress {
 export interface GetQueryRoutes {
   destPubkey: string;
   amount: number;
-  outgoingChanId?: string;
 }
 
 export interface InitWallet {


### PR DESCRIPTION
## Summary

- LND 0.20.0 deprecates the singular `outgoing_chan_id` query parameter on `QueryRoutes` in favor of the plural `outgoing_chan_ids` (lnd PR #10057).
- In RTL the deprecated path was already unreachable: no caller of the `GetQueryRoutes` action ever populated `outgoingChanId`, so the conditional in the LND effect and the server controller never fired and the query parameter was never sent to LND.
- This PR removes the dead code: the optional field on the `GetQueryRoutes` model, the conditional URL builder in `lnd.effects.ts`, and the passthrough in `server/controllers/lnd/graph.ts`. Compiled `backend/controllers/lnd/graph.js` regenerated via `npm run buildbackend`.
- The send-payment and channel-rebalance flows already use `outgoing_chan_ids` (plural), so no behavior change there. If multi-channel selection is ever wanted in the QueryRoutes diagnostic UI, it can be added as a separate enhancement against the new plural field.

## Test plan

- [ ] `npm run buildbackend` succeeds
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] Manual: open the LND QueryRoutes page, run a query against a known destination, confirm hops still render
