### PR TITLE
Link the release notes folder from the README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@
 <a href="https://snyk.io/test/github/Ride-The-Lightning/RTL"><img src="https://snyk.io/test/github/Ride-The-Lightning/RTL/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/Ride-The-Lightning/RTL" style="max-width:100%;"></a>
 [![license](https://img.shields.io/github/license/DAVFoundation/captain-n3m0.svg?style=flat-square)](https://github.com/DAVFoundation/captain-n3m0/blob/master/LICENSE)
 
-**Intro** -- [Application Features](./docs/Application_features.md) -- [Road Map](./docs/Roadmap.md) -- [Application Configurations](./docs/Application_configurations.md) -- [Core Lightning](./docs/Core_lightning_setup.md) -- [Eclair](./docs/Eclair_setup.md) -- [Contribution](./docs/Contributing.md)
+**Intro** -- [Application Features](./docs/Application_features.md) -- [Road Map](./docs/Roadmap.md) -- [Application Configurations](./docs/Application_configurations.md) -- [Core Lightning](./docs/Core_lightning_setup.md) -- [Eclair](./docs/Eclair_setup.md) -- [Contribution](./docs/Contributing.md) -- [Release Notes](../release-notes)
 
 * [Introduction](#intro)
 * [Architecture](#arch)

--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -256,6 +256,14 @@ this release should add its entry under the appropriate section below.
 
 ## Developer Tooling
 
+- **Link the release notes from the README for discoverability**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD)).
+  The `release-notes/` folder was not referenced anywhere — no README link, workflow, or
+  script — so it was effectively undiscoverable. The README's intro navigation now links to
+  it (`[Release Notes](../release-notes)`, alongside the existing docs links), so the
+  per-release notes are reachable from the repo homepage. The folder stays at the repo root
+  (release history is content, not `.github/` repo-meta).
+
 - **Documented the Dependabot / dependency-update process in CONTRIBUTING.md**
   ([#1636](https://github.com/Ride-The-Lightning/RTL/pull/1636)).
   Dependabot's security PRs target `master` and are never merged individually — they are

--- a/release-notes/Release-notes-0.15.9.md
+++ b/release-notes/Release-notes-0.15.9.md
@@ -257,7 +257,7 @@ this release should add its entry under the appropriate section below.
 ## Developer Tooling
 
 - **Link the release notes from the README for discoverability**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD)).
+  ([#1646](https://github.com/Ride-The-Lightning/RTL/pull/1646)).
   The `release-notes/` folder was not referenced anywhere — no README link, workflow, or
   script — so it was effectively undiscoverable. The README's intro navigation now links to
   it (`[Release Notes](../release-notes)`, alongside the existing docs links), so the


### PR DESCRIPTION
Makes the `release-notes/` folder discoverable. It was previously referenced nowhere — no README link, workflow, or script — so users and contributors had no path to it from the repo homepage.

## Change

- Adds `[Release Notes](../release-notes)` to the README's intro navigation line, alongside the existing docs links. (The rendered README is `.github/README.md`, so the link is `../release-notes` to reach the repo-root folder; verified it resolves.)
- Links the **folder**, not a version-specific file, so it never goes stale across releases.

## Why not move the folder under `.github/docs`

Considered it (the docs live there), but release notes are release *content/history*, conventionally kept at the repo root or in GitHub Releases — not in `.github/`, which is for repo meta/config (workflows, issue templates). Moving it into `.github/docs` would also bury it deeper, reducing discoverability rather than improving it. Linking from the README fixes the actual gap without relocating anything or touching any references.