### PR TITLE
Fix setOptions cache poisoning when one node's auth credential load fails

### DIFF
--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -192,11 +192,11 @@ export class CommonService {
             }
         };
         this.setOptions = (req) => {
-            if (this.nodes[0].authentication.options && this.nodes[0].authentication.options.headers) {
-                return;
-            }
             if (this.nodes && this.nodes.length > 0) {
                 this.nodes.forEach((node) => {
+                    if (node.authentication.options && node.authentication.options.headers) {
+                        return;
+                    }
                     node.authentication.options = {
                         url: '',
                         rejectUnauthorized: false,

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -204,9 +204,9 @@ export class CommonService {
   };
 
   public setOptions = (req) => {
-    if (this.nodes[0].authentication.options && this.nodes[0].authentication.options.headers) { return; }
     if (this.nodes && this.nodes.length > 0) {
       this.nodes.forEach((node) => {
+        if (node.authentication.options && node.authentication.options.headers) { return; }
         node.authentication.options = {
           url: '',
           rejectUnauthorized: false,


### PR DESCRIPTION
## Problem

`CommonService.setOptions(req)` in `server/utils/common.ts` short-circuits at the top:

```ts
if (this.nodes[0].authentication.options && this.nodes[0].authentication.options.headers) { return; }
```

The cache check is on `this.nodes[0]` regardless of which node was being processed. If `nodes[0]`'s auth load succeeds (e.g. LND, which reads `admin.macaroon` synchronously) but `nodes[1]`'s does not (e.g. CLN, where `getRuneValue()` throws because the rune file isn't ready yet or doesn't match the `LIGHTNING_RUNE="..."` pattern), then:

1. The first `setOptions` call processes both nodes. `nodes[0]` gets `options.headers` set. `nodes[1]` hits the inner catch, which is re-thrown, caught by the outer catch, and `nodes[1].authentication.options` is reset to `{ url: '', rejectUnauthorized: false, json: true, form: '' }` — **no `headers`**.
2. Every subsequent `setOptions` call returns immediately on line 207 because `nodes[0].authentication.options.headers` is set. `nodes[1]` is never retried, even after its underlying problem (missing/unwritten rune file, transient FS error) clears.
3. Requests against the broken node fail forever with errors like `Core lightning get info failed due to missing rune!` until the user restarts RTL.

This is reachable in the wild whenever a CLN rune file is generated asynchronously after RTL starts — for example, when RTL and CLN are managed by an orchestrator that boots them concurrently and the rune file is written by a one-shot that races RTL startup.

## Fix

Move the cache check inside the `forEach` so it's per-node:

```ts
this.nodes.forEach((node) => {
  if (node.authentication.options && node.authentication.options.headers) { return; }
  node.authentication.options = { url: '', rejectUnauthorized: false, json: true, form: null };
  // ...rest unchanged
});
```

A node whose credentials loaded successfully is still skipped on subsequent calls (no perf regression). A node whose load failed — and whose `options.headers` therefore isn't set — gets retried on the next request, picking up the credential once it's available.

## Reproduction

1. Configure two nodes: an LND with a valid macaroon, and a CLN with a `runePath` pointing at a file that does not yet exist (or is mid-write and does not yet contain `LIGHTNING_RUNE="..."`).
2. Hit any endpoint that touches CLN — e.g. CLN GetInfo. Observe `Core lightning get info failed due to missing rune!`.
3. Create or finish writing the rune file.
4. Without this patch: error persists indefinitely until RTL is restarted. With this patch: the next request succeeds.

## Files changed

- `server/utils/common.ts` — source.
- `backend/utils/common.js` — corresponding compiled output (same change applied by hand; happy to rebuild with `npm run buildbackend` and force-push if you'd prefer).

No new dependencies, no API change, no test changes (the `setOptions` path doesn't currently have unit coverage in this area).