### PR TITLE
Backfill 0.15.9 release notes for pre-process merged PRs

### DIFF
--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -5,6 +5,23 @@ this release should add its entry under the appropriate section below.
 
 ## Bug Fixes
 
+- **All implementations: fix a page-load error when a channel's alias is undefined**
+  ([#1581](https://github.com/Ride-The-Lightning/RTL/pull/1581)).
+  On the home dashboard, channel labels were rendered as `(channel.alias || channel.peer_id).length`
+  (and the `remote_alias`/`shortChannelId` variants). When both the alias and its fallback id were
+  undefined, calling `.length` on `undefined` threw during change detection and errored the page on
+  load. The bindings now fall back to an empty string (`|| ''`, with optional chaining) so a missing
+  alias can no longer break the page.
+
+- **Multi-node: fix stale auth options blocking a node whose credentials weren't ready at startup**
+  ([#1601](https://github.com/Ride-The-Lightning/RTL/pull/1601)).
+  `CommonService.setOptions` short-circuited on `this.nodes[0]` regardless of which node was being
+  processed, so once the first node's auth headers loaded, every subsequent call returned early. A
+  second node whose credential load had failed — e.g. a Core Lightning rune file written
+  asynchronously after RTL starts — was never retried and kept failing with `missing rune!` until
+  RTL was restarted. The cache check is now per-node, so a node that failed to initialize is retried
+  on the next request once its credential is available, while already-loaded nodes are still skipped.
+
 - **Core Lightning: fix contradictory channel connection status between the list and the
   detail panel** ([#1625](https://github.com/Ride-The-Lightning/RTL/pull/1625), fixes
   [#1606](https://github.com/Ride-The-Lightning/RTL/issues/1606)).
@@ -45,6 +62,14 @@ this release should add its entry under the appropriate section below.
 
 ## Enhancements
 
+- **Add a Disable Authentication option**
+  ([#1582](https://github.com/Ride-The-Lightning/RTL/pull/1582)).
+  A new `disableAuth` config flag (or `DISABLE_AUTH` environment variable) lets RTL run without its
+  login screen — intended for node-platform vendors who put their own authentication layer in front
+  of RTL, not for standalone users. When enabled, RTL issues a session token automatically and
+  disables password updates and 2FA; a configured `APP_PASSWORD` is rejected as incompatible.
+  Backend, frontend, and configuration docs were updated.
+
 - **LND: show "Blocks till Maturity" by default on the Pending Force Closing list**
   ([#1627](https://github.com/Ride-The-Lightning/RTL/pull/1627), fixes
   [#1567](https://github.com/Ride-The-Lightning/RTL/issues/1567)).
@@ -56,6 +81,16 @@ this release should add its entry under the appropriate section below.
   customized this page keep their saved columns and can add it via the column-settings gear.
 
 ## Developer Tooling
+
+- **Rebuilt the regtest docker fixture**
+  ([#1621](https://github.com/Ride-The-Lightning/RTL/pull/1621)).
+  The `docker/` dev setup had been unable to start since February 2021 — a broken `boltz` service
+  (undeclared `BOLTZ_*` variables, a non-existent build context, and undeclared volumes) made
+  Compose reject the whole project, so even `docker compose up -d bitcoind` failed. It was replaced
+  with a working regtest network: `bitcoind` 30.0 + three LND 0.20.0-beta nodes
+  (alice → bob → carol, so RTL's routing/forwarding screens have data) + RTL, all using Polar's
+  multi-arch images (nothing built locally; works on arm64), plus a deterministic `seed.sh`. The
+  Core Lightning node below was later added on top of this fixture.
 
 - **Added a Core Lightning node to the regtest docker fixture**
   ([#1625](https://github.com/Ride-The-Lightning/RTL/pull/1625)).


### PR DESCRIPTION
## Backfill release notes for pre-process merged PRs

Several PRs were merged onto `Release-0.15.9` before the per-PR release-notes process was established, so they never got entries in `release-notes/Release-notes-0.15.9.md`. This adds them, matching the existing format and grouping.

### Added entries

**Bug Fixes**
- **#1581** — Fix a page-load error when a channel's alias is undefined (`.length` was called on `undefined` when both alias and its fallback id were missing).
- **#1601** — Fix stale auth options blocking a node whose credentials weren't ready at startup (`setOptions` cache check was on `nodes[0]` instead of per-node, so a node that failed to initialize — e.g. a CLN rune file written asynchronously — was never retried until an RTL restart).

**Enhancements**
- **#1582** — Add a Disable Authentication option (`disableAuth` config flag / `DISABLE_AUTH` env var) for node-platform vendors fronting RTL with their own auth.

**Developer Tooling**
- **#1621** — Rebuilt the regtest docker fixture (bitcoind 30 + 3 LND nodes + RTL, Polar multi-arch images, deterministic seed), replacing the setup that had been unable to start since Feb 2021.

### Not included
Version bump (`0.15.9`), the LICENSE copyright-year update, and the internal `rtlreviewbot.yml` CI config were intentionally left out — none are user- or contributor-facing changes that warrant a release note.

Docs-only change; no code touched.
