### PR TITLE
Restore items-per-page dropdown on paginated tables (#1580)

### DIFF
--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -31,6 +31,18 @@ this release should add its entry under the appropriate section below.
   guard was applied there for parity. Eclair's modal doesn't use `selNode.settings`, so it is
   unaffected.
 
+- **All implementations: restore the "items per page" dropdown (and first/last-page buttons)
+  on paginated tables** ([#XXXX](https://github.com/Ride-The-Lightning/RTL/pull/XXXX), fixes
+  [#1580](https://github.com/Ride-The-Lightning/RTL/issues/1580)).
+  A dependency-update commit in the 0.15.8-beta cycle mechanically renamed the paginator
+  binding `[showFirstLastButtons]` to `[hidePageSize]` on every `mat-paginator` while keeping
+  the same `screenSize === XS ? false : true` expression. Because the two properties have
+  opposite polarity, this inverted the behavior: on desktop the page-size selector was hidden,
+  so users were locked to 10 items per page with no way to raise it — and the first/last-page
+  buttons were dropped everywhere as collateral. Reverting the ~44 affected paginators back to
+  `[showFirstLastButtons]` restores both behaviors across the LND, Core Lightning, Eclair and
+  shared tables.
+
 ## Developer Tooling
 
 - **Added a Core Lightning node to the regtest docker fixture**

--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -32,7 +32,7 @@ this release should add its entry under the appropriate section below.
   unaffected.
 
 - **All implementations: restore the "items per page" dropdown (and first/last-page buttons)
-  on paginated tables** ([#XXXX](https://github.com/Ride-The-Lightning/RTL/pull/XXXX), fixes
+  on paginated tables** ([#1626](https://github.com/Ride-The-Lightning/RTL/pull/1626), fixes
   [#1580](https://github.com/Ride-The-Lightning/RTL/issues/1580)).
   A dependency-update commit in the 0.15.8-beta cycle mechanically renamed the paginator
   binding `[showFirstLastButtons]` to `[hidePageSize]` on every `mat-paginator` while keeping

--- a/src/app/cln/liquidity-ads/liquidity-ads-list/liquidity-ads-list.component.html
+++ b/src/app/cln/liquidity-ads/liquidity-ads-list/liquidity-ads-list.component.html
@@ -167,7 +167,7 @@
             <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
           </table>
         </div>
-        <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+        <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
       </div>
     </mat-card-content>
   </mat-card>

--- a/src/app/cln/on-chain/utxo-tables/utxos/utxos.component.html
+++ b/src/app/cln/on-chain/utxo-tables/utxos/utxos.component.html
@@ -104,7 +104,7 @@
         <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
-      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
   </div>
 </div>

--- a/src/app/cln/peers-channels/channels/channels-tables/channel-active-htlcs-table/channel-active-htlcs-table.component.html
+++ b/src/app/cln/peers-channels/channels/channels-tables/channel-active-htlcs-table/channel-active-htlcs-table.component.html
@@ -142,5 +142,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/cln/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.html
+++ b/src/app/cln/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.html
@@ -142,5 +142,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/cln/peers-channels/channels/channels-tables/channel-pending-table/channel-pending-table.component.html
+++ b/src/app/cln/peers-channels/channels/channels-tables/channel-pending-table/channel-pending-table.component.html
@@ -127,5 +127,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/cln/peers-channels/peers/peers.component.html
+++ b/src/app/cln/peers-channels/peers/peers.component.html
@@ -88,6 +88,6 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/cln/routing/failed-transactions/failed-transactions.component.html
+++ b/src/app/cln/routing/failed-transactions/failed-transactions.component.html
@@ -108,5 +108,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/cln/routing/forwarding-history/forwarding-history.component.html
+++ b/src/app/cln/routing/forwarding-history/forwarding-history.component.html
@@ -110,5 +110,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/cln/routing/local-failed-transactions/local-failed-transactions.component.html
+++ b/src/app/cln/routing/local-failed-transactions/local-failed-transactions.component.html
@@ -93,5 +93,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/cln/routing/routing-peers/routing-peers.component.html
+++ b/src/app/cln/routing/routing-peers/routing-peers.component.html
@@ -51,7 +51,7 @@
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
       </div>
-      <mat-paginator #paginatorIn class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator #paginatorIn class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
     <div fxLayout="column" fxFlex="49" fxLayoutAlign="end stretch">
       <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutAlign.gt-sm="space-between center" fxLayoutAlign="start stretch" class="page-sub-title-container w-100" [ngClass]="{'mt-2': screenSize !== screenSizeEnum.LG}">
@@ -112,7 +112,7 @@
           <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
-        <mat-paginator #paginatorOut class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+        <mat-paginator #paginatorOut class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
       </div>
     </div>
   </div>

--- a/src/app/cln/transactions/invoices/invoices-table/lightning-invoices-table.component.html
+++ b/src/app/cln/transactions/invoices/invoices-table/lightning-invoices-table.component.html
@@ -141,6 +141,6 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/cln/transactions/offers/offer-bookmarks-table/offer-bookmarks-table.component.html
+++ b/src/app/cln/transactions/offers/offer-bookmarks-table/offer-bookmarks-table.component.html
@@ -90,6 +90,6 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/cln/transactions/offers/offers-table/offers-table.component.html
+++ b/src/app/cln/transactions/offers/offers-table/offers-table.component.html
@@ -93,6 +93,6 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/cln/transactions/payments/lightning-payments.component.html
+++ b/src/app/cln/transactions/payments/lightning-payments.component.html
@@ -263,6 +263,6 @@
         </table>
       </div>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/eclair/on-chain/on-chain-transaction-history/on-chain-transaction-history.component.html
+++ b/src/app/eclair/on-chain/on-chain-transaction-history/on-chain-transaction-history.component.html
@@ -90,9 +90,9 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
       <!-- Remove below one line after paginator api is fixed -->
-      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
       <!-- Uncomment after paginator api is fixed -->
-      <!-- <mat-paginator class="mb-1" [length]="totalRecords" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" /> -->
+      <!-- <mat-paginator class="mb-1" [length]="totalRecords" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" /> -->
     </div>
   </div>
 </div>

--- a/src/app/eclair/peers-channels/channels/channels-tables/channel-inactive-table/channel-inactive-table.component.html
+++ b/src/app/eclair/peers-channels/channels/channels-tables/channel-inactive-table/channel-inactive-table.component.html
@@ -110,5 +110,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/eclair/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.html
+++ b/src/app/eclair/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.html
@@ -121,5 +121,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/eclair/peers-channels/channels/channels-tables/channel-pending-table/channel-pending-table.component.html
+++ b/src/app/eclair/peers-channels/channels/channels-tables/channel-pending-table/channel-pending-table.component.html
@@ -87,5 +87,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/eclair/peers-channels/peers/peers.component.html
+++ b/src/app/eclair/peers-channels/peers/peers.component.html
@@ -90,6 +90,6 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/eclair/routing/forwarding-history/forwarding-history.component.html
+++ b/src/app/eclair/routing/forwarding-history/forwarding-history.component.html
@@ -115,5 +115,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/eclair/routing/routing-peers/routing-peers.component.html
+++ b/src/app/eclair/routing/routing-peers/routing-peers.component.html
@@ -61,7 +61,7 @@
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
       </div>
-      <mat-paginator #paginatorIn class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator #paginatorIn class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
     <div fxLayout="column" fxFlex="49" fxLayoutAlign="end stretch" class="mb-4">
       <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutAlign.gt-sm="space-between center" fxLayoutAlign="start stretch" class="page-sub-title-container w-100" [ngClass]="{'mt-2': screenSize !== screenSizeEnum.LG}">
@@ -122,7 +122,7 @@
           <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
-        <mat-paginator #paginatorOut class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+        <mat-paginator #paginatorOut class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
       </div>
     </div>
   </div>

--- a/src/app/eclair/transactions/invoices/lightning-invoices.component.html
+++ b/src/app/eclair/transactions/invoices/lightning-invoices.component.html
@@ -136,8 +136,8 @@
       </table>
     </div>
     <!-- Remove below one line after paginator api is fixed -->
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     <!-- Uncomment after paginator api is fixed -->
-    <!-- <mat-paginator class="mb-1" [length]="totalRecords" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" /> -->
+    <!-- <mat-paginator class="mb-1" [length]="totalRecords" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" /> -->
   </div>
 </div>

--- a/src/app/eclair/transactions/payments/lightning-payments.component.html
+++ b/src/app/eclair/transactions/payments/lightning-payments.component.html
@@ -250,8 +250,8 @@
       </div>
     </div>
     <!-- Remove below one line after paginator api is fixed -->
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     <!-- Uncomment after paginator api is fixed -->
-    <!-- <mat-paginator class="mb-1" [length]="totalRecords" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" /> -->
+    <!-- <mat-paginator class="mb-1" [length]="totalRecords" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" /> -->
   </div>
 </div>

--- a/src/app/lnd/backup/channel-backup-table/channel-backup-table.component.html
+++ b/src/app/lnd/backup/channel-backup-table/channel-backup-table.component.html
@@ -66,5 +66,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/lnd/backup/channel-restore-table/channel-restore-table.component.html
+++ b/src/app/lnd/backup/channel-restore-table/channel-restore-table.component.html
@@ -53,5 +53,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/lnd/on-chain/utxo-tables/on-chain-transaction-history/on-chain-transaction-history.component.html
+++ b/src/app/lnd/on-chain/utxo-tables/on-chain-transaction-history/on-chain-transaction-history.component.html
@@ -89,7 +89,7 @@
         <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
-      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
   </div>
 </div>

--- a/src/app/lnd/on-chain/utxo-tables/utxos/utxos.component.html
+++ b/src/app/lnd/on-chain/utxo-tables/utxos/utxos.component.html
@@ -105,7 +105,7 @@
         <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
-      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
   </div>
 </div>

--- a/src/app/lnd/peers-channels/channels/channels-tables/channel-active-htlcs-table/channel-active-htlcs-table.component.html
+++ b/src/app/lnd/peers-channels/channels/channels-tables/channel-active-htlcs-table/channel-active-htlcs-table.component.html
@@ -138,5 +138,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/lnd/peers-channels/channels/channels-tables/channel-closed-table/channel-closed-table.component.html
+++ b/src/app/lnd/peers-channels/channels/channels-tables/channel-closed-table/channel-closed-table.component.html
@@ -129,5 +129,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/lnd/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.html
+++ b/src/app/lnd/peers-channels/channels/channels-tables/channel-open-table/channel-open-table.component.html
@@ -175,5 +175,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/lnd/peers-channels/peers/peers.component.html
+++ b/src/app/lnd/peers-channels/peers/peers.component.html
@@ -109,6 +109,6 @@
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/lnd/routing/forwarding-history/forwarding-history.component.html
+++ b/src/app/lnd/routing/forwarding-history/forwarding-history.component.html
@@ -91,5 +91,5 @@
       <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
     </table>
   </div>
-  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+  <mat-paginator *ngIf="errorMessage === ''" class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
 </div>

--- a/src/app/lnd/routing/non-routing-peers/non-routing-peers.component.html
+++ b/src/app/lnd/routing/non-routing-peers/non-routing-peers.component.html
@@ -129,6 +129,6 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
     </div>
-    <mat-paginator #paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+    <mat-paginator #paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
   </div>
 </div>

--- a/src/app/lnd/routing/routing-peers/routing-peers.component.html
+++ b/src/app/lnd/routing/routing-peers/routing-peers.component.html
@@ -65,7 +65,7 @@
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
       </div>
-      <mat-paginator #paginatorIn class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator #paginatorIn class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
     <div fxLayout="column" fxFlex="49" fxLayoutAlign="start stretch" class="mb-4">
       <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutAlign.gt-sm="space-between center" fxLayoutAlign="start stretch" class="page-sub-title-container w-100" [ngClass]="{'mt-2': screenSize !== screenSizeEnum.LG}">
@@ -123,7 +123,7 @@
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
       </div>
-      <mat-paginator #paginatorOut class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator #paginatorOut class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
   </div>
 </div>

--- a/src/app/lnd/transactions/invoices/lightning-invoices.component.html
+++ b/src/app/lnd/transactions/invoices/lightning-invoices.component.html
@@ -187,7 +187,7 @@
         <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
-      <mat-paginator class="mb-1" [length]="totalInvoices" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" />
+      <mat-paginator class="mb-1" [length]="totalInvoices" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" />
     </div>
   </div>
 </div>

--- a/src/app/lnd/transactions/payments/lightning-payments.component.html
+++ b/src/app/lnd/transactions/payments/lightning-payments.component.html
@@ -292,7 +292,7 @@
           <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
-        <mat-paginator class="mb-1" [length]="totalPayments" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" />
+        <mat-paginator class="mb-1" [length]="totalPayments" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" (page)="onPageChange($event)" />
       </div>
     </div>
   </div>

--- a/src/app/shared/components/ln-services/boltz/swaps/swaps.component.html
+++ b/src/app/shared/components/ln-services/boltz/swaps/swaps.component.html
@@ -138,7 +138,7 @@
         <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
-      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
   </div>
 </div>

--- a/src/app/shared/components/ln-services/loop/swaps/swaps.component.html
+++ b/src/app/shared/components/ln-services/loop/swaps/swaps.component.html
@@ -99,7 +99,7 @@
         <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
-      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+      <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
     </div>
   </div>
 </div>

--- a/src/app/shared/components/transactions-report-table/transactions-report-table.component.html
+++ b/src/app/shared/components/transactions-report-table/transactions-report-table.component.html
@@ -60,7 +60,7 @@
           <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
           <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
         </table>
-        <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [hidePageSize]="screenSize === screenSizeEnum.XS ? false : true" />
+        <mat-paginator class="mb-1" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Fixes #1580

### Problem
Since v0.15.8-beta, paginated tables (e.g. `lnd/routing/forwardinghistory`) no longer show the **items-per-page** dropdown on desktop — users are locked to 10 rows with no way to raise the page size. The first/last-page buttons also disappeared everywhere.

### Root cause
A dependency-update commit in the 0.15.8-beta cycle (`4e08fd7c`) mechanically renamed the paginator binding `[showFirstLastButtons]` → `[hidePageSize]` on every `mat-paginator`, while keeping the identical `screenSize === XS ? false : true` expression. The two `MatPaginator` inputs have **opposite polarity**, so this inverted the behaviour:

| Property | `true` means | Desktop (non-XS) | Mobile (XS) |
|---|---|---|---|
| old `showFirstLastButtons` | show first/last buttons | shown | hidden |
| new `hidePageSize` | hide the page-size selector | **selector hidden** | shown |

So on desktop the expression evaluated to `true` → the page-size dropdown was hidden, and the first/last buttons were dropped as collateral.

### Fix
Revert all ~44 affected paginators (LND, Core Lightning, Eclair, shared) back to `[showFirstLastButtons]="screenSize === screenSizeEnum.XS ? false : true"`. This restores both the always-visible page-size dropdown and the conditional first/last-page buttons — the pre-0.15.8 behaviour.

### Verification
- Built the branch image and brought up the `docker/` regtest fixture (seeded, so the forwarding-history table has real data).
- Confirmed in the AOT bundle that every app paginator now binds `showFirstLastButtons` (with `hidePageSize` unset → selector visible), and no app template binds `hidePageSize` anymore.
- Eyeballed the running UI.

Release note added under `release-notes/Release-notes-0.15.9.md`.