### PR TITLE
fix(a11y): add accessible names to dialog close buttons

### DIFF
--- a/src/app/cln/liquidity-ads/open-liquidity-channel-modal/open-liquidity-channel-modal.component.html
+++ b/src/app/cln/liquidity-ads/open-liquidity-channel-modal/open-liquidity-channel-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column">

--- a/src/app/cln/liquidity-ads/open-liquidity-channel-modal/open-liquidity-channel-modal.component.html
+++ b/src/app/cln/liquidity-ads/open-liquidity-channel-modal/open-liquidity-channel-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button tabindex="6" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column">

--- a/src/app/cln/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
+++ b/src/app/cln/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{sweepAll ? 'Sweep All Funds' : 'Send Funds'}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column">
       <div *ngIf="recommendedFee.minimumFee" fxFlex="100" class="alert alert-info mb-2">

--- a/src/app/cln/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
+++ b/src/app/cln/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{sweepAll ? 'Sweep All Funds' : 'Send Funds'}}</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column">
       <div *ngIf="recommendedFee.minimumFee" fxFlex="100" class="alert alert-info mb-2">

--- a/src/app/cln/peers-channels/channels/bump-fee-modal/bump-fee.component.html
+++ b/src/app/cln/peers-channels/channels/bump-fee-modal/bump-fee.component.html
@@ -4,7 +4,7 @@
         <div fxFlex="95" fxLayoutAlign="start start">
           <span class="page-title">Bump Fee</span>
         </div>
-        <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+        <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
       </mat-card-header>
       <mat-card-content class="padding-gap-x-large">
         <form fxLayout="column">

--- a/src/app/cln/peers-channels/channels/bump-fee-modal/bump-fee.component.html
+++ b/src/app/cln/peers-channels/channels/bump-fee-modal/bump-fee.component.html
@@ -4,7 +4,7 @@
         <div fxFlex="95" fxLayoutAlign="start start">
           <span class="page-title">Bump Fee</span>
         </div>
-        <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+        <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
       </mat-card-header>
       <mat-card-content class="padding-gap-x-large">
         <form fxLayout="column">

--- a/src/app/cln/peers-channels/channels/channel-information-modal/channel-information.component.html
+++ b/src/app/cln/peers-channels/channels/channel-information-modal/channel-information.component.html
@@ -5,7 +5,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">Channel Information</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/cln/peers-channels/channels/channel-information-modal/channel-information.component.html
+++ b/src/app/cln/peers-channels/channels/channel-information-modal/channel-information.component.html
@@ -5,7 +5,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">Channel Information</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/cln/peers-channels/channels/open-channel-modal/open-channel.component.html
+++ b/src/app/cln/peers-channels/channels/open-channel-modal/open-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column" (submit)="onOpenChannel()" (reset)="resetData()">

--- a/src/app/cln/peers-channels/channels/open-channel-modal/open-channel.component.html
+++ b/src/app/cln/peers-channels/channels/open-channel-modal/open-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column" (submit)="onOpenChannel()" (reset)="resetData()">

--- a/src/app/cln/peers-channels/connect-peer/connect-peer.component.html
+++ b/src/app/cln/peers-channels/connect-peer/connect-peer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Connect to a new peer</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/cln/peers-channels/connect-peer/connect-peer.component.html
+++ b/src/app/cln/peers-channels/connect-peer/connect-peer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Connect to a new peer</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/cln/transactions/invoices/create-invoice-modal/create-invoice.component.html
+++ b/src/app/cln/transactions/invoices/create-invoice-modal/create-invoice.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Invoice</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addInvoiceForm="ngForm" fxLayout="row wrap" fxLayoutAlign="start space-between" fxFlex="100">

--- a/src/app/cln/transactions/invoices/create-invoice-modal/create-invoice.component.html
+++ b/src/app/cln/transactions/invoices/create-invoice-modal/create-invoice.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Invoice</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addInvoiceForm="ngForm" fxLayout="row wrap" fxLayoutAlign="start space-between" fxFlex="100">

