### PR TITLE
Rebuild compiled cln/channels.js to match its source (#1606)

### DIFF
--- a/backend/controllers/cln/channels.js
+++ b/backend/controllers/cln/channels.js
@@ -21,6 +21,11 @@ export const listPeerChannels = (req, res, next) => {
         const getPeerAliasesTasks = body.channels.map((channel) => () => {
             channel.to_them_msat = channel.total_msat - channel.to_us_msat;
             channel.balancedness = (channel.total_msat === 0) ? 1 : (1 - Math.abs((channel.to_us_msat - channel.to_them_msat) / channel.total_msat)).toFixed(3);
+            // listpeerchannels reports connection state as peer_connected. Mirror it onto the
+            // documented legacy 'connected' field (see the Channel model) as a real boolean, so
+            // any backward-compat consumer of this endpoint gets a defined true/false rather than
+            // undefined when peer_connected is absent (issue #1606).
+            channel.connected = !!channel.peer_connected;
             return getAlias(req.session.selectedNode, channel, 'peer_id');
         });
         common.runWithConcurrencyLimit(getPeerAliasesTasks, 20, () => {

--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -105,6 +105,15 @@ this release should add its entry under the appropriate section below.
   mobile (SM) layouts, so it's surfaced on the list out of the box. Users who have already
   customized this page keep their saved columns and can add it via the column-settings gear.
 
+## Code Health
+
+- **Rebuild the compiled CLN channels controller to match its source**
+  ([#1631](https://github.com/Ride-The-Lightning/RTL/pull/1631)).
+  The #1606 fix updated `server/controllers/cln/channels.ts` to mirror `peer_connected` onto the
+  legacy `connected` field, but the committed compiled artifact
+  `backend/controllers/cln/channels.js` was never regenerated, so it lagged its source. Rebuilt it
+  so the committed backend output includes the connected-mirror line.
+
 ## Developer Tooling
 
 - **Rebuilt the regtest docker fixture**


### PR DESCRIPTION
### Problem
The #1606 fix updated the source `server/controllers/cln/channels.ts` to mirror `peer_connected` onto the legacy `connected` field:

```ts
channel.connected = !!channel.peer_connected;
```

…but the committed **compiled** artifact `backend/controllers/cln/channels.js` was never regenerated, so it lagged its source. Since this repo commits the `backend/` build output, anyone running from the committed artifact (without a local rebuild) would be missing that line — i.e. the #1606 connected-mirror fix wasn't actually present in the shipped compiled controller.

### How it surfaced
Running `npm run buildbackend` produced exactly one dirty file — `backend/controllers/cln/channels.js` — confirming the drift is isolated to this one file.

### Change
Rebuilt `backend/controllers/cln/channels.js` from its current source so the committed compiled output matches. Verified the source already contained the line and no other backend artifact was stale.

Release note added under Code Health.
