### PR TITLE
fix(a11y): add accessible names to icon-only buttons

### DIFF
--- a/src/app/shared/components/horizontal-scroller/horizontal-scroller.component.html
+++ b/src/app/shared/components/horizontal-scroller/horizontal-scroller.component.html
@@ -1,14 +1,14 @@
 <div fxLayout="row" fxLayoutAlign="space-between stretch" fxFlex="100" class="padding-gap-x">
   <div fxLayout="row" fxLayoutAlign="start center" fxFlex="20">
-    <button mat-icon-button color="primary" type="button" tabindex="1" class="pr-4" (click)="onStepChange('FIRST')"><mat-icon>skip_previous</mat-icon></button>
-    <button mat-icon-button color="primary" type="button" tabindex="2" [disabled]="disablePrev" (click)="onStepChange('PREVIOUS')"><mat-icon>navigate_before</mat-icon></button>
+    <button mat-icon-button aria-label="Go to first" color="primary" type="button" tabindex="1" class="pr-4" (click)="onStepChange('FIRST')"><mat-icon>skip_previous</mat-icon></button>
+    <button mat-icon-button aria-label="Go to previous" color="primary" type="button" tabindex="2" [disabled]="disablePrev" (click)="onStepChange('PREVIOUS')"><mat-icon>navigate_before</mat-icon></button>
   </div>
   <ng-container *ngIf="animationDirection === 'forward'" [ngTemplateOutlet]="controlsPanel" [ngTemplateOutletContext]="{animationDirection:'forward'}" />
   <ng-container *ngIf="animationDirection === 'backward'" [ngTemplateOutlet]="controlsPanel" [ngTemplateOutletContext]="{animationDirection:'backward'}" />
   <ng-container *ngIf="animationDirection === ''" [ngTemplateOutlet]="controlsPanel" [ngTemplateOutletContext]="{animationDirection:''}" />
   <div fxLayout="row" fxLayoutAlign="end center" fxFlex="20">
-    <button mat-icon-button color="primary" type="button" tabindex="5" class="pr-4" [disabled]="disableNext" (click)="onStepChange('NEXT')"><mat-icon>navigate_next</mat-icon></button>
-    <button mat-icon-button color="primary" type="button" tabindex="6" (click)="onStepChange('LAST')"><mat-icon>skip_next</mat-icon></button>
+    <button mat-icon-button aria-label="Go to next" color="primary" type="button" tabindex="5" class="pr-4" [disabled]="disableNext" (click)="onStepChange('NEXT')"><mat-icon>navigate_next</mat-icon></button>
+    <button mat-icon-button aria-label="Go to last" color="primary" type="button" tabindex="6" (click)="onStepChange('LAST')"><mat-icon>skip_next</mat-icon></button>
   </div>
 </div>
 <ng-template #controlsPanel let-item='animationDirection'>

--- a/src/app/shared/components/navigation/top-menu/top-menu.component.html
+++ b/src/app/shared/components/navigation/top-menu/top-menu.component.html
@@ -29,7 +29,7 @@
   </p>
 </mat-menu>
 
-<button tabindex="7" mat-icon-button [matMenuTriggerFor]="topMenu">
+<button tabindex="7" mat-icon-button aria-label="Open user menu" [matMenuTriggerFor]="topMenu">
   <img class="rtl-log-top" alt="RTL Logo" src="assets/images/RTL-Horse-BY.svg">
   <mat-icon class="rtl-logo-dropdown color-white">arrow_drop_down</mat-icon>
 </button>


### PR DESCRIPTION
Fixes #1560

A handful of mat-icon-button controls contain only a Material icon, with no visible text, no aria-label and no matTooltip. Screen readers announce them as unnamed buttons (or fall back to the icon ligature text, e.g. "skip_previous"), and voice-control users have no name to activate them with (WCAG 2.1 - 4.1.2 Name, Role, Value).

Add a descriptive aria-label to each; no behaviour, layout or styling changes:

- reports horizontal scroller paging buttons: "Go to first", "Go to previous", "Go to next", "Go to last"
- top menu trigger (RTL logo + dropdown arrow): "Open user menu"