--- a/src/app/cln/transactions/invoices/invoice-information-modal/invoice-information.component.html
+++ b/src/app/cln/transactions/invoices/invoice-information-modal/invoice-information.component.html
@@ -14,7 +14,7 @@
           <span *ngIf="invoice?.status === 'expired'" class="dot red ml-1" matTooltip="Expired" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
         </span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/cln/transactions/invoices/invoice-information-modal/invoice-information.component.html
+++ b/src/app/cln/transactions/invoices/invoice-information-modal/invoice-information.component.html
@@ -14,7 +14,7 @@
           <span *ngIf="invoice?.status === 'expired'" class="dot red ml-1" matTooltip="Expired" matTooltipPosition="right" [ngClass]="{'mr-0': screenSize === screenSizeEnum.XS}"></span>
         </span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/cln/transactions/offers/create-offer-modal/create-offer.component.html
+++ b/src/app/cln/transactions/offers/create-offer-modal/create-offer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Offer</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addOfferForm="ngForm" fxLayout="row wrap" fxLayoutAlign="start space-between" fxFlex="100">

--- a/src/app/cln/transactions/offers/create-offer-modal/create-offer.component.html
+++ b/src/app/cln/transactions/offers/create-offer-modal/create-offer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Offer</span>
       </div>
-      <button tabindex="6" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addOfferForm="ngForm" fxLayout="row wrap" fxLayoutAlign="start space-between" fxFlex="100">

--- a/src/app/cln/transactions/offers/offer-information-modal/offer-information.component.html
+++ b/src/app/cln/transactions/offers/offer-information-modal/offer-information.component.html
@@ -9,7 +9,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ?  (newlyAdded ? 'Created' : 'Offer') : (newlyAdded ? 'Offer Created' : 'Offer Information')}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/cln/transactions/offers/offer-information-modal/offer-information.component.html
+++ b/src/app/cln/transactions/offers/offer-information-modal/offer-information.component.html
@@ -9,7 +9,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ?  (newlyAdded ? 'Created' : 'Offer') : (newlyAdded ? 'Offer Created' : 'Offer Information')}}</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/cln/transactions/send-payment-modal/send-payment.component.html
+++ b/src/app/cln/transactions/send-payment-modal/send-payment.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button tabindex="12" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column" fxLayoutAlign="start stretch">
       <mat-radio-group class="my-1" color="primary" name="paymentType" fxFlex="100" fxLayoutAlign="start start" [(ngModel)]="paymentType" (change)="onPaymentTypeChange()">

--- a/src/app/eclair/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
+++ b/src/app/eclair/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column">
       <div *ngIf="recommendedFee.minimumFee" fxFlex="100" class="alert alert-info mb-2">

--- a/src/app/eclair/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
+++ b/src/app/eclair/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column">
       <div *ngIf="recommendedFee.minimumFee" fxFlex="100" class="alert alert-info mb-2">

--- a/src/app/eclair/peers-channels/channels/channel-information-modal/channel-information.component.html
+++ b/src/app/eclair/peers-channels/channels/channel-information-modal/channel-information.component.html
@@ -5,7 +5,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">Channel Information</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/eclair/peers-channels/channels/channel-information-modal/channel-information.component.html
+++ b/src/app/eclair/peers-channels/channels/channel-information-modal/channel-information.component.html
@@ -5,7 +5,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">Channel Information</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/eclair/peers-channels/channels/channel-rebalance-modal/channel-rebalance.component.html
+++ b/src/app/eclair/peers-channels/channels/channel-rebalance-modal/channel-rebalance.component.html
@@ -4,7 +4,7 @@
       <div fxLayoutAlign="start center"><span class="page-title">Channel Rebalance</span></div>
       <div fxLayoutAlign="end center">
         <button tabindex="21" class="btn-close-x p-0" mat-button (click)="showInfo()">?</button>
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </div>
   </mat-card-header>
