### PR TITLE
Re-land the seed.sh .env fix dropped from #1623

### DIFF
--- a/docker/scripts/seed.sh
+++ b/docker/scripts/seed.sh
@@ -19,6 +19,16 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Docker Compose reads .env by itself; bash does not. Without this the defaults
+# below silently win, and the summary at the end prints a password that does not
+# work.
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
 BITCOIN_RPC_USER="${BITCOIN_RPC_USER:-rtldev}"
 BITCOIN_RPC_PASSWORD="${BITCOIN_RPC_PASSWORD:-rtldev}"
 


### PR DESCRIPTION
Re-lands a commit that was dropped when #1623 was merged.

## What happened

#1623 had two commits. GitHub records it as merged with **one**: `df48de11` is a squash of `50daef30` (the `multiPass` change) only. The second commit — `0edde2bc`, the `seed.sh` fix — is not an ancestor of `master`. Most likely the merge happened from the UI before the second push landed.

## Why it matters

The result is a half-fix that's arguably worse than the original bug. On `master` today:

- `docker/.env` correctly says `RTL_PASSWORD=rtldev`
- `docker/scripts/seed.sh` never sources `.env`, so `${RTL_PASSWORD:-password}` falls through to the default

So `seed.sh` finishes by telling the user to log in with `password` — the exact blacklisted value #1623 removed, which bounces them to a forced password change and never reaches the dashboard. The config is right and the instructions are wrong, which is a worse failure than both being wrong, because the user has no reason to doubt the message.

Demonstrated:

```
$ bash -c 'set -a; source .env; set +a; printf "%s\n" "${RTL_PASSWORD:-password}"'
rtldev
$ bash -c 'printf "%s\n" "${RTL_PASSWORD:-password}"'      # what master does
password
```

## The fix

Source `.env` in `seed.sh`. Docker Compose reads it automatically; bash does not — that asymmetry is what made this easy to miss, since every `docker compose` call in the script picks up `.env` fine and only the bash-level variable doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
