### PR TITLE
Add baseline screenshot capture, fix fixture's blacklisted password

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -24,6 +24,9 @@ ALICE_REST_PORT=8081
 BOB_REST_PORT=8082
 CAROL_REST_PORT=8083
 
-# RTL
+# RTL. Must not be one of RTL's blacklisted weak passwords
+# ('password', 'changeme', 'moneyprintergobrrr') or RTL forces a password change
+# on every login and parks you on the auth settings screen. Set in
+# rtl/RTL-Config.regtest.json as multiPass; this is only used for messages.
 RTL_PORT=3000
-RTL_PASSWORD=password
+RTL_PASSWORD=rtldev

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,7 @@ docker compose up -d          # bitcoind, alice, bob, carol, rtl
 ./scripts/seed.sh             # fund, connect, open channels, make payments
 ```
 
-Then open <http://localhost:3000> — password `password`. All three nodes appear in
+Then open <http://localhost:3000> — password `rtldev`. All three nodes appear in
 the node switcher.
 
 Tear down, discarding all state:

--- a/docker/capture/.gitignore
+++ b/docker/capture/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+# Captured screenshots live in the RTL-Design repo (baseline/), not here.
+shots/

--- a/docker/capture/README.md
+++ b/docker/capture/README.md
@@ -1,0 +1,56 @@
+# Baseline screenshot capture
+
+Drives RTL against the regtest fixture and captures a fixed set of screens.
+
+The point is that the capture conditions live in code rather than in someone's
+memory: viewport, device scale factor, browser and screen list are all pinned in
+`capture.mjs`. A capture taken today and one taken after a redesign differ only
+by the design.
+
+## Use
+
+The fixture must be running (see `../README.md`).
+
+```bash
+npm install
+npx playwright install chromium
+
+# empty states -- BEFORE seeding
+cd .. && docker compose down -v && docker compose up -d && cd capture
+node capture.mjs empty
+
+# populated -- AFTER seeding
+cd .. && ./scripts/seed.sh && cd capture
+node capture.mjs full
+```
+
+Output goes to `./shots` (gitignored). Screenshots belong in the RTL-Design
+repo under `baseline/`:
+
+```bash
+OUT_DIR=/path/to/RTL-Design/baseline node capture.mjs full
+```
+
+## Conditions
+
+| | |
+|---|---|
+| Viewport | 1440×900 (mobile 390×844) |
+| Device scale factor | 2 — so files are 2880×1800 |
+| Browser | Chromium via Playwright |
+| Password | `rtldev` (must match `multiPass` in `../rtl/RTL-Config.regtest.json`) |
+
+Record these in `baseline/README.md` in the design repo. Device scale factor
+especially: re-shooting at a different ratio makes before/after comparisons
+invalid, and nobody remembers it a year later.
+
+## Notes
+
+- Routes were verified against a running RTL by checking page content, not the
+  URL. Angular renders its 404 component without changing the URL, so a route
+  can look fine and be a "Page Not Found".
+- The password must not be one of RTL's blacklisted weak passwords
+  (`password`, `changeme`, `moneyprintergobrrr`) or login is redirected to a
+  forced password change and never reaches the dashboard.
+- Loop and Boltz are not configured in the fixture, so those shots record the
+  unconfigured state.

--- a/docker/capture/capture.mjs
+++ b/docker/capture/capture.mjs
@@ -1,0 +1,175 @@
+/**
+ * Deterministic screenshot capture of RTL against the regtest fixture.
+ *
+ * The point of this script is that the capture conditions live in code rather
+ * than in someone's memory. Viewport, device scale factor, browser and the
+ * screen list are all pinned here, so a capture taken today and one taken after
+ * a redesign differ only by the design.
+ *
+ * Requires the fixture to be running (see ../README.md).
+ *
+ *   node capture.mjs empty     # BEFORE ./scripts/seed.sh -- empty states
+ *   node capture.mjs full      # AFTER  ./scripts/seed.sh -- populated
+ *
+ * Every route below was verified against a running RTL by checking page content,
+ * not just the URL: Angular renders its 404 component without changing the URL,
+ * so a path can look fine and be a "Page Not Found".
+ */
+
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+
+// --- capture conditions. Record these in baseline/README.md. -----------------
+const BASE = 'http://localhost:3000';
+const PASSWORD = 'rtldev';          // must match multiPass in rtl/RTL-Config.regtest.json
+const VIEWPORT = { width: 1440, height: 900 };
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const SCALE = 2;                    // Retina. 1440x900 CSS px -> 2880x1800 file.
+const OUT = process.env.OUT_DIR || './shots';
+const SETTLE_MS = 1200;             // let charts and tables finish rendering
+
+// --- shot lists --------------------------------------------------------------
+// node: which LND node to view. null = whatever is selected (login screen).
+
+const EMPTY = [
+  { file: 'lnd-login.png',                    route: '/rtl/login',                         node: null, noAuth: true },
+  { file: 'lnd-dashboard-operator-empty.png', route: '/rtl/lnd/home',                      node: 'alice' },
+  { file: 'lnd-channels-empty.png',           route: '/rtl/lnd/connections/channels/open', node: 'alice' },
+  { file: 'lnd-peers-empty.png',              route: '/rtl/lnd/connections/peers',         node: 'alice' },
+  { file: 'lnd-payments-empty.png',           route: '/rtl/lnd/transactions/payments',     node: 'alice' },
+  { file: 'lnd-invoices-empty.png',           route: '/rtl/lnd/transactions/invoices',     node: 'alice' },
+];
+
+const FULL = [
+  { file: 'lnd-dashboard-operator-day.png',   route: '/rtl/lnd/home',                          node: 'alice' },
+  { file: 'lnd-dashboard-merchant-day.png',   route: '/rtl/lnd/home',                          node: 'carol' },
+  { file: 'lnd-dashboard-routing-day.png',    route: '/rtl/lnd/home',                          node: 'bob'   },
+  { file: 'lnd-channels-open.png',            route: '/rtl/lnd/connections/channels/open',     node: 'alice' },
+  { file: 'lnd-channels-open-routing.png',    route: '/rtl/lnd/connections/channels/open',     node: 'bob'   },
+  { file: 'lnd-channels-pending.png',         route: '/rtl/lnd/connections/channels/pending',  node: 'alice' },
+  { file: 'lnd-channels-closed.png',          route: '/rtl/lnd/connections/channels/closed',   node: 'alice' },
+  { file: 'lnd-peers.png',                    route: '/rtl/lnd/connections/peers',             node: 'bob'   },
+  { file: 'lnd-payments.png',                 route: '/rtl/lnd/transactions/payments',         node: 'alice' },
+  { file: 'lnd-invoices.png',                 route: '/rtl/lnd/transactions/invoices',         node: 'carol' },
+  { file: 'lnd-onchain-receive.png',          route: '/rtl/lnd/onchain/receive/0',             node: 'alice' },
+  { file: 'lnd-onchain-send.png',             route: '/rtl/lnd/onchain/send/0',                node: 'alice' },
+  { file: 'lnd-routing-forwardinghistory.png',route: '/rtl/lnd/routing/forwardinghistory',     node: 'bob'   },
+  { file: 'lnd-routing-peers.png',            route: '/rtl/lnd/routing/peers',                 node: 'bob'   },
+  { file: 'lnd-reports-routing.png',          route: '/rtl/lnd/reports/routingreport',         node: 'bob'   },
+  { file: 'lnd-reports-transactions.png',     route: '/rtl/lnd/reports/transactions',          node: 'alice' },
+  { file: 'lnd-graph-queryroutes.png',        route: '/rtl/lnd/graph/queryroutes',             node: 'alice' },
+  { file: 'lnd-graph-lookups.png',            route: '/rtl/lnd/graph/lookups',                 node: 'alice' },
+  { file: 'lnd-network.png',                  route: '/rtl/lnd/network',                       node: 'alice' },
+  { file: 'lnd-wallet.png',                   route: '/rtl/lnd/wallet',                        node: 'alice' },
+  { file: 'lnd-messages-sign.png',            route: '/rtl/lnd/messages/sign',                 node: 'alice' },
+  { file: 'lnd-messages-verify.png',          route: '/rtl/lnd/messages/verify',               node: 'alice' },
+  { file: 'lnd-channelbackup.png',            route: '/rtl/lnd/channelbackup/bckup',           node: 'alice' },
+  { file: 'lnd-settings-app.png',             route: '/rtl/settings/app',                      node: 'alice' },
+  { file: 'lnd-settings-auth.png',            route: '/rtl/settings/auth',                     node: 'alice' },
+  { file: 'lnd-settings-nodeconfig.png',      route: '/rtl/settings/bconfig',                  node: 'alice' },
+  // Loop and Boltz are NOT configured in this fixture, so these record the
+  // unconfigured state. That is what most RTL users see, but it is not
+  // comparable to the lnd/loop and lnd/swapservices mockups, which assumed a
+  // configured service. Note this in baseline/README.md.
+  { file: 'lnd-services-loop-unconfigured.png',  route: '/rtl/services/loop/loopout',  node: 'alice' },
+  { file: 'lnd-services-boltz-unconfigured.png', route: '/rtl/services/boltz/swapout', node: 'alice' },
+];
+
+// --- helpers -----------------------------------------------------------------
+
+const log = (m) => console.log(`  ${m}`);
+
+async function login(page) {
+  await page.goto(`${BASE}/rtl/login`, { waitUntil: 'networkidle' });
+  await page.fill('input#password', PASSWORD);
+  await page.click('button[type=submit]');
+  // RTL forces a password change for blacklisted passwords ('password',
+  // 'changeme', 'moneyprintergobrrr') and parks on /rtl/settings/auth.
+  await page.waitForURL('**/lnd/home', { timeout: 20000 }).catch(() => {
+    throw new Error(
+      `login did not reach the dashboard (landed on ${page.url()}).\n` +
+      `    If this is /rtl/settings/auth, the password is blacklisted by RTL.`
+    );
+  });
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+/** Switch the active node via the sidebar selector. */
+async function selectNode(page, name) {
+  const select = page.locator('mat-select').first();
+  const current = (await select.innerText()).trim();
+  if (current.startsWith(name)) return;
+  await select.click();
+  // hasText is a case-insensitive substring match, which matters: mat-option's
+  // text carries surrounding whitespace, so an anchored /^name/ regex misses.
+  const option = page.locator('mat-option').filter({ hasText: `${name} (LND)` }).first();
+  await option.waitFor({ state: 'visible', timeout: 10000 });
+  await option.click();
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+async function shot(page, { file, route, node, noAuth }) {
+  if (node) await selectNode(page, node);
+  await page.goto(BASE + route, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(SETTLE_MS);
+
+  const body = await page.locator('body').innerText();
+  if (/Page Not Found|does not exist/i.test(body)) {
+    log(`SKIP ${file}  (route 404s: ${route})`);
+    return false;
+  }
+  await page.screenshot({ path: `${OUT}/${file}`, fullPage: false });
+  log(`${file}${node ? `  [${node}]` : ''}`);
+  return true;
+}
+
+// --- main --------------------------------------------------------------------
+
+const phase = process.argv[2];
+if (!['empty', 'full'].includes(phase)) {
+  console.error('usage: node capture.mjs <empty|full>');
+  console.error('  empty  run BEFORE ./scripts/seed.sh');
+  console.error('  full   run AFTER  ./scripts/seed.sh');
+  process.exit(1);
+}
+
+await mkdir(OUT, { recursive: true });
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: SCALE });
+const page = await context.newPage();
+
+console.log(`\nCapturing "${phase}" -> ${OUT}  (${VIEWPORT.width}x${VIEWPORT.height} @${SCALE}x)\n`);
+
+const shots = phase === 'empty' ? EMPTY : FULL;
+let ok = 0, skipped = 0;
+
+// The login screen is the only shot taken before authenticating.
+const pre = shots.filter((s) => s.noAuth);
+for (const s of pre) {
+  await page.goto(BASE + s.route, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(SETTLE_MS);
+  await page.screenshot({ path: `${OUT}/${s.file}` });
+  log(s.file);
+  ok++;
+}
+
+await login(page);
+for (const s of shots.filter((s) => !s.noAuth)) {
+  (await shot(page, s)) ? ok++ : skipped++;
+}
+
+// Mobile, dashboard only. The readme claims RTL is "device agnostic".
+if (phase === 'full') {
+  const mob = await browser.newContext({ viewport: MOBILE_VIEWPORT, deviceScaleFactor: SCALE, isMobile: true, hasTouch: true });
+  const mp = await mob.newPage();
+  await login(mp);
+  await mp.goto(`${BASE}/rtl/lnd/home`, { waitUntil: 'networkidle' });
+  await mp.waitForTimeout(SETTLE_MS);
+  await mp.screenshot({ path: `${OUT}/lnd-dashboard-operator-mobile.png` });
+  log(`lnd-dashboard-operator-mobile.png  [${MOBILE_VIEWPORT.width}x${MOBILE_VIEWPORT.height}]`);
+  ok++;
+  await mob.close();
+}
+
+await browser.close();
+console.log(`\n${ok} captured, ${skipped} skipped -> ${OUT}\n`);

--- a/docker/capture/package-lock.json
+++ b/docker/capture/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "rtl-baseline-capture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rtl-baseline-capture",
+      "version": "1.0.0",
+      "devDependencies": {
+        "playwright": "^1.61.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/docker/capture/package.json
+++ b/docker/capture/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rtl-baseline-capture",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Deterministic screenshot capture of RTL against the regtest fixture",
+  "scripts": {
+    "capture": "node capture.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.61.1"
+  }
+}

--- a/docker/rtl/RTL-Config.regtest.json
+++ b/docker/rtl/RTL-Config.regtest.json
@@ -1,5 +1,5 @@
 {
-  "multiPass": "password",
+  "multiPass": "rtldev",
   "port": "3000",
   "defaultNodeIndex": 1,
   "dbDirectoryPath": "/RTL/database",


### PR DESCRIPTION
Adds the baseline screenshot harness, and fixes a bug in the fixture merged in #1621.

## Bug: the fixture's password is blacklisted by RTL

`PASSWORD_BLACKLIST` in `src/app/shared/services/consts-enums-functions.ts:302` is `['password', 'changeme', 'moneyprintergobrrr']`. When a blacklisted password is used, `login.component.ts:87` sets `defaultPassword: true` and `app.component.ts:97` redirects to `/rtl/settings/auth` to force a password change.

The fixture set `multiPass` to exactly `"password"` — the first entry on that list. So every fresh browser session logged in, got bounced to the change-password screen, and never reached the dashboard. It's session-based, not first-run only, so it happened every time.

Password is now `rtldev`. `.env` documents why it must stay off the blacklist.

## capture/

Drives RTL against the fixture and captures a fixed set of screens for the 1.0 design baseline.

The value is that capture conditions live in code, not in someone's head. Viewport (1440×900), device scale factor (2, so files are 2880×1800), browser and the screen list are pinned in `capture.mjs`. When 2.0 lands, the "after" can be shot under identical conditions — otherwise a re-shoot on a different display silently invalidates every before/after comparison.

```bash
cd docker/capture && npm install && npx playwright install chromium
node capture.mjs empty   # before ./scripts/seed.sh -- empty states
node capture.mjs full    # after  -- populated
```

Screenshots are gitignored; they belong in the RTL-Design repo.

## Routes were verified, not assumed

Angular renders its 404 component **without changing the URL**, so a route can look fine while being a "Page Not Found". My first pass compared `location.pathname` and reported 24/24 OK. Re-probing by page content found three of them are actually 404s:

- `/rtl/settings/config`
- `/rtl/settings/nodesettings`
- `/rtl/settings/pglayout`

Node Config is `/rtl/settings/bconfig`. The script only contains content-verified routes.

## Verified

29 screens captured, 0 skipped, against the seeded fixture. Node switching across alice/bob/carol works. bob's forwarding history shows all 5 seeded routed payments with the exact amounts — the screen a two-node fixture leaves empty.

## Known gaps

- Loop and Boltz aren't configured, so those two shots record the unconfigured state
- Onboarding/first-run can't be captured, since the config pre-configures three nodes
- Night mode and persona switching aren't scripted yet; both are per-node settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