@@ -146,7 +146,7 @@
     <mat-card-header fxLayout="row" fxFlex="8" fxLayoutAlign="space-between center" class="modal-info-header">
       <div fxFlex="95" fxLayoutAlign="start start"><span class="page-title"></span></div>
       <div fxFlex="5" fxLayoutAlign="end center">
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="flgShowInfo=false;stepNumber=1;">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="flgShowInfo=false;stepNumber=1;"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </mat-card-header>
     <mat-card-content fxLayout="column" fxFlex="70" fxLayoutAlign="space-between center" class="padding-gap-x-large">

--- a/src/app/eclair/peers-channels/channels/open-channel-modal/open-channel.component.html
+++ b/src/app/eclair/peers-channels/channels/open-channel-modal/open-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button tabindex="11" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column" (submit)="onOpenChannel()" (reset)="resetData()">

--- a/src/app/eclair/peers-channels/channels/open-channel-modal/open-channel.component.html
+++ b/src/app/eclair/peers-channels/channels/open-channel-modal/open-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column" (submit)="onOpenChannel()" (reset)="resetData()">

--- a/src/app/eclair/peers-channels/connect-peer/connect-peer.component.html
+++ b/src/app/eclair/peers-channels/connect-peer/connect-peer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Connect to a new peer</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/eclair/peers-channels/connect-peer/connect-peer.component.html
+++ b/src/app/eclair/peers-channels/connect-peer/connect-peer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Connect to a new peer</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/eclair/transactions/create-invoice-modal/create-invoice.component.html
+++ b/src/app/eclair/transactions/create-invoice-modal/create-invoice.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Invoice</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addInvoiceForm="ngForm" fxLayout="row wrap" fxLayoutAlign="start space-between" fxFlex="100">

--- a/src/app/eclair/transactions/create-invoice-modal/create-invoice.component.html
+++ b/src/app/eclair/transactions/create-invoice-modal/create-invoice.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Invoice</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addInvoiceForm="ngForm" fxLayout="row wrap" fxLayoutAlign="start space-between" fxFlex="100">

--- a/src/app/eclair/transactions/invoice-information-modal/invoice-information.component.html
+++ b/src/app/eclair/transactions/invoice-information-modal/invoice-information.component.html
@@ -9,7 +9,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ?  (newlyAdded ? 'Created' : 'Invoice') : (newlyAdded ? 'Invoice Created' : 'Invoice Information')}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/eclair/transactions/invoice-information-modal/invoice-information.component.html
+++ b/src/app/eclair/transactions/invoice-information-modal/invoice-information.component.html
@@ -9,7 +9,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ?  (newlyAdded ? 'Created' : 'Invoice') : (newlyAdded ? 'Invoice Created' : 'Invoice Information')}}</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/eclair/transactions/payment-information-modal/payment-information.component.html
+++ b/src/app/eclair/transactions/payment-information-modal/payment-information.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Payment Information</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content #scrollContainer class="h-40 padding-gap-x-large" [perfectScrollbar]>
       <div fxLayout="column">

--- a/src/app/eclair/transactions/payment-information-modal/payment-information.component.html
+++ b/src/app/eclair/transactions/payment-information-modal/payment-information.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Payment Information</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content #scrollContainer class="h-40 padding-gap-x-large" [perfectScrollbar]>
       <div fxLayout="column">

--- a/src/app/eclair/transactions/send-payment-modal/send-payment.component.html
+++ b/src/app/eclair/transactions/send-payment-modal/send-payment.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #sendPaymentForm="ngForm" fxLayoutAlign="space-between stretch" fxLayout="column">

--- a/src/app/eclair/transactions/send-payment-modal/send-payment.component.html
+++ b/src/app/eclair/transactions/send-payment-modal/send-payment.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #sendPaymentForm="ngForm" fxLayoutAlign="space-between stretch" fxLayout="column">

--- a/src/app/lnd/on-chain/on-chain-label-modal/on-chain-label-modal.component.html
+++ b/src/app/lnd/on-chain/on-chain-label-modal/on-chain-label-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Label UTXO</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="row wrap" fxLayoutAlign="space-between start" fxFlex="100" class="overflow-x-hidden" (submit)="onLabelUTXO()" (reset)="resetData()">

