### PR TITLE
Fix the regtest fixture using a password RTL blacklists

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -24,6 +24,9 @@ ALICE_REST_PORT=8081
 BOB_REST_PORT=8082
 CAROL_REST_PORT=8083
 
-# RTL
+# RTL. Must not be one of RTL's blacklisted weak passwords
+# ('password', 'changeme', 'moneyprintergobrrr') or RTL forces a password change
+# on every login and parks you on the auth settings screen. Set in
+# rtl/RTL-Config.regtest.json as multiPass; this is only used for messages.
 RTL_PORT=3000
-RTL_PASSWORD=password
+RTL_PASSWORD=rtldev

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,7 @@ docker compose up -d          # bitcoind, alice, bob, carol, rtl
 ./scripts/seed.sh             # fund, connect, open channels, make payments
 ```
 
-Then open <http://localhost:3000> — password `password`. All three nodes appear in
+Then open <http://localhost:3000> — password `rtldev`. All three nodes appear in
 the node switcher.
 
 Tear down, discarding all state:

--- a/docker/rtl/RTL-Config.regtest.json
+++ b/docker/rtl/RTL-Config.regtest.json
@@ -1,5 +1,5 @@
 {
-  "multiPass": "password",
+  "multiPass": "rtldev",
   "port": "3000",
   "defaultNodeIndex": 1,
   "dbDirectoryPath": "/RTL/database",


### PR DESCRIPTION
Fixes a bug in the fixture merged in #1621: the documented password is one RTL blacklists, so login never reaches the dashboard.

## The bug

`PASSWORD_BLACKLIST` in `src/app/shared/services/consts-enums-functions.ts:302`:

```ts
export const PASSWORD_BLACKLIST = ['password', 'changeme', 'moneyprintergobrrr'];
```

When a blacklisted password is used, `login.component.ts:87` sets `defaultPassword: true`, and `app.component.ts:97` then redirects to `/rtl/settings/auth` to force a password change.

The fixture set `multiPass` to exactly `"password"` — the first entry on that list. So logging in with the password printed by `seed.sh` and documented in `docker/README.md` bounced straight to the change-password screen. The check is session-based rather than first-run-only, so it happened on **every** fresh browser session.

## The fix

Password is now `rtldev`. `.env` documents why it must stay off the blacklist, since the failure mode is confusing — you appear to log in successfully and simply never arrive.

## Verified

Login now lands on `/rtl/lnd/home`. Confirmed the staged config hashes correctly: RTL rewrites `multiPass` to `multiPassHashed`, and the stored value matches `sha256("rtldev")` = `beaff3218d4fd360881f5ab3ec3396610a193b650175fe9f76acfd120cd00e5c`.

Note that changing `rtl/RTL-Config.regtest.json` alone isn't enough on a running fixture — the `rtl_config` volume persists, so the init container must be forced to re-stage:

```bash
docker compose up -d --force-recreate rtl-config-init rtl
```

A plain `docker compose down -v && docker compose up -d` also does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
