### PR TITLE
Prevent multi-node config overwrite during application settings updates

### DIFF
--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -200,7 +200,7 @@ export const updateNodeSettings = (req, res, next) => {
     const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
     if (node && node.settings) {
-        node.settings = req.body.settings;
+        node.settings = { ...node.settings, ...req.body.settings };
         if (req.body.authentication.boltzMacaroonPath) {
             node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
         }
@@ -238,14 +238,59 @@ export const updateApplicationSettings = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Updating Application Settings..' });
     const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
     try {
-        const config = common.addSecureData(req.body);
-        common.appConfig = JSON.parse(JSON.stringify(config));
-        delete config.selectedNodeIndex;
-        delete config.enable2FA;
-        delete config.allowPasswordUpdate;
-        delete config.rtlConfFilePath;
-        delete config.rtlPass;
-        fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
+        const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
+        const requestConfig = JSON.parse(JSON.stringify(req.body));
+        const config = common.addSecureData(JSON.parse(JSON.stringify(requestConfig)));
+        const mergedConfig = JSON.parse(JSON.stringify(oldConfig));
+        Object.keys(config).forEach((key) => {
+            if (key !== 'nodes') {
+                mergedConfig[key] = config[key];
+            }
+        });
+        if (requestConfig.nodes && requestConfig.nodes.length > 0) {
+            const oldNodes = oldConfig.nodes || [];
+            mergedConfig.nodes = oldNodes.map((oldNode) => {
+                const newNode = requestConfig.nodes.find((node) => node.index === oldNode.index);
+                const node = newNode ? {
+                    ...oldNode,
+                    ...newNode,
+                    authentication: { ...(oldNode.authentication || {}), ...(newNode.authentication || {}) },
+                    settings: { ...(oldNode.settings || {}), ...(newNode.settings || {}) }
+                } : {
+                    ...oldNode,
+                    authentication: { ...(oldNode.authentication || {}) },
+                    settings: { ...(oldNode.settings || {}) }
+                };
+                delete node.authentication?.options;
+                delete node.authentication?.runeValue;
+                return node;
+            });
+            requestConfig.nodes.forEach((newNode) => {
+                if (!oldNodes.find((node) => node.index === newNode.index)) {
+                    const node = JSON.parse(JSON.stringify(newNode));
+                    delete node.authentication?.options;
+                    delete node.authentication?.runeValue;
+                    mergedConfig.nodes.push(node);
+                }
+            });
+        }
+        delete mergedConfig.selectedNodeIndex;
+        delete mergedConfig.enable2FA;
+        delete mergedConfig.allowPasswordUpdate;
+        delete mergedConfig.rtlConfFilePath;
+        delete mergedConfig.rtlPass;
+        common.appConfig = JSON.parse(JSON.stringify({
+            ...mergedConfig,
+            selectedNodeIndex: config.selectedNodeIndex !== undefined ?
+                config.selectedNodeIndex : common.appConfig.selectedNodeIndex,
+            enable2FA: config.enable2FA !== undefined ?
+                config.enable2FA : common.appConfig.enable2FA,
+            allowPasswordUpdate: config.allowPasswordUpdate !== undefined ?
+                config.allowPasswordUpdate : common.appConfig.allowPasswordUpdate,
+            rtlConfFilePath: common.appConfig.rtlConfFilePath,
+            rtlPass: common.appConfig.rtlPass
+        }));
+        fs.writeFileSync(RTLConfFile, JSON.stringify(mergedConfig, null, 2), 'utf-8');
         const newConfig = JSON.parse(JSON.stringify(common.appConfig));
         logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.maskPasswords(newConfig) });
         res.status(201).json(common.removeSecureData(newConfig));

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -197,26 +197,26 @@ export const getConfig = (req, res, next) => {
 export const updateNodeSettings = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Updating Node Settings..' });
     const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
-    const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
-    const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
-    if (node && node.settings) {
-        node.settings = { ...node.settings, ...req.body.settings };
-        if (node.authentication && req.body.authentication) {
-            if (req.body.authentication.boltzMacaroonPath) {
-                node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-            }
-            else {
-                delete node.authentication.boltzMacaroonPath;
-            }
-            if (req.body.authentication.swapMacaroonPath) {
-                node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-            }
-            else {
-                delete node.authentication.swapMacaroonPath;
+    try {
+        const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
+        const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
+        if (node && node.settings) {
+            node.settings = { ...node.settings, ...req.body.settings };
+            if (node.authentication && req.body.authentication) {
+                if (req.body.authentication.boltzMacaroonPath) {
+                    node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+                }
+                else {
+                    delete node.authentication.boltzMacaroonPath;
+                }
+                if (req.body.authentication.swapMacaroonPath) {
+                    node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+                }
+                else {
+                    delete node.authentication.swapMacaroonPath;
+                }
             }
         }
-    }
-    try {
         fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
         const selectedNode = common.findNode(req.session.selectedNode.index);
         if (selectedNode && selectedNode.settings) {

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -254,7 +254,7 @@ export const updateApplicationSettings = (req, res, next) => {
     try {
         const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
         const config = common.addSecureData(JSON.parse(JSON.stringify(req.body)));
-        const runtimeConfig = JSON.parse(JSON.stringify(oldConfig));
+        const runtimeConfig = oldConfig;
         Object.keys(config).forEach((key) => {
             if (key !== 'nodes') {
                 runtimeConfig[key] = config[key];
@@ -298,6 +298,7 @@ export const updateApplicationSettings = (req, res, next) => {
         delete fileConfig.allowPasswordUpdate;
         delete fileConfig.rtlConfFilePath;
         delete fileConfig.rtlPass;
+        delete fileConfig.multiPass;
         fileConfig.nodes?.forEach((node) => {
             delete node.authentication?.options;
             delete node.authentication?.runeValue;

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -218,9 +218,19 @@ export const updateNodeSettings = (req, res, next) => {
         fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
         const selectedNode = common.findNode(req.session.selectedNode.index);
         if (selectedNode && selectedNode.settings) {
-            selectedNode.settings = req.body.settings;
-            selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-            selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+            selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
+            if (req.body.authentication.boltzMacaroonPath) {
+                selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+            }
+            else {
+                delete selectedNode.authentication.boltzMacaroonPath;
+            }
+            if (req.body.authentication.swapMacaroonPath) {
+                selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+            }
+            else {
+                delete selectedNode.authentication.swapMacaroonPath;
+            }
             common.replaceNode(req, selectedNode);
         }
         let responseNode = JSON.parse(JSON.stringify(common.selectedNode));
@@ -239,18 +249,19 @@ export const updateApplicationSettings = (req, res, next) => {
     const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
     try {
         const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
-        const requestConfig = JSON.parse(JSON.stringify(req.body));
-        const config = common.addSecureData(JSON.parse(JSON.stringify(requestConfig)));
-        const mergedConfig = JSON.parse(JSON.stringify(oldConfig));
+        const config = common.addSecureData(JSON.parse(JSON.stringify(req.body)));
+        const runtimeConfig = JSON.parse(JSON.stringify(oldConfig));
         Object.keys(config).forEach((key) => {
             if (key !== 'nodes') {
-                mergedConfig[key] = config[key];
+                runtimeConfig[key] = config[key];
             }
         });
-        if (requestConfig.nodes && requestConfig.nodes.length > 0) {
-            const oldNodes = oldConfig.nodes || [];
-            mergedConfig.nodes = oldNodes.map((oldNode) => {
-                const newNode = requestConfig.nodes.find((node) => node.index === oldNode.index);
+        if (config.nodes && config.nodes.length > 0) {
+            const oldNodes = (common.appConfig.nodes && common.appConfig.nodes.length > 0) ? common.appConfig.nodes : (oldConfig.nodes || []);
+            const newNodesMap = new Map(config.nodes.map((node) => [node.index, node]));
+            const updatedAndExistingNodes = oldNodes.map((oldNode) => {
+                const newNode = newNodesMap.get(oldNode.index);
+                newNodesMap.delete(oldNode.index);
                 const node = newNode ? {
                     ...oldNode,
                     ...newNode,
@@ -261,26 +272,13 @@ export const updateApplicationSettings = (req, res, next) => {
                     authentication: { ...(oldNode.authentication || {}) },
                     settings: { ...(oldNode.settings || {}) }
                 };
-                delete node.authentication?.options;
-                delete node.authentication?.runeValue;
                 return node;
             });
-            requestConfig.nodes.forEach((newNode) => {
-                if (!oldNodes.find((node) => node.index === newNode.index)) {
-                    const node = JSON.parse(JSON.stringify(newNode));
-                    delete node.authentication?.options;
-                    delete node.authentication?.runeValue;
-                    mergedConfig.nodes.push(node);
-                }
-            });
+            const newOnlyNodes = [...newNodesMap.values()].map((newNode) => JSON.parse(JSON.stringify(newNode)));
+            runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
         }
-        delete mergedConfig.selectedNodeIndex;
-        delete mergedConfig.enable2FA;
-        delete mergedConfig.allowPasswordUpdate;
-        delete mergedConfig.rtlConfFilePath;
-        delete mergedConfig.rtlPass;
         common.appConfig = JSON.parse(JSON.stringify({
-            ...mergedConfig,
+            ...runtimeConfig,
             selectedNodeIndex: config.selectedNodeIndex !== undefined ?
                 config.selectedNodeIndex : common.appConfig.selectedNodeIndex,
             enable2FA: config.enable2FA !== undefined ?
@@ -290,7 +288,17 @@ export const updateApplicationSettings = (req, res, next) => {
             rtlConfFilePath: common.appConfig.rtlConfFilePath,
             rtlPass: common.appConfig.rtlPass
         }));
-        fs.writeFileSync(RTLConfFile, JSON.stringify(mergedConfig, null, 2), 'utf-8');
+        const fileConfig = JSON.parse(JSON.stringify(common.appConfig));
+        delete fileConfig.selectedNodeIndex;
+        delete fileConfig.enable2FA;
+        delete fileConfig.allowPasswordUpdate;
+        delete fileConfig.rtlConfFilePath;
+        delete fileConfig.rtlPass;
+        fileConfig.nodes?.forEach((node) => {
+            delete node.authentication?.options;
+            delete node.authentication?.runeValue;
+        });
+        fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
         const newConfig = JSON.parse(JSON.stringify(common.appConfig));
         logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.maskPasswords(newConfig) });
         res.status(201).json(common.removeSecureData(newConfig));

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -201,17 +201,19 @@ export const updateNodeSettings = (req, res, next) => {
     const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
     if (node && node.settings) {
         node.settings = { ...node.settings, ...req.body.settings };
-        if (req.body.authentication.boltzMacaroonPath) {
-            node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-        }
-        else {
-            delete node.authentication.boltzMacaroonPath;
-        }
-        if (req.body.authentication.swapMacaroonPath) {
-            node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-        }
-        else {
-            delete node.authentication.swapMacaroonPath;
+        if (node.authentication && req.body.authentication) {
+            if (req.body.authentication.boltzMacaroonPath) {
+                node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+            }
+            else {
+                delete node.authentication.boltzMacaroonPath;
+            }
+            if (req.body.authentication.swapMacaroonPath) {
+                node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+            }
+            else {
+                delete node.authentication.swapMacaroonPath;
+            }
         }
     }
     try {
@@ -219,17 +221,19 @@ export const updateNodeSettings = (req, res, next) => {
         const selectedNode = common.findNode(req.session.selectedNode.index);
         if (selectedNode && selectedNode.settings) {
             selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
-            if (req.body.authentication.boltzMacaroonPath) {
-                selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-            }
-            else {
-                delete selectedNode.authentication.boltzMacaroonPath;
-            }
-            if (req.body.authentication.swapMacaroonPath) {
-                selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-            }
-            else {
-                delete selectedNode.authentication.swapMacaroonPath;
+            if (selectedNode.authentication && req.body.authentication) {
+                if (req.body.authentication.boltzMacaroonPath) {
+                    selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+                }
+                else {
+                    delete selectedNode.authentication.boltzMacaroonPath;
+                }
+                if (req.body.authentication.swapMacaroonPath) {
+                    selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+                }
+                else {
+                    delete selectedNode.authentication.swapMacaroonPath;
+                }
             }
             common.replaceNode(req, selectedNode);
         }

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -69,16 +69,18 @@ export class CommonService {
             if (config.secret2FA === this.appConfig.secret2FA) {
                 config.secret2FA = this.appConfig.secret2FA;
             }
-            config.nodes.map((node, i) => {
-                if (this.appConfig && this.appConfig.nodes && this.appConfig.nodes.length > i && this.appConfig.nodes[i].authentication) {
-                    if (this.appConfig.nodes[i].authentication.macaroonPath) {
-                        node.authentication.macaroonPath = this.appConfig.nodes[i].authentication.macaroonPath;
+            const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
+            config.nodes.map((node) => {
+                const appConfigNode = appConfigNodes.get(node.index);
+                if (appConfigNode?.authentication) {
+                    if (appConfigNode.authentication.macaroonPath) {
+                        node.authentication.macaroonPath = appConfigNode.authentication.macaroonPath;
                     }
-                    if (this.appConfig.nodes[i].authentication.runePath) {
-                        node.authentication.runePath = this.appConfig.nodes[i].authentication.runePath;
+                    if (appConfigNode.authentication.runePath) {
+                        node.authentication.runePath = appConfigNode.authentication.runePath;
                     }
-                    if (this.appConfig.nodes[i].authentication.lnApiPassword) {
-                        node.authentication.lnApiPassword = this.appConfig.nodes[i].authentication.lnApiPassword;
+                    if (appConfigNode.authentication.lnApiPassword) {
+                        node.authentication.lnApiPassword = appConfigNode.authentication.lnApiPassword;
                     }
                 }
                 return node;

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -70,7 +70,7 @@ export class CommonService {
                 config.secret2FA = this.appConfig.secret2FA;
             }
             const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
-            config.nodes.forEach((node) => {
+            config.nodes?.forEach((node) => {
                 const appConfigNode = appConfigNodes.get(node.index);
                 if (appConfigNode?.authentication) {
                     if (appConfigNode.authentication.macaroonPath) {

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -73,6 +73,7 @@ export class CommonService {
             config.nodes?.forEach((node) => {
                 const appConfigNode = appConfigNodes.get(node.index);
                 if (appConfigNode?.authentication) {
+                    node.authentication = node.authentication || {};
                     if (appConfigNode.authentication.macaroonPath) {
                         node.authentication.macaroonPath = appConfigNode.authentication.macaroonPath;
                     }

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -69,7 +69,7 @@ export class CommonService {
             if (config.secret2FA === this.appConfig.secret2FA) {
                 config.secret2FA = this.appConfig.secret2FA;
             }
-            const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
+            const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
             config.nodes?.forEach((node) => {
                 const appConfigNode = appConfigNodes.get(node.index);
                 if (appConfigNode?.authentication) {

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -55,7 +55,7 @@ export class CommonService {
             delete config.multiPass;
             delete config.multiPassHashed;
             delete config.secret2FA;
-            config.nodes?.map((node) => this.removeAuthSecureData(node));
+            config.nodes?.forEach((node) => this.removeAuthSecureData(node));
             return config;
         };
         this.addSecureData = (config) => {
@@ -70,7 +70,7 @@ export class CommonService {
                 config.secret2FA = this.appConfig.secret2FA;
             }
             const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
-            config.nodes.map((node) => {
+            config.nodes.forEach((node) => {
                 const appConfigNode = appConfigNodes.get(node.index);
                 if (appConfigNode?.authentication) {
                     if (appConfigNode.authentication.macaroonPath) {
@@ -83,7 +83,6 @@ export class CommonService {
                         node.authentication.lnApiPassword = appConfigNode.authentication.lnApiPassword;
                     }
                 }
-                return node;
             });
             return config;
         };

--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -5,6 +5,19 @@ this release should add its entry under the appropriate section below.
 
 ## Bug Fixes
 
+- **Multi-node: preserve per-node auth when saving application settings**
+  ([#1645](https://github.com/Ride-The-Lightning/RTL/pull/1645), supersedes
+  [#1598](https://github.com/Ride-The-Lightning/RTL/pull/1598)).
+  When saving application settings on a multi-node setup, `addSecureData` matched each saved
+  node against the in-memory config by **array position** (`appConfig.nodes[i]`), so once nodes
+  were reordered or one was removed, another node's `macaroonPath`/`runePath` could be grafted
+  onto the wrong node — corrupting its authentication. Matching is now keyed by `node.index`
+  (via a lookup map) in both `addSecureData` and the config-write path, and the persisted
+  `RTL-Config.json` is sanitized of runtime-only fields (the request `options` object and the
+  resolved `runeValue`) so they are never written to disk. Contributed by @CosimoRicciardi in
+  #1598; landed here rebased onto the release branch with a regression test
+  (`test/backend/rtlconf.test.mjs`).
+
 - **All implementations: fix a page-load error when a channel's alias is undefined**
   ([#1581](https://github.com/Ride-The-Lightning/RTL/pull/1581)).
   On the home dashboard, channel labels were rendered as `(channel.alias || channel.peer_id).length`

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -204,7 +204,7 @@ export const updateNodeSettings = (req, res, next) => {
   const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
   const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
   if (node && node.settings) {
-    node.settings = req.body.settings;
+    node.settings = { ...node.settings, ...req.body.settings };
     if (req.body.authentication.boltzMacaroonPath) {
       node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
     } else {
@@ -220,9 +220,17 @@ export const updateNodeSettings = (req, res, next) => {
     fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
     const selectedNode = common.findNode(req.session.selectedNode.index);
     if (selectedNode && selectedNode.settings) {
-      selectedNode.settings = req.body.settings;
-      selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-      selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+      selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
+      if (req.body.authentication.boltzMacaroonPath) {
+        selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+      } else {
+        delete selectedNode.authentication.boltzMacaroonPath;
+      }
+      if (req.body.authentication.swapMacaroonPath) {
+        selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+      } else {
+        delete selectedNode.authentication.swapMacaroonPath;
+      }
       common.replaceNode(req, selectedNode);
     }
     let responseNode = JSON.parse(JSON.stringify(common.selectedNode));
@@ -240,14 +248,57 @@ export const updateApplicationSettings = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Updating Application Settings..' });
   const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
   try {
-    const config = common.addSecureData(req.body);
-    common.appConfig = JSON.parse(JSON.stringify(config));
-    delete config.selectedNodeIndex;
-    delete config.enable2FA;
-    delete config.allowPasswordUpdate;
-    delete config.rtlConfFilePath;
-    delete config.rtlPass;
-    fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
+    const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
+    const config = common.addSecureData(JSON.parse(JSON.stringify(req.body)));
+    const runtimeConfig = JSON.parse(JSON.stringify(oldConfig));
+    Object.keys(config).forEach((key) => {
+      if (key !== 'nodes') {
+        runtimeConfig[key] = config[key];
+      }
+    });
+    if (config.nodes && config.nodes.length > 0) {
+      const oldNodes = (common.appConfig.nodes && common.appConfig.nodes.length > 0) ? common.appConfig.nodes : (oldConfig.nodes || []);
+      const newNodesMap = new Map(config.nodes.map((node) => [node.index, node]));
+      const updatedAndExistingNodes = oldNodes.map((oldNode) => {
+        const newNode = newNodesMap.get(oldNode.index);
+        newNodesMap.delete(oldNode.index);
+        const node = newNode ? {
+          ...oldNode,
+          ...newNode,
+          authentication: { ...(oldNode.authentication || {}), ...(newNode.authentication || {}) },
+          settings: { ...(oldNode.settings || {}), ...(newNode.settings || {}) }
+        } : {
+          ...oldNode,
+          authentication: { ...(oldNode.authentication || {}) },
+          settings: { ...(oldNode.settings || {}) }
+        };
+        return node;
+      });
+      const newOnlyNodes = [...newNodesMap.values()].map((newNode) => JSON.parse(JSON.stringify(newNode)));
+      runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
+    }
+    common.appConfig = JSON.parse(JSON.stringify({
+      ...runtimeConfig,
+      selectedNodeIndex: config.selectedNodeIndex !== undefined ?
+        config.selectedNodeIndex : common.appConfig.selectedNodeIndex,
+      enable2FA: config.enable2FA !== undefined ?
+        config.enable2FA : common.appConfig.enable2FA,
+      allowPasswordUpdate: config.allowPasswordUpdate !== undefined ?
+        config.allowPasswordUpdate : common.appConfig.allowPasswordUpdate,
+      rtlConfFilePath: common.appConfig.rtlConfFilePath,
+      rtlPass: common.appConfig.rtlPass
+    }));
+    const fileConfig = JSON.parse(JSON.stringify(common.appConfig));
+    delete fileConfig.selectedNodeIndex;
+    delete fileConfig.enable2FA;
+    delete fileConfig.allowPasswordUpdate;
+    delete fileConfig.rtlConfFilePath;
+    delete fileConfig.rtlPass;
+    fileConfig.nodes?.forEach((node) => {
+      delete node.authentication?.options;
+      delete node.authentication?.runeValue;
+    });
+    fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
     const newConfig = JSON.parse(JSON.stringify(common.appConfig));
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.maskPasswords(newConfig) });
     res.status(201).json(common.removeSecureData(newConfig));

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -201,24 +201,24 @@ export const getConfig = (req, res, next) => {
 export const updateNodeSettings = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Updating Node Settings..' });
   const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
-  const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
-  const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
-  if (node && node.settings) {
-    node.settings = { ...node.settings, ...req.body.settings };
-    if (node.authentication && req.body.authentication) {
-      if (req.body.authentication.boltzMacaroonPath) {
-        node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-      } else {
-        delete node.authentication.boltzMacaroonPath;
-      }
-      if (req.body.authentication.swapMacaroonPath) {
-        node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-      } else {
-        delete node.authentication.swapMacaroonPath;
+  try {
+    const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
+    const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
+    if (node && node.settings) {
+      node.settings = { ...node.settings, ...req.body.settings };
+      if (node.authentication && req.body.authentication) {
+        if (req.body.authentication.boltzMacaroonPath) {
+          node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+        } else {
+          delete node.authentication.boltzMacaroonPath;
+        }
+        if (req.body.authentication.swapMacaroonPath) {
+          node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+        } else {
+          delete node.authentication.swapMacaroonPath;
+        }
       }
     }
-  }
-  try {
     fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
     const selectedNode = common.findNode(req.session.selectedNode.index);
     if (selectedNode && selectedNode.settings) {

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -254,7 +254,7 @@ export const updateApplicationSettings = (req, res, next) => {
   try {
     const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     const config = common.addSecureData(JSON.parse(JSON.stringify(req.body)));
-    const runtimeConfig = JSON.parse(JSON.stringify(oldConfig));
+    const runtimeConfig = oldConfig;
     Object.keys(config).forEach((key) => {
       if (key !== 'nodes') {
         runtimeConfig[key] = config[key];
@@ -298,6 +298,7 @@ export const updateApplicationSettings = (req, res, next) => {
     delete fileConfig.allowPasswordUpdate;
     delete fileConfig.rtlConfFilePath;
     delete fileConfig.rtlPass;
+    delete fileConfig.multiPass;
     fileConfig.nodes?.forEach((node) => {
       delete node.authentication?.options;
       delete node.authentication?.runeValue;

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -205,15 +205,17 @@ export const updateNodeSettings = (req, res, next) => {
   const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
   if (node && node.settings) {
     node.settings = { ...node.settings, ...req.body.settings };
-    if (req.body.authentication.boltzMacaroonPath) {
-      node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-    } else {
-      delete node.authentication.boltzMacaroonPath;
-    }
-    if (req.body.authentication.swapMacaroonPath) {
-      node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-    } else {
-      delete node.authentication.swapMacaroonPath;
+    if (node.authentication && req.body.authentication) {
+      if (req.body.authentication.boltzMacaroonPath) {
+        node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+      } else {
+        delete node.authentication.boltzMacaroonPath;
+      }
+      if (req.body.authentication.swapMacaroonPath) {
+        node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+      } else {
+        delete node.authentication.swapMacaroonPath;
+      }
     }
   }
   try {
@@ -221,15 +223,17 @@ export const updateNodeSettings = (req, res, next) => {
     const selectedNode = common.findNode(req.session.selectedNode.index);
     if (selectedNode && selectedNode.settings) {
       selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
-      if (req.body.authentication.boltzMacaroonPath) {
-        selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-      } else {
-        delete selectedNode.authentication.boltzMacaroonPath;
-      }
-      if (req.body.authentication.swapMacaroonPath) {
-        selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-      } else {
-        delete selectedNode.authentication.swapMacaroonPath;
+      if (selectedNode.authentication && req.body.authentication) {
+        if (req.body.authentication.boltzMacaroonPath) {
+          selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
+        } else {
+          delete selectedNode.authentication.boltzMacaroonPath;
+        }
+        if (req.body.authentication.swapMacaroonPath) {
+          selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
+        } else {
+          delete selectedNode.authentication.swapMacaroonPath;
+        }
       }
       common.replaceNode(req, selectedNode);
     }

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -78,16 +78,18 @@ export class CommonService {
     if (config.secret2FA === this.appConfig.secret2FA) {
       config.secret2FA = this.appConfig.secret2FA;
     }
-    config.nodes.map((node, i) => {
-      if (this.appConfig && this.appConfig.nodes && this.appConfig.nodes.length > i && this.appConfig.nodes[i].authentication) {
-        if (this.appConfig.nodes[i].authentication.macaroonPath) {
-          node.authentication.macaroonPath = this.appConfig.nodes[i].authentication.macaroonPath;
+    const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
+    config.nodes.map((node) => {
+      const appConfigNode = appConfigNodes.get(node.index);
+      if (appConfigNode?.authentication) {
+        if (appConfigNode.authentication.macaroonPath) {
+          node.authentication.macaroonPath = appConfigNode.authentication.macaroonPath;
         }
-        if (this.appConfig.nodes[i].authentication.runePath) {
-          node.authentication.runePath = this.appConfig.nodes[i].authentication.runePath;
+        if (appConfigNode.authentication.runePath) {
+          node.authentication.runePath = appConfigNode.authentication.runePath;
         }
-        if (this.appConfig.nodes[i].authentication.lnApiPassword) {
-          node.authentication.lnApiPassword = this.appConfig.nodes[i].authentication.lnApiPassword;
+        if (appConfigNode.authentication.lnApiPassword) {
+          node.authentication.lnApiPassword = appConfigNode.authentication.lnApiPassword;
         }
       }
       return node;

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -63,7 +63,7 @@ export class CommonService {
     delete config.multiPass;
     delete config.multiPassHashed;
     delete config.secret2FA;
-    config.nodes?.map((node) => this.removeAuthSecureData(node));
+    config.nodes?.forEach((node) => this.removeAuthSecureData(node));
     return config;
   };
 
@@ -79,7 +79,7 @@ export class CommonService {
       config.secret2FA = this.appConfig.secret2FA;
     }
     const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
-    config.nodes.map((node) => {
+    config.nodes.forEach((node) => {
       const appConfigNode = appConfigNodes.get(node.index);
       if (appConfigNode?.authentication) {
         if (appConfigNode.authentication.macaroonPath) {
@@ -92,7 +92,6 @@ export class CommonService {
           node.authentication.lnApiPassword = appConfigNode.authentication.lnApiPassword;
         }
       }
-      return node;
     });
     return config;
   };

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -82,6 +82,7 @@ export class CommonService {
     config.nodes?.forEach((node) => {
       const appConfigNode = appConfigNodes.get(node.index);
       if (appConfigNode?.authentication) {
+        node.authentication = node.authentication || {};
         if (appConfigNode.authentication.macaroonPath) {
           node.authentication.macaroonPath = appConfigNode.authentication.macaroonPath;
         }

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -78,7 +78,7 @@ export class CommonService {
     if (config.secret2FA === this.appConfig.secret2FA) {
       config.secret2FA = this.appConfig.secret2FA;
     }
-    const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
+    const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
     config.nodes?.forEach((node) => {
       const appConfigNode = appConfigNodes.get(node.index);
       if (appConfigNode?.authentication) {

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -79,7 +79,7 @@ export class CommonService {
       config.secret2FA = this.appConfig.secret2FA;
     }
     const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]));
-    config.nodes.forEach((node) => {
+    config.nodes?.forEach((node) => {
       const appConfigNode = appConfigNodes.get(node.index);
       if (appConfigNode?.authentication) {
         if (appConfigNode.authentication.macaroonPath) {

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { updateApplicationSettings } from '../../backend/controllers/shared/RTLConf.js';
+import { Common } from '../../backend/utils/common.js';
+import { WSServer } from '../../backend/utils/webSocketServer.js';
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+test('updateApplicationSettings preserves indexed node auth and sanitizes only persisted config', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie', logoutRedirectLink: '', cookieValue: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      },
+      {
+        index: 2,
+        lnNode: 'cln-secondary',
+        lnImplementation: 'CLN',
+        authentication: { runePath: '/cln/rune' },
+        settings: { userPersona: 'MERCHANT', themeMode: 'NIGHT', blockExplorerUrl: 'https://old.example' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 2,
+    enable2FA: true,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    multiPassHashed: 'multi-pass-hash',
+    nodes: [
+      {
+        ...oldConfig.nodes[0],
+        authentication: {
+          ...oldConfig.nodes[0].authentication,
+          options: { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } }
+        }
+      },
+      {
+        ...oldConfig.nodes[1],
+        authentication: {
+          ...oldConfig.nodes[1].authentication,
+          runeValue: 'runtime-rune',
+          options: { headers: { rune: 'runtime-rune' } }
+        }
+      }
+    ]
+  });
+  const requestBody = {
+    defaultNodeIndex: 0,
+    selectedNodeIndex: 2,
+    enable2FA: false,
+    allowPasswordUpdate: false,
+    dbDirectoryPath: '/db-updated',
+    secret2FA: '',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' },
+    nodes: [
+      {
+        index: 2,
+        lnNode: 'cln-secondary',
+        lnImplementation: 'CLN',
+        authentication: { swapMacaroonPath: '/loop/cln' },
+        settings: { themeMode: 'DAY' }
+      },
+      {
+        index: 5,
+        lnNode: 'new-lnd',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/new-lnd/admin' },
+        settings: { userPersona: 'OPERATOR' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[1];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    let responseBody;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return {
+            json: (body) => {
+              responseBody = body;
+            }
+          };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0, 2, 5]);
+
+    const runtimeClnNode = Common.appConfig.nodes[1];
+    assert.equal(runtimeClnNode.authentication.runePath, '/cln/rune');
+    assert.equal(runtimeClnNode.authentication.macaroonPath, undefined);
+    assert.equal(runtimeClnNode.authentication.runeValue, 'runtime-rune');
+    assert.deepEqual(runtimeClnNode.authentication.options, { headers: { rune: 'runtime-rune' } });
+    assert.equal(runtimeClnNode.authentication.swapMacaroonPath, '/loop/cln');
+    assert.equal(runtimeClnNode.settings.themeMode, 'DAY');
+    assert.equal(runtimeClnNode.settings.blockExplorerUrl, 'https://old.example');
+
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 2, 5]);
+    assert.equal(fileConfig.rtlPass, undefined);
+    assert.equal(fileConfig.rtlConfFilePath, undefined);
+    assert.equal(fileConfig.selectedNodeIndex, undefined);
+    assert.equal(fileConfig.enable2FA, undefined);
+    assert.equal(fileConfig.allowPasswordUpdate, undefined);
+    assert.equal(fileConfig.nodes[1].authentication.runePath, '/cln/rune');
+    assert.equal(fileConfig.nodes[1].authentication.macaroonPath, undefined);
+    assert.equal(fileConfig.nodes[1].authentication.runeValue, undefined);
+    assert.equal(fileConfig.nodes[1].authentication.options, undefined);
+    assert.equal(responseBody.nodes[1].authentication.runePath, undefined);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
Lands @CosimoRicciardi's multi-node config-overwrite fix (originally #1598) rebased onto the release branch, with a release note and the contributor's regression test. Opened as a fresh PR to avoid force-pushing the contributor's fork branch; their six commits are cherry-picked as-is with authorship preserved.

Closes #1598.

## The bug

On a multi-node setup, saving application settings could corrupt a node's authentication. `CommonService.addSecureData` re-attached each node's secret paths by matching the saved config against the in-memory config **by array position** (`this.appConfig.nodes[i]`). Once nodes were reordered or one was removed, position `i` no longer referred to the same node, so one node's `macaroonPath` / `runePath` could be written onto another.

## The fix (by @CosimoRicciardi)

- Match nodes by `node.index` via a lookup `Map` instead of array position, in both `addSecureData` and the settings-write path (`updateApplicationSettings` / `updateNodeSettings`).
- Merge new settings over existing per-node `settings`/`authentication` rather than wholesale replacing them, guarding missing `authentication` objects.
- Sanitize the persisted `RTL-Config.json` of runtime-only fields before writing — the request `options` object and the resolved `runeValue` — so transient auth material never lands on disk.
- Adds `test/backend/rtlconf.test.mjs` (Node's built-in test runner) asserting indexed auth is preserved and only persisted config is sanitized.

## Provenance & verification

- Six commits cherry-picked from #1598 unchanged (authorship = Cosimo Ricciardi); the only added commit is the release-note entry.
- Rebased onto `Release-0.15.9` with **zero conflicts** despite overlapping the files reworked by the axios (#1638) and csrf (#1643) migrations — the sanitizer's `delete authentication.options` correctly accounts for the axios-era options object.
- `buildbackend` compiles clean, `npm run lint` passes, and the contributor's `rtlconf.test.mjs` passes.

> Note: this is auth-critical config-persistence logic. Recommend a docker-fixture multi-node smoke test (update settings, confirm each node's macaroon/rune survives) before merge, on top of the unit test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