--- a/src/app/lnd/on-chain/on-chain-label-modal/on-chain-label-modal.component.html
+++ b/src/app/lnd/on-chain/on-chain-label-modal/on-chain-label-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Label UTXO</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="row wrap" fxLayoutAlign="space-between start" fxFlex="100" class="overflow-x-hidden" (submit)="onLabelUTXO()" (reset)="resetData()">

--- a/src/app/lnd/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
+++ b/src/app/lnd/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{sweepAll ? 'Sweep All Funds' : 'Send Funds'}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column">
       <div *ngIf="recommendedFee.minimumFee" fxFlex="100" class="alert alert-info mb-2">

--- a/src/app/lnd/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
+++ b/src/app/lnd/on-chain/on-chain-send-modal/on-chain-send-modal.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{sweepAll ? 'Sweep All Funds' : 'Send Funds'}}</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" fxLayout="column">
       <div *ngIf="recommendedFee.minimumFee" fxFlex="100" class="alert alert-info mb-2">

--- a/src/app/lnd/peers-channels/channels/bump-fee-modal/bump-fee.component.html
+++ b/src/app/lnd/peers-channels/channels/bump-fee-modal/bump-fee.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Bump Fee</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form fxLayout="column">

--- a/src/app/lnd/peers-channels/channels/bump-fee-modal/bump-fee.component.html
+++ b/src/app/lnd/peers-channels/channels/bump-fee-modal/bump-fee.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Bump Fee</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form fxLayout="column">

--- a/src/app/lnd/peers-channels/channels/channel-information-modal/channel-information.component.html
+++ b/src/app/lnd/peers-channels/channels/channel-information-modal/channel-information.component.html
@@ -5,7 +5,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">Channel Information</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/lnd/peers-channels/channels/channel-information-modal/channel-information.component.html
+++ b/src/app/lnd/peers-channels/channels/channel-information-modal/channel-information.component.html
@@ -5,7 +5,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">Channel Information</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/lnd/peers-channels/channels/channel-rebalance-modal/channel-rebalance.component.html
+++ b/src/app/lnd/peers-channels/channels/channel-rebalance-modal/channel-rebalance.component.html
@@ -4,7 +4,7 @@
       <div fxLayoutAlign="start center"><span class="page-title">Channel Rebalance</span></div>
       <div fxLayoutAlign="end center">
         <button tabindex="21" class="btn-close-x p-0" mat-button (click)="showInfo()">?</button>
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </div>
   </mat-card-header>
@@ -145,7 +145,7 @@
     <mat-card-header fxLayout="row" fxFlex="8" fxLayoutAlign="space-between center" class="modal-info-header">
       <div fxFlex="95" fxLayoutAlign="start start"><span class="page-title"></span></div>
       <div fxFlex="5" fxLayoutAlign="end center">
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="flgShowInfo=false;stepNumber=1;">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="flgShowInfo=false;stepNumber=1;"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </mat-card-header>
     <mat-card-content fxLayout="column" fxFlex="70" fxLayoutAlign="space-between center" class="padding-gap-x-large">

--- a/src/app/lnd/peers-channels/channels/close-channel-modal/close-channel.component.html
+++ b/src/app/lnd/peers-channels/channels/close-channel-modal/close-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{channelToClose.active ? 'Close Channel' : 'Force Close Channel'}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form fxLayout="column">

--- a/src/app/lnd/peers-channels/channels/close-channel-modal/close-channel.component.html
+++ b/src/app/lnd/peers-channels/channels/close-channel-modal/close-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{channelToClose.active ? 'Close Channel' : 'Force Close Channel'}}</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form fxLayout="column">

--- a/src/app/lnd/peers-channels/channels/open-channel-modal/open-channel.component.html
+++ b/src/app/lnd/peers-channels/channels/open-channel-modal/open-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column" (submit)="onOpenChannel()" (reset)="resetData()">

--- a/src/app/lnd/peers-channels/channels/open-channel-modal/open-channel.component.html
+++ b/src/app/lnd/peers-channels/channels/open-channel-modal/open-channel.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{alertTitle}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #form="ngForm" fxLayout="column" (submit)="onOpenChannel()" (reset)="resetData()">

--- a/src/app/lnd/peers-channels/connect-peer/connect-peer.component.html
+++ b/src/app/lnd/peers-channels/connect-peer/connect-peer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Connect to a new peer</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/lnd/peers-channels/connect-peer/connect-peer.component.html
+++ b/src/app/lnd/peers-channels/connect-peer/connect-peer.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Connect to a new peer</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/lnd/transactions/create-invoice-modal/create-invoice.component.html
+++ b/src/app/lnd/transactions/create-invoice-modal/create-invoice.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Invoice</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addInvoiceForm="ngForm" fxLayout="row wrap" fxLayoutAlign="space-between start" fxFlex="100">

--- a/src/app/lnd/transactions/create-invoice-modal/create-invoice.component.html
+++ b/src/app/lnd/transactions/create-invoice-modal/create-invoice.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Create Invoice</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #addInvoiceForm="ngForm" fxLayout="row wrap" fxLayoutAlign="space-between start" fxFlex="100">

--- a/src/app/lnd/transactions/invoice-information-modal/invoice-information.component.html
+++ b/src/app/lnd/transactions/invoice-information-modal/invoice-information.component.html
@@ -9,7 +9,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ?  (newlyAdded ? 'Created' : 'Invoice') : (newlyAdded ? 'Invoice Created' : 'Invoice Information')}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/lnd/transactions/invoice-information-modal/invoice-information.component.html
+++ b/src/app/lnd/transactions/invoice-information-modal/invoice-information.component.html
@@ -9,7 +9,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ?  (newlyAdded ? 'Created' : 'Invoice') : (newlyAdded ? 'Invoice Created' : 'Invoice Information')}}</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large" [ngClass]="{'xs-scroll-y': screenSize === screenSizeEnum.XS}">
       <div fxLayout="column">

--- a/src/app/lnd/transactions/send-payment-modal/send-payment.component.html
+++ b/src/app/lnd/transactions/send-payment-modal/send-payment.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button tabindex="11" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" default mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #sendPaymentForm="ngForm" fxLayoutAlign="space-between stretch" fxLayout="column">

--- a/src/app/lnd/transactions/send-payment-modal/send-payment.component.html
+++ b/src/app/lnd/transactions/send-payment-modal/send-payment.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Send Payment</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form #sendPaymentForm="ngForm" fxLayoutAlign="space-between stretch" fxLayout="column">

--- a/src/app/shared/components/data-modal/alert-message/alert-message.component.html
+++ b/src/app/shared/components/data-modal/alert-message/alert-message.component.html
@@ -7,7 +7,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{data.alertTitle || alertTypeEnum[data.type]}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <ng-container *ngIf="data.scrollable">
       <mat-card-content #scrollContainer class="padding-gap-x-large" [perfectScrollbar] [ngClass]="{'h-40': data.scrollable}">

--- a/src/app/shared/components/data-modal/alert-message/alert-message.component.html
+++ b/src/app/shared/components/data-modal/alert-message/alert-message.component.html
@@ -7,7 +7,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{data.alertTitle || alertTypeEnum[data.type]}}</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <ng-container *ngIf="data.scrollable">
       <mat-card-content #scrollContainer class="padding-gap-x-large" [perfectScrollbar] [ngClass]="{'h-40': data.scrollable}">

--- a/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.html
+++ b/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{data.alertTitle || alertTypeEnum[data.type]}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose(false)"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose(false)"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form fxLayout="column">

--- a/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.html
+++ b/src/app/shared/components/data-modal/confirmation-message/confirmation-message.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{data.alertTitle || alertTypeEnum[data.type]}}</span>
       </div>
-      <button tabindex="8" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose(false)">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose(false)"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <form fxLayout="column">

--- a/src/app/shared/components/data-modal/error-message/error-message.component.html
+++ b/src/app/shared/components/data-modal/error-message/error-message.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{data.alertTitle || 'ERROR'}}</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large error-alert-block">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/error-message/error-message.component.html
+++ b/src/app/shared/components/data-modal/error-message/error-message.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">{{data.alertTitle || 'ERROR'}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large error-alert-block">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/is-authorized/is-authorized.component.html
+++ b/src/app/shared/components/data-modal/is-authorized/is-authorized.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Authenticate with your RTL Password</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content fxLayout="row" class="padding-gap-x-large">
       <form fxLayout="column" fxFlex="100" fxLayoutAlign="start stretch">

--- a/src/app/shared/components/data-modal/is-authorized/is-authorized.component.html
+++ b/src/app/shared/components/data-modal/is-authorized/is-authorized.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Authenticate with your RTL Password</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content fxLayout="row" class="padding-gap-x-large">
       <form fxLayout="column" fxFlex="100" fxLayoutAlign="start stretch">

--- a/src/app/shared/components/data-modal/login-2fa-token/login-2fa-token.component.html
+++ b/src/app/shared/components/data-modal/login-2fa-token/login-2fa-token.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Two Factor Token</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content fxLayout="row" class="padding-gap-x-large">
       <form #tokenForm="ngForm" fxLayout="column" fxFlex="100" (ngSubmit)="onVerifyToken()">

--- a/src/app/shared/components/data-modal/login-2fa-token/login-2fa-token.component.html
+++ b/src/app/shared/components/data-modal/login-2fa-token/login-2fa-token.component.html
@@ -4,7 +4,7 @@
       <div fxFlex="95" fxLayoutAlign="start start">
         <span class="page-title">Two Factor Token</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content fxLayout="row" class="padding-gap-x-large">
       <form #tokenForm="ngForm" fxLayout="column" fxFlex="100" (ngSubmit)="onVerifyToken()">

--- a/src/app/shared/components/data-modal/on-chain-generated-address/on-chain-generated-address.component.html
+++ b/src/app/shared/components/data-modal/on-chain-generated-address/on-chain-generated-address.component.html
@@ -8,7 +8,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ? 'Address' : 'Generated Address'}}</span>
       </div>
-      <button tabindex="2" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/on-chain-generated-address/on-chain-generated-address.component.html
+++ b/src/app/shared/components/data-modal/on-chain-generated-address/on-chain-generated-address.component.html
@@ -8,7 +8,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{screenSize === screenSizeEnum.XS ? 'Address' : 'Generated Address'}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/show-pubkey/show-pubkey.component.html
+++ b/src/app/shared/components/data-modal/show-pubkey/show-pubkey.component.html
@@ -8,7 +8,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{selInfoType.infoName}}</span>
       </div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/show-pubkey/show-pubkey.component.html
+++ b/src/app/shared/components/data-modal/show-pubkey/show-pubkey.component.html
@@ -8,7 +8,7 @@
         <fa-icon class="page-title-img mr-1" [icon]="faReceipt" />
         <span class="page-title">{{selInfoType.infoName}}</span>
       </div>
-      <button tabindex="3" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/two-factor-auth/two-factor-auth.component.html
+++ b/src/app/shared/components/data-modal/two-factor-auth/two-factor-auth.component.html
@@ -2,7 +2,7 @@
   <div fxFlex="100">
     <mat-card-header fxLayout="row" fxLayoutAlign="space-between center" class="modal-info-header">
       <div fxFlex="95" fxLayoutAlign="start start"><span class="page-title">Setup Two Factor Authentication</span></div>
-      <button tabindex="15" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-button [mat-dialog-close]="false">X</button>
+      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/shared/components/data-modal/two-factor-auth/two-factor-auth.component.html
+++ b/src/app/shared/components/data-modal/two-factor-auth/two-factor-auth.component.html
@@ -2,7 +2,7 @@
   <div fxFlex="100">
     <mat-card-header fxLayout="row" fxLayoutAlign="space-between center" class="modal-info-header">
       <div fxFlex="95" fxLayoutAlign="start start"><span class="page-title">Setup Two Factor Authentication</span></div>
-      <button type="button" aria-label="Close dialog" fxFlex="5" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
+      <button type="button" aria-label="Close dialog" fxFlex="none" fxLayoutAlign="center center" class="btn-close-x p-0" mat-icon-button [mat-dialog-close]="false"><mat-icon aria-hidden="true">close</mat-icon></button>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
       <div fxLayout="column">

--- a/src/app/shared/components/ln-services/boltz/swap-modal/swap-modal.component.html
+++ b/src/app/shared/components/ln-services/boltz/swap-modal/swap-modal.component.html
@@ -4,7 +4,7 @@
       <div fxLayoutAlign="start start" [ngClass]="screenSize === screenSizeEnum.XS || screenSize === screenSizeEnum.SM ? 'flex-83' : 'flex-91'"><span class="page-title">{{swapDirectionCaption}}</span></div>
       <div fxLayoutAlign="end end" [ngClass]="screenSize === screenSizeEnum.XS || screenSize === screenSizeEnum.SM ? 'flex-17' : 'flex-9'">
         <button tabindex="21" class="btn-close-x p-0" mat-button (click)="showInfo()">?</button>
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
@@ -110,7 +110,7 @@
     <mat-card-header fxLayout="row" fxFlex="8" fxLayoutAlign="space-between center" class="modal-info-header">
       <div fxFlex="95" fxLayoutAlign="start start"><span class="page-title"></span></div>
       <div fxFlex="5" fxLayoutAlign="end center">
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="flgShowInfo=false;stepNumber=1;">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="flgShowInfo=false;stepNumber=1;"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </mat-card-header>
     <mat-card-content fxLayout="column" fxFlex="70" fxLayoutAlign="space-between center" class="padding-gap-x-large">

--- a/src/app/shared/components/ln-services/loop/loop-modal/loop-modal.component.html
+++ b/src/app/shared/components/ln-services/loop/loop-modal/loop-modal.component.html
@@ -4,7 +4,7 @@
       <div fxLayoutAlign="start start" [ngClass]="screenSize === screenSizeEnum.XS || screenSize === screenSizeEnum.SM ? 'flex-83' : 'flex-91'"><span class="page-title">{{channel ? ('Channel ' + loopDirectionCaption) : loopDirectionCaption}}</span></div>
       <div fxLayoutAlign="space-between end" [ngClass]="screenSize === screenSizeEnum.XS || screenSize === screenSizeEnum.SM ? 'flex-17' : 'flex-9'">
         <button tabindex="21" class="btn-close-x p-0" mat-button (click)="showInfo()">?</button>
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="onClose()">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="onClose()"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </mat-card-header>
     <mat-card-content class="padding-gap-x-large">
@@ -121,7 +121,7 @@
     <mat-card-header fxLayout="row" fxFlex="8" fxLayoutAlign="space-between center" class="modal-info-header">
       <div fxFlex="95" fxLayoutAlign="start start"><span class="page-title"></span></div>
       <div fxFlex="5" fxLayoutAlign="end center">
-        <button tabindex="22" class="btn-close-x p-0" mat-button (click)="flgShowInfo=false;stepNumber=1;">X</button>
+        <button type="button" aria-label="Close dialog" class="btn-close-x p-0" mat-icon-button (click)="flgShowInfo=false;stepNumber=1;"><mat-icon aria-hidden="true">close</mat-icon></button>
       </div>
     </mat-card-header>
     <mat-card-content fxLayout="column" fxFlex="70" fxLayoutAlign="space-between center" class="padding-gap-x-large">


### PR DESCRIPTION
Modal close buttons rendered only the visible text "X" on a mat-button, so screen reader and voice-control users had no meaningful name to identify or activate them.

Convert all 45 dialog close buttons (across 41 modal templates for LND, CLN, Eclair and shared components) to icon buttons with a proper accessible name:

- mat-button "X" -> mat-icon-button with a "close" mat-icon
- add aria-label="Close dialog"
- mark the icon aria-hidden="true" so it is not announced
- add type="button" to prevent implicit form submission
- drop the positive tabindex; the button now follows natural DOM order

Each button keeps its original action untouched ([mat-dialog-close]="false" or (click)="onClose()"). The four "?" info-toggle buttons that share the btn-close-x class are intentionally left unchanged, as they are not close actions.

Fixes #1562