### PR TITLE
Reduce exposure of authentication secrets in logs and config responses

### DIFF
--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -89,7 +89,8 @@ export const getFile = (req, res, next) => {
             return res.status(err.statusCode).json({ message: err.error, error: err.error });
         }
         else {
-            logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'File Data Received', data: data });
+            // File contents can carry node credentials; never write them to the log.
+            logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'File Data Received' });
             res.status(200).json(data);
         }
     });
@@ -109,7 +110,6 @@ export const getApplicationSettings = (req, res, next) => {
             delete appConfData.SSO.rtlCookiePath;
             delete appConfData.SSO.cookieValue;
             delete appConfData.SSO.logoutRedirectLink;
-            appConfData.secret2FA = '';
             appConfData.dbDirectoryPath = '';
             appConfData.nodes[selNodeIdx].authentication = new Authentication();
             delete appConfData.nodes[selNodeIdx].settings.bitcoindConfigPath;
@@ -281,7 +281,7 @@ export const updateApplicationSettings = (req, res, next) => {
             const newOnlyNodes = [...newNodesMap.values()].map((newNode) => JSON.parse(JSON.stringify(newNode)));
             runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
         }
-        common.appConfig = JSON.parse(JSON.stringify({
+        const newAppConfig = JSON.parse(JSON.stringify({
             ...runtimeConfig,
             selectedNodeIndex: config.selectedNodeIndex !== undefined ?
                 config.selectedNodeIndex : common.appConfig.selectedNodeIndex,
@@ -292,7 +292,7 @@ export const updateApplicationSettings = (req, res, next) => {
             rtlConfFilePath: common.appConfig.rtlConfFilePath,
             rtlPass: common.appConfig.rtlPass
         }));
-        const fileConfig = JSON.parse(JSON.stringify(common.appConfig));
+        const fileConfig = JSON.parse(JSON.stringify(newAppConfig));
         delete fileConfig.selectedNodeIndex;
         delete fileConfig.enable2FA;
         delete fileConfig.allowPasswordUpdate;
@@ -307,12 +307,14 @@ export const updateApplicationSettings = (req, res, next) => {
             delete node.authentication?.options;
             delete node.authentication?.runeValue;
         });
+        // Persist first and only then adopt the new runtime config, so a failed write
+        // (read-only volume, ENOSPC) cannot leave the process diverged from the file.
         fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
-        const newConfig = JSON.parse(JSON.stringify(common.appConfig));
+        common.appConfig = newAppConfig;
         // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
         // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.
-        logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.removeSecureData(newConfig) });
-        res.status(201).json(common.removeSecureData(newConfig));
+        logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.removeSecureData(newAppConfig) });
+        res.status(201).json(common.removeSecureData(newAppConfig));
     }
     catch (errRes) {
         const errMsg = 'Update Default Node Error';

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import * as fs from 'fs';
-import { sep } from 'path';
+import { resolve, sep } from 'path';
 import ini from 'ini';
 import parseHocon from 'hocon-parser';
 import request from '../../utils/request.js';
@@ -76,7 +76,23 @@ export const getCurrencyRates = (req, res, next) => {
 };
 export const getFile = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting File..' });
-    const file = req.query.path ? req.query.path : (req.session.selectedNode.settings.channelBackupPath + sep + 'channel-' + req.query.channel?.replace(':', '-') + '.bak');
+    const channelBackupPath = req.session.selectedNode.settings.channelBackupPath;
+    let file = '';
+    if (req.query.path) {
+        // The UI only ever requests channel backup files; contain caller paths to the node's
+        // backup directory so this endpoint cannot read the config, macaroons or the SSO
+        // cookie (getConfig serves the config file masked; this must not bypass that).
+        const resolved = resolve(req.query.path);
+        if (resolved !== resolve(channelBackupPath) && !resolved.startsWith(resolve(channelBackupPath) + sep)) {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Blocked file read outside the channel backup directory', data: req.query.path });
+            const err = common.handleError({ statusCode: 403, message: 'Reading File Error', error: 'File path is outside the channel backup directory' }, 'RTLConf', 'Reading File Error', req.session.selectedNode);
+            return res.status(err.statusCode).json({ message: err.message, error: err.error });
+        }
+        file = resolved;
+    }
+    else {
+        file = channelBackupPath + sep + 'channel-' + req.query.channel?.replace(':', '-') + '.bak';
+    }
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'Channel Point', data: req.query.channel });
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'File Path', data: file });
     fs.readFile(file, 'utf8', (errRes, data) => {
@@ -307,9 +323,12 @@ export const updateApplicationSettings = (req, res, next) => {
             delete node.authentication?.options;
             delete node.authentication?.runeValue;
         });
-        // Persist first and only then adopt the new runtime config, so a failed write
-        // (read-only volume, ENOSPC) cannot leave the process diverged from the file.
-        fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+        // Persist atomically (temp file + rename, so a mid-write failure cannot truncate the
+        // config) and only then adopt the new runtime config, so a failed write leaves the
+        // process on the old one.
+        const tempConfigFile = RTLConfFile + '.tmp';
+        fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+        fs.renameSync(tempConfigFile, RTLConfFile);
         common.appConfig = newAppConfig;
         // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
         // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -217,7 +217,12 @@ export const updateNodeSettings = (req, res, next) => {
         const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
         const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
         if (node && node.settings) {
+            // channelBackupPath anchors getFile's containment root and is documented as a
+            // config-file-only setting; accepting it from the API would let the caller being
+            // contained choose the containment base. Pin it to the server-held value.
+            const serverChannelBackupPath = node.settings.channelBackupPath;
             node.settings = { ...node.settings, ...req.body.settings };
+            node.settings.channelBackupPath = serverChannelBackupPath;
             if (node.authentication && req.body.authentication) {
                 if (req.body.authentication.boltzMacaroonPath) {
                     node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
@@ -236,7 +241,9 @@ export const updateNodeSettings = (req, res, next) => {
         fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
         const selectedNode = common.findNode(req.session.selectedNode.index);
         if (selectedNode && selectedNode.settings) {
+            const serverChannelBackupPath = selectedNode.settings.channelBackupPath;
             selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
+            selectedNode.settings.channelBackupPath = serverChannelBackupPath;
             if (selectedNode.authentication && req.body.authentication) {
                 if (req.body.authentication.boltzMacaroonPath) {
                     selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
@@ -325,10 +332,20 @@ export const updateApplicationSettings = (req, res, next) => {
         });
         // Persist atomically (temp file + rename, so a mid-write failure cannot truncate the
         // config) and only then adopt the new runtime config, so a failed write leaves the
-        // process on the old one.
+        // process on the old one. The temp file inherits the existing file's mode so a
+        // hardened 0600 is not silently downgraded; a fresh file gets 0600. Symlinks and
+        // single-file bind mounts cannot be renamed over — fall back to an in-place write,
+        // which preserves inode and mode.
         const tempConfigFile = RTLConfFile + '.tmp';
-        fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
-        fs.renameSync(tempConfigFile, RTLConfFile);
+        try {
+            fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+            fs.chmodSync(tempConfigFile, fs.existsSync(RTLConfFile) ? (fs.statSync(RTLConfFile).mode & 0o777) : 0o600);
+            fs.renameSync(tempConfigFile, RTLConfFile);
+        }
+        catch {
+            fs.rmSync(tempConfigFile, { force: true, recursive: true });
+            fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+        }
         common.appConfig = newAppConfig;
         // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
         // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -299,6 +299,10 @@ export const updateApplicationSettings = (req, res, next) => {
         delete fileConfig.rtlConfFilePath;
         delete fileConfig.rtlPass;
         delete fileConfig.multiPass;
+        // Runtime-only SSO bearer; must not be persisted with the config.
+        if (fileConfig.SSO) {
+            delete fileConfig.SSO.cookieValue;
+        }
         fileConfig.nodes?.forEach((node) => {
             delete node.authentication?.options;
             delete node.authentication?.runeValue;

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -309,7 +309,9 @@ export const updateApplicationSettings = (req, res, next) => {
         });
         fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
         const newConfig = JSON.parse(JSON.stringify(common.appConfig));
-        logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.maskPasswords(newConfig) });
+        // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
+        // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.
+        logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.removeSecureData(newConfig) });
         res.status(201).json(common.removeSecureData(newConfig));
     }
     catch (errRes) {

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -26,9 +26,15 @@ export class CommonService {
             const length = keys.length;
             if (length !== 0) {
                 for (let i = 0; i < length; i++) {
-                    // Truthiness guard: null is 'object' too, and the recursive call mutates in
-                    // place — assigning into keys[] here clobbered the key list for numeric keys.
-                    if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+                    // Header maps always carry credentials in this codebase (macaroon, rune, basic
+                    // auth). Key-substring matching cannot catch them without also hiding the *Path
+                    // fields the settings UI legitimately shows, so mask the whole map.
+                    if (keys[i] === 'headers' && obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+                        Object.keys(obj[keys[i]]).forEach((headerKey) => { obj[keys[i]][headerKey] = '*'.repeat(20); });
+                    }
+                    else if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+                        // Truthiness guard: null is 'object' too, and the recursive call mutates in
+                        // place — assigning into keys[] here clobbered the key list for numeric keys.
                         this.maskPasswords(obj[keys[i]]);
                     }
                     if (typeof keys[i] === 'string' &&
@@ -73,24 +79,25 @@ export class CommonService {
             config.rtlConfFilePath = this.appConfig.rtlConfFilePath;
             config.rtlPass = this.appConfig.rtlPass;
             config.multiPassHashed = this.appConfig.multiPassHashed;
-            // Merge rather than replace: sanitized client responses never carry cookieValue, and
-            // a trimmed or missing SSO object must not silently wipe server-held SSO state. The
-            // cookie is always pinned to the server-held value.
-            config.SSO = {
-                ...(this.appConfig.SSO || {}),
-                ...(config.SSO || {}),
-                rtlCookiePath: this.appConfig.SSO?.rtlCookiePath,
-                cookieValue: this.appConfig.SSO?.cookieValue
-            };
+            // Deployment-level switches are pinned to server-held values: the settings API must
+            // not flip the authentication mode (disableAuth, SSO) or move SSO fields, and no UI
+            // flow writes them. Pinning the whole object also means a trimmed or missing SSO
+            // object can never wipe server state.
+            config.disableAuth = this.appConfig.disableAuth;
+            config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
             }
-            // Restore the TOTP seed only when the client omits it (sanitized responses never
-            // include it, so an echo would otherwise wipe it). An explicit value is the settings
-            // UI's enable/disable flow and is honored.
-            if (config.secret2FA === undefined) {
+            // Restore the TOTP seed when the client omits it — and when it sends an empty seed
+            // while still claiming 2FA is on (the pre-login config response carries that shape).
+            // An explicit non-empty seed is the settings UI's enable flow and is honored; an
+            // empty seed with enable2FA false is its disable flow and is honored too.
+            if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
                 config.secret2FA = this.appConfig.secret2FA;
             }
+            // enable2FA derives from the seed, matching the boot-time derivation in config.ts,
+            // so the two fields can never diverge after a save.
+            config.enable2FA = !!config.secret2FA;
             const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
             config.nodes?.forEach((node) => {
                 const appConfigNode = appConfigNodes.get(node.index);

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -26,14 +26,17 @@ export class CommonService {
             const length = keys.length;
             if (length !== 0) {
                 for (let i = 0; i < length; i++) {
-                    if (typeof obj[keys[i]] === 'object') {
-                        keys[keys[i]] = this.maskPasswords(obj[keys[i]]);
+                    // Truthiness guard: null is 'object' too, and the recursive call mutates in
+                    // place — assigning into keys[] here clobbered the key list for numeric keys.
+                    if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+                        this.maskPasswords(obj[keys[i]]);
                     }
                     if (typeof keys[i] === 'string' &&
                         ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
                             keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
                             keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('secret2fa') ||
-                            keys[i].toLowerCase().includes('cookievalue'))) {
+                            keys[i].toLowerCase().includes('cookievalue') || keys[i].toLowerCase().includes('rtlpass') ||
+                            keys[i].toLowerCase().includes('runevalue'))) {
                         obj[keys[i]] = '*'.repeat(20);
                     }
                 }
@@ -51,30 +54,41 @@ export class CommonService {
             return node;
         };
         this.removeSecureData = (config) => {
-            delete config.rtlConfFilePath;
-            delete config.rtlPass;
-            delete config.multiPass;
-            delete config.multiPassHashed;
-            delete config.secret2FA;
+            // Clone before deleting: cookieValue is runtime-only, so mutating a caller's live
+            // appConfig would destroy SSO state with no way to restore it.
+            const sanitized = JSON.parse(JSON.stringify(config));
+            delete sanitized.rtlConfFilePath;
+            delete sanitized.rtlPass;
+            delete sanitized.multiPass;
+            delete sanitized.multiPassHashed;
+            delete sanitized.secret2FA;
             // The SSO cookie is a live bearer credential; it must never leave the server.
-            if (config.SSO) {
-                delete config.SSO.cookieValue;
+            if (sanitized.SSO) {
+                delete sanitized.SSO.cookieValue;
             }
-            config.nodes?.forEach((node) => this.removeAuthSecureData(node));
-            return config;
+            sanitized.nodes?.forEach((node) => this.removeAuthSecureData(node));
+            return sanitized;
         };
         this.addSecureData = (config) => {
             config.rtlConfFilePath = this.appConfig.rtlConfFilePath;
             config.rtlPass = this.appConfig.rtlPass;
             config.multiPassHashed = this.appConfig.multiPassHashed;
-            config.SSO.rtlCookiePath = this.appConfig.SSO.rtlCookiePath;
-            // cookieValue is stripped from client responses, so a settings save can never echo it;
-            // restore the server-held value or the save would silently wipe the live SSO cookie.
-            config.SSO.cookieValue = this.appConfig.SSO.cookieValue;
+            // Merge rather than replace: sanitized client responses never carry cookieValue, and
+            // a trimmed or missing SSO object must not silently wipe server-held SSO state. The
+            // cookie is always pinned to the server-held value.
+            config.SSO = {
+                ...(this.appConfig.SSO || {}),
+                ...(config.SSO || {}),
+                rtlCookiePath: this.appConfig.SSO?.rtlCookiePath,
+                cookieValue: this.appConfig.SSO?.cookieValue
+            };
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
             }
-            if (config.secret2FA === this.appConfig.secret2FA) {
+            // Restore the TOTP seed only when the client omits it (sanitized responses never
+            // include it, so an echo would otherwise wipe it). An explicit value is the settings
+            // UI's enable/disable flow and is honored.
+            if (config.secret2FA === undefined) {
                 config.secret2FA = this.appConfig.secret2FA;
             }
             const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
@@ -353,10 +367,11 @@ export class CommonService {
             this.logger.log({ selectedNode: selectedNode, level: 'ERROR', fileName: fileName, msg: errMsg, error: (typeof err === 'object' ? JSON.stringify(err) : err) });
             let newErrorObj = { statusCode: 500, message: '', error: '' };
             if (err.code && err.code === 'ENOENT') {
+                // The absolute path stays in the server log above but is not echoed to clients.
                 newErrorObj = {
                     statusCode: 500,
-                    message: 'No such file or directory ' + (err.path ? err.path : ''),
-                    error: 'No such file or directory ' + (err.path ? err.path : '')
+                    message: 'No such file or directory',
+                    error: 'No such file or directory'
                 };
             }
             else {

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -32,7 +32,8 @@ export class CommonService {
                     if (typeof keys[i] === 'string' &&
                         ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
                             keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
-                            keys[i].toLowerCase().includes('rpcuser'))) {
+                            keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('secret2fa') ||
+                            keys[i].toLowerCase().includes('cookievalue'))) {
                         obj[keys[i]] = '*'.repeat(20);
                     }
                 }
@@ -55,6 +56,10 @@ export class CommonService {
             delete config.multiPass;
             delete config.multiPassHashed;
             delete config.secret2FA;
+            // The SSO cookie is a live bearer credential; it must never leave the server.
+            if (config.SSO) {
+                delete config.SSO.cookieValue;
+            }
             config.nodes?.forEach((node) => this.removeAuthSecureData(node));
             return config;
         };
@@ -63,6 +68,9 @@ export class CommonService {
             config.rtlPass = this.appConfig.rtlPass;
             config.multiPassHashed = this.appConfig.multiPassHashed;
             config.SSO.rtlCookiePath = this.appConfig.SSO.rtlCookiePath;
+            // cookieValue is stripped from client responses, so a settings save can never echo it;
+            // restore the server-held value or the save would silently wipe the live SSO cookie.
+            config.SSO.cookieValue = this.appConfig.SSO.cookieValue;
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
             }
@@ -103,7 +111,7 @@ export class CommonService {
                     this.logger.log({ selectedNode: this.selectedNode, level: 'ERROR', fileName: 'Common', msg: 'Loop macaroon Error', error: err });
                 }
             }
-            this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Swap Options', data: swapOptions });
+            this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Swap Options Set' });
             return swapOptions;
         };
         this.getBoltzServerOptions = (req) => {
@@ -121,7 +129,7 @@ export class CommonService {
                     this.logger.log({ selectedNode: this.selectedNode, level: 'ERROR', fileName: 'Common', msg: 'Boltz macaroon Error', error: err });
                 }
             }
-            this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Boltz Options', data: boltzOptions });
+            this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Boltz Options Set' });
             return boltzOptions;
         };
         this.getOptions = (req) => {
@@ -167,7 +175,7 @@ export class CommonService {
                     }
                 }
                 if (req.session.selectedNode) {
-                    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Updated Node Options for ' + req.session.selectedNode.lnNode, data: req.session.selectedNode.authentication.options });
+                    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Updated Node Options for ' + req.session.selectedNode.lnNode });
                 }
                 return { status: 200, message: 'Updated Successfully' };
             }
@@ -237,7 +245,7 @@ export class CommonService {
                             form: ''
                         };
                     }
-                    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Set Node Options for ' + node.lnNode, data: node.authentication.options });
+                    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Set Node Options for ' + node.lnNode });
                 });
                 this.updateSelectedNodeOptions(req);
             }

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -22,32 +22,37 @@ export class CommonService {
             { name: 'JUL', days: 31 }, { name: 'AUG', days: 31 }, { name: 'SEP', days: 30 }, { name: 'OCT', days: 31 }, { name: 'NOV', days: 30 }, { name: 'DEC', days: 31 }
         ];
         this.maskPasswords = (obj) => {
-            const keys = Object.keys(obj);
-            const length = keys.length;
-            if (length !== 0) {
-                for (let i = 0; i < length; i++) {
-                    // Header maps always carry credentials in this codebase (macaroon, rune, basic
-                    // auth). Key-substring matching cannot catch them without also hiding the *Path
-                    // fields the settings UI legitimately shows, so mask the whole map.
-                    if (keys[i] === 'headers' && obj[keys[i]] && typeof obj[keys[i]] === 'object') {
-                        Object.keys(obj[keys[i]]).forEach((headerKey) => { obj[keys[i]][headerKey] = '*'.repeat(20); });
-                    }
-                    else if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
-                        // Truthiness guard: null is 'object' too, and the recursive call mutates in
-                        // place — assigning into keys[] here clobbered the key list for numeric keys.
-                        this.maskPasswords(obj[keys[i]]);
-                    }
-                    if (typeof keys[i] === 'string' &&
-                        ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
-                            keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
-                            keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('secret2fa') ||
-                            keys[i].toLowerCase().includes('cookievalue') || keys[i].toLowerCase().includes('rtlpass') ||
-                            keys[i].toLowerCase().includes('runevalue'))) {
-                        obj[keys[i]] = '*'.repeat(20);
+            // Clone up front: masking a live config object must not blank the credentials LN
+            // requests authenticate with (mirrors removeSecureData).
+            const masked = JSON.parse(JSON.stringify(obj));
+            const maskRecursive = (current) => {
+                const keys = Object.keys(current);
+                const length = keys.length;
+                if (length !== 0) {
+                    for (let i = 0; i < length; i++) {
+                        // Header maps always carry credentials in this codebase (macaroon, rune, basic
+                        // auth). Key-substring matching cannot catch them without also hiding the *Path
+                        // fields the settings UI legitimately shows, so mask the whole map.
+                        if (keys[i] === 'headers' && current[keys[i]] && typeof current[keys[i]] === 'object') {
+                            Object.keys(current[keys[i]]).forEach((headerKey) => { current[keys[i]][headerKey] = '*'.repeat(20); });
+                        }
+                        else if (current[keys[i]] && typeof current[keys[i]] === 'object') {
+                            // Truthiness guard: null is 'object' too and must not reach Object.keys.
+                            maskRecursive(current[keys[i]]);
+                        }
+                        if (typeof keys[i] === 'string' &&
+                            ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
+                                keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
+                                keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('rpcauth') ||
+                                keys[i].toLowerCase().includes('secret2fa') || keys[i].toLowerCase().includes('cookievalue') ||
+                                keys[i].toLowerCase().includes('rtlpass') || keys[i].toLowerCase().includes('runevalue'))) {
+                            current[keys[i]] = '*'.repeat(20);
+                        }
                     }
                 }
-            }
-            return obj;
+                return current;
+            };
+            return maskRecursive(masked);
         };
         this.removeAuthSecureData = (node) => {
             if (node.authentication) {
@@ -78,20 +83,31 @@ export class CommonService {
         this.addSecureData = (config) => {
             config.rtlConfFilePath = this.appConfig.rtlConfFilePath;
             config.rtlPass = this.appConfig.rtlPass;
-            config.multiPassHashed = this.appConfig.multiPassHashed;
+            // Pin the hash only when the server holds one: on a default install's first boot the
+            // file already has multiPassHashed but the in-memory config does not, and pinning
+            // undefined would erase the only password from the file on save, bricking the boot.
+            if (this.appConfig.multiPassHashed) {
+                config.multiPassHashed = this.appConfig.multiPassHashed;
+            }
+            else {
+                delete config.multiPassHashed;
+            }
             // Deployment-level switches are pinned to server-held values: the settings API must
-            // not flip the authentication mode (disableAuth, SSO) or move SSO fields, and no UI
-            // flow writes them. Pinning the whole object also means a trimmed or missing SSO
-            // object can never wipe server state.
+            // not flip the authentication mode (disableAuth, SSO) or move SSO fields, the
+            // password policy, or the database location; no UI flow writes them. Pinning the
+            // whole SSO object also means a trimmed or missing SSO object can never wipe server
+            // state.
             config.disableAuth = this.appConfig.disableAuth;
+            config.allowPasswordUpdate = this.appConfig.allowPasswordUpdate;
+            config.dbDirectoryPath = this.appConfig.dbDirectoryPath;
             config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
             }
             // Restore the TOTP seed when the client omits it — and when it sends an empty seed
-            // while still claiming 2FA is on (the pre-login config response carries that shape).
-            // An explicit non-empty seed is the settings UI's enable flow and is honored; an
-            // empty seed with enable2FA false is its disable flow and is honored too.
+            // while still claiming 2FA is on (an inconsistent pair no honest flow produces).
+            // The settings UI's enable flow sends a non-empty seed; its disable flow sends an
+            // empty seed with enable2FA false. Both are honored.
             if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
                 config.secret2FA = this.appConfig.secret2FA;
             }

--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -302,7 +302,9 @@ export class ConfigService {
                         this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'Config', msg: 'Something went wrong while creating the backup directory: \n' + err });
                     }
                     this.common.nodes[idx].settings.logFile = config.rtlConfFilePath + '/logs/RTL-Node-' + node.index + '.log';
-                    this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.nodes[idx]) });
+                    // maskPasswords keeps paths visible for debugging while redacting lnApiPassword
+                    // and any other credential fields before they reach the log file.
+                    this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(JSON.parse(JSON.stringify(this.common.nodes[idx])))) });
                     const log_file = this.common.nodes[idx].settings.logFile;
                     if (fs.existsSync(log_file || '')) {
                         fs.writeFile((log_file || ''), '', () => { });

--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -304,7 +304,7 @@ export class ConfigService {
                     this.common.nodes[idx].settings.logFile = config.rtlConfFilePath + '/logs/RTL-Node-' + node.index + '.log';
                     // maskPasswords keeps paths visible for debugging while redacting credential
                     // fields such as lnApiPassword before they reach the log file.
-                    this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(JSON.parse(JSON.stringify(this.common.nodes[idx])))) });
+                    this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(this.common.nodes[idx])) });
                     const log_file = this.common.nodes[idx].settings.logFile;
                     if (fs.existsSync(log_file || '')) {
                         fs.writeFile((log_file || ''), '', () => { });

--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -302,8 +302,8 @@ export class ConfigService {
                         this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'Config', msg: 'Something went wrong while creating the backup directory: \n' + err });
                     }
                     this.common.nodes[idx].settings.logFile = config.rtlConfFilePath + '/logs/RTL-Node-' + node.index + '.log';
-                    // maskPasswords keeps paths visible for debugging while redacting lnApiPassword
-                    // and any other credential fields before they reach the log file.
+                    // maskPasswords keeps paths visible for debugging while redacting credential
+                    // fields such as lnApiPassword before they reach the log file.
                     this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(JSON.parse(JSON.stringify(this.common.nodes[idx])))) });
                     const log_file = this.common.nodes[idx].settings.logFile;
                     if (fs.existsSync(log_file || '')) {

--- a/release-notes/Release-notes-0.15.10.md
+++ b/release-notes/Release-notes-0.15.10.md
@@ -12,7 +12,7 @@ this release should add its entry under the appropriate section below.
   are encouraged to update promptly.
 
 - **Config & logging: reduce exposure of authentication secrets**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD)).
+  ([#1659](https://github.com/Ride-The-Lightning/RTL/pull/1659)).
   Tightens redaction of authentication material in node logs and configuration API
   responses, and keeps runtime-only SSO state out of the persisted config file. Adds
   regression coverage (`test/backend/common.test.mjs`). Users are encouraged to update

--- a/release-notes/Release-notes-0.15.10.md
+++ b/release-notes/Release-notes-0.15.10.md
@@ -14,9 +14,10 @@ this release should add its entry under the appropriate section below.
 - **Config & logging: reduce exposure of authentication secrets**
   ([#1659](https://github.com/Ride-The-Lightning/RTL/pull/1659)).
   Tightens redaction of authentication material in node logs and configuration API
-  responses, and keeps runtime-only SSO state out of the persisted config file. Adds
-  regression coverage (`test/backend/common.test.mjs`). Users are encouraged to update
-  promptly.
+  responses, pins deployment-level authentication settings server-side, contains backup
+  file downloads to the node's backup directory, and hardens the settings persistence
+  path. Adds regression coverage (`test/backend/common.test.mjs`). Users are encouraged
+  to update promptly.
 
 ## Code Health
 

--- a/release-notes/Release-notes-0.15.10.md
+++ b/release-notes/Release-notes-0.15.10.md
@@ -11,6 +11,13 @@ this release should add its entry under the appropriate section below.
   (`test/backend/authenticate.test.mjs`). Users who have two-factor authentication enabled
   are encouraged to update promptly.
 
+- **Config & logging: reduce exposure of authentication secrets**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD)).
+  Tightens redaction of authentication material in node logs and configuration API
+  responses, and keeps runtime-only SSO state out of the persisted config file. Adds
+  regression coverage (`test/backend/common.test.mjs`). Users are encouraged to update
+  promptly.
+
 ## Code Health
 
 - **Batch dependency update resolving the open Dependabot security PRs**

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -220,7 +220,12 @@ export const updateNodeSettings = (req, res, next) => {
     const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
     if (node && node.settings) {
+      // channelBackupPath anchors getFile's containment root and is documented as a
+      // config-file-only setting; accepting it from the API would let the caller being
+      // contained choose the containment base. Pin it to the server-held value.
+      const serverChannelBackupPath = node.settings.channelBackupPath;
       node.settings = { ...node.settings, ...req.body.settings };
+      node.settings.channelBackupPath = serverChannelBackupPath;
       if (node.authentication && req.body.authentication) {
         if (req.body.authentication.boltzMacaroonPath) {
           node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
@@ -237,7 +242,9 @@ export const updateNodeSettings = (req, res, next) => {
     fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
     const selectedNode = common.findNode(req.session.selectedNode.index);
     if (selectedNode && selectedNode.settings) {
+      const serverChannelBackupPath = selectedNode.settings.channelBackupPath;
       selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
+      selectedNode.settings.channelBackupPath = serverChannelBackupPath;
       if (selectedNode.authentication && req.body.authentication) {
         if (req.body.authentication.boltzMacaroonPath) {
           selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
@@ -322,10 +329,19 @@ export const updateApplicationSettings = (req, res, next) => {
     });
     // Persist atomically (temp file + rename, so a mid-write failure cannot truncate the
     // config) and only then adopt the new runtime config, so a failed write leaves the
-    // process on the old one.
+    // process on the old one. The temp file inherits the existing file's mode so a
+    // hardened 0600 is not silently downgraded; a fresh file gets 0600. Symlinks and
+    // single-file bind mounts cannot be renamed over — fall back to an in-place write,
+    // which preserves inode and mode.
     const tempConfigFile = RTLConfFile + '.tmp';
-    fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
-    fs.renameSync(tempConfigFile, RTLConfFile);
+    try {
+      fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+      fs.chmodSync(tempConfigFile, fs.existsSync(RTLConfFile) ? (fs.statSync(RTLConfFile).mode & 0o777) : 0o600);
+      fs.renameSync(tempConfigFile, RTLConfFile);
+    } catch {
+      fs.rmSync(tempConfigFile, { force: true, recursive: true });
+      fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+    }
     common.appConfig = newAppConfig;
     // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
     // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -299,6 +299,8 @@ export const updateApplicationSettings = (req, res, next) => {
     delete fileConfig.rtlConfFilePath;
     delete fileConfig.rtlPass;
     delete fileConfig.multiPass;
+    // Runtime-only SSO bearer; must not be persisted with the config.
+    if (fileConfig.SSO) { delete fileConfig.SSO.cookieValue; }
     fileConfig.nodes?.forEach((node) => {
       delete node.authentication?.options;
       delete node.authentication?.runeValue;

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -307,7 +307,9 @@ export const updateApplicationSettings = (req, res, next) => {
     });
     fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
     const newConfig = JSON.parse(JSON.stringify(common.appConfig));
-    logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.maskPasswords(newConfig) });
+    // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
+    // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.
+    logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.removeSecureData(newConfig) });
     res.status(201).json(common.removeSecureData(newConfig));
   } catch (errRes) {
     const errMsg = 'Update Default Node Error';

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -91,7 +91,8 @@ export const getFile = (req, res, next) => {
       const err = common.handleError({ statusCode: 500, message: errMsg, error: errRes }, 'RTLConf', errMsg, req.session.selectedNode);
       return res.status(err.statusCode).json({ message: err.error, error: err.error });
     } else {
-      logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'File Data Received', data: data });
+      // File contents can carry node credentials; never write them to the log.
+      logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'File Data Received' });
       res.status(200).json(data);
     }
   });
@@ -112,7 +113,6 @@ export const getApplicationSettings = (req, res, next) => {
       delete appConfData.SSO.rtlCookiePath;
       delete appConfData.SSO.cookieValue;
       delete appConfData.SSO.logoutRedirectLink;
-      appConfData.secret2FA = '';
       appConfData.dbDirectoryPath = '';
       appConfData.nodes[selNodeIdx].authentication = new Authentication();
       delete appConfData.nodes[selNodeIdx].settings.bitcoindConfigPath;
@@ -281,7 +281,7 @@ export const updateApplicationSettings = (req, res, next) => {
       const newOnlyNodes = [...newNodesMap.values()].map((newNode) => JSON.parse(JSON.stringify(newNode)));
       runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
     }
-    common.appConfig = JSON.parse(JSON.stringify({
+    const newAppConfig = JSON.parse(JSON.stringify({
       ...runtimeConfig,
       selectedNodeIndex: config.selectedNodeIndex !== undefined ?
         config.selectedNodeIndex : common.appConfig.selectedNodeIndex,
@@ -292,7 +292,7 @@ export const updateApplicationSettings = (req, res, next) => {
       rtlConfFilePath: common.appConfig.rtlConfFilePath,
       rtlPass: common.appConfig.rtlPass
     }));
-    const fileConfig = JSON.parse(JSON.stringify(common.appConfig));
+    const fileConfig = JSON.parse(JSON.stringify(newAppConfig));
     delete fileConfig.selectedNodeIndex;
     delete fileConfig.enable2FA;
     delete fileConfig.allowPasswordUpdate;
@@ -305,12 +305,14 @@ export const updateApplicationSettings = (req, res, next) => {
       delete node.authentication?.options;
       delete node.authentication?.runeValue;
     });
+    // Persist first and only then adopt the new runtime config, so a failed write
+    // (read-only volume, ENOSPC) cannot leave the process diverged from the file.
     fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
-    const newConfig = JSON.parse(JSON.stringify(common.appConfig));
+    common.appConfig = newAppConfig;
     // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
     // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.
-    logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.removeSecureData(newConfig) });
-    res.status(201).json(common.removeSecureData(newConfig));
+    logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Application Settings Updated', data: common.removeSecureData(newAppConfig) });
+    res.status(201).json(common.removeSecureData(newAppConfig));
   } catch (errRes) {
     const errMsg = 'Update Default Node Error';
     const err = common.handleError({ statusCode: 500, message: errMsg, error: errRes }, 'RTLConf', errMsg, req.session.selectedNode);

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import * as fs from 'fs';
-import { sep } from 'path';
+import { resolve, sep } from 'path';
 import ini from 'ini';
 import parseHocon from 'hocon-parser';
 import request from '../../utils/request.js';
@@ -81,7 +81,22 @@ export const getCurrencyRates = (req, res, next) => {
 
 export const getFile = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting File..' });
-  const file = req.query.path ? req.query.path : (req.session.selectedNode.settings.channelBackupPath + sep + 'channel-' + req.query.channel?.replace(':', '-') + '.bak');
+  const channelBackupPath = req.session.selectedNode.settings.channelBackupPath;
+  let file = '';
+  if (req.query.path) {
+    // The UI only ever requests channel backup files; contain caller paths to the node's
+    // backup directory so this endpoint cannot read the config, macaroons or the SSO
+    // cookie (getConfig serves the config file masked; this must not bypass that).
+    const resolved = resolve(req.query.path);
+    if (resolved !== resolve(channelBackupPath) && !resolved.startsWith(resolve(channelBackupPath) + sep)) {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Blocked file read outside the channel backup directory', data: req.query.path });
+      const err = common.handleError({ statusCode: 403, message: 'Reading File Error', error: 'File path is outside the channel backup directory' }, 'RTLConf', 'Reading File Error', req.session.selectedNode);
+      return res.status(err.statusCode).json({ message: err.message, error: err.error });
+    }
+    file = resolved;
+  } else {
+    file = channelBackupPath + sep + 'channel-' + req.query.channel?.replace(':', '-') + '.bak';
+  }
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'Channel Point', data: req.query.channel });
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'File Path', data: file });
   fs.readFile(file, 'utf8', (errRes, data) => {
@@ -305,9 +320,12 @@ export const updateApplicationSettings = (req, res, next) => {
       delete node.authentication?.options;
       delete node.authentication?.runeValue;
     });
-    // Persist first and only then adopt the new runtime config, so a failed write
-    // (read-only volume, ENOSPC) cannot leave the process diverged from the file.
-    fs.writeFileSync(RTLConfFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+    // Persist atomically (temp file + rename, so a mid-write failure cannot truncate the
+    // config) and only then adopt the new runtime config, so a failed write leaves the
+    // process on the old one.
+    const tempConfigFile = RTLConfFile + '.tmp';
+    fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+    fs.renameSync(tempConfigFile, RTLConfFile);
     common.appConfig = newAppConfig;
     // removeSecureData clones, so the runtime config is untouched; it strips rtlPass,
     // the TOTP seed, the SSO cookie and all per-node credentials symmetrically.

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -31,9 +31,14 @@ export class CommonService {
     const length = keys.length;
     if (length !== 0) {
       for (let i = 0; i < length; i++) {
-        // Truthiness guard: null is 'object' too, and the recursive call mutates in
-        // place — assigning into keys[] here clobbered the key list for numeric keys.
-        if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+        // Header maps always carry credentials in this codebase (macaroon, rune, basic
+        // auth). Key-substring matching cannot catch them without also hiding the *Path
+        // fields the settings UI legitimately shows, so mask the whole map.
+        if (keys[i] === 'headers' && obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+          Object.keys(obj[keys[i]]).forEach((headerKey) => { obj[keys[i]][headerKey] = '*'.repeat(20); });
+        } else if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+          // Truthiness guard: null is 'object' too, and the recursive call mutates in
+          // place — assigning into keys[] here clobbered the key list for numeric keys.
           this.maskPasswords(obj[keys[i]]);
         }
         if (typeof keys[i] === 'string' &&
@@ -80,24 +85,25 @@ export class CommonService {
     config.rtlConfFilePath = this.appConfig.rtlConfFilePath;
     config.rtlPass = this.appConfig.rtlPass;
     config.multiPassHashed = this.appConfig.multiPassHashed;
-    // Merge rather than replace: sanitized client responses never carry cookieValue, and
-    // a trimmed or missing SSO object must not silently wipe server-held SSO state. The
-    // cookie is always pinned to the server-held value.
-    config.SSO = {
-      ...(this.appConfig.SSO || {}),
-      ...(config.SSO || {}),
-      rtlCookiePath: this.appConfig.SSO?.rtlCookiePath,
-      cookieValue: this.appConfig.SSO?.cookieValue
-    };
+    // Deployment-level switches are pinned to server-held values: the settings API must
+    // not flip the authentication mode (disableAuth, SSO) or move SSO fields, and no UI
+    // flow writes them. Pinning the whole object also means a trimmed or missing SSO
+    // object can never wipe server state.
+    config.disableAuth = this.appConfig.disableAuth;
+    config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
     }
-    // Restore the TOTP seed only when the client omits it (sanitized responses never
-    // include it, so an echo would otherwise wipe it). An explicit value is the settings
-    // UI's enable/disable flow and is honored.
-    if (config.secret2FA === undefined) {
+    // Restore the TOTP seed when the client omits it — and when it sends an empty seed
+    // while still claiming 2FA is on (the pre-login config response carries that shape).
+    // An explicit non-empty seed is the settings UI's enable flow and is honored; an
+    // empty seed with enable2FA false is its disable flow and is honored too.
+    if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
       config.secret2FA = this.appConfig.secret2FA;
     }
+    // enable2FA derives from the seed, matching the boot-time derivation in config.ts,
+    // so the two fields can never diverge after a save.
+    config.enable2FA = !!config.secret2FA;
     const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
     config.nodes?.forEach((node) => {
       const appConfigNode = appConfigNodes.get(node.index);

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -31,14 +31,17 @@ export class CommonService {
     const length = keys.length;
     if (length !== 0) {
       for (let i = 0; i < length; i++) {
-        if (typeof obj[keys[i]] === 'object') {
-          keys[keys[i]] = this.maskPasswords(obj[keys[i]]);
+        // Truthiness guard: null is 'object' too, and the recursive call mutates in
+        // place — assigning into keys[] here clobbered the key list for numeric keys.
+        if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
+          this.maskPasswords(obj[keys[i]]);
         }
         if (typeof keys[i] === 'string' &&
           ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
             keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
             keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('secret2fa') ||
-            keys[i].toLowerCase().includes('cookievalue'))
+            keys[i].toLowerCase().includes('cookievalue') || keys[i].toLowerCase().includes('rtlpass') ||
+            keys[i].toLowerCase().includes('runevalue'))
         ) {
           obj[keys[i]] = '*'.repeat(20);
         }
@@ -59,29 +62,40 @@ export class CommonService {
   };
 
   public removeSecureData = (config: ApplicationConfig) => {
-    delete config.rtlConfFilePath;
-    delete config.rtlPass;
-    delete config.multiPass;
-    delete config.multiPassHashed;
-    delete config.secret2FA;
+    // Clone before deleting: cookieValue is runtime-only, so mutating a caller's live
+    // appConfig would destroy SSO state with no way to restore it.
+    const sanitized = JSON.parse(JSON.stringify(config));
+    delete sanitized.rtlConfFilePath;
+    delete sanitized.rtlPass;
+    delete sanitized.multiPass;
+    delete sanitized.multiPassHashed;
+    delete sanitized.secret2FA;
     // The SSO cookie is a live bearer credential; it must never leave the server.
-    if (config.SSO) { delete config.SSO.cookieValue; }
-    config.nodes?.forEach((node) => this.removeAuthSecureData(node));
-    return config;
+    if (sanitized.SSO) { delete sanitized.SSO.cookieValue; }
+    sanitized.nodes?.forEach((node) => this.removeAuthSecureData(node));
+    return sanitized;
   };
 
   public addSecureData = (config: ApplicationConfig) => {
     config.rtlConfFilePath = this.appConfig.rtlConfFilePath;
     config.rtlPass = this.appConfig.rtlPass;
     config.multiPassHashed = this.appConfig.multiPassHashed;
-    config.SSO.rtlCookiePath = this.appConfig.SSO.rtlCookiePath;
-    // cookieValue is stripped from client responses, so a settings save can never echo it;
-    // restore the server-held value or the save would silently wipe the live SSO cookie.
-    config.SSO.cookieValue = this.appConfig.SSO.cookieValue;
+    // Merge rather than replace: sanitized client responses never carry cookieValue, and
+    // a trimmed or missing SSO object must not silently wipe server-held SSO state. The
+    // cookie is always pinned to the server-held value.
+    config.SSO = {
+      ...(this.appConfig.SSO || {}),
+      ...(config.SSO || {}),
+      rtlCookiePath: this.appConfig.SSO?.rtlCookiePath,
+      cookieValue: this.appConfig.SSO?.cookieValue
+    };
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
     }
-    if (config.secret2FA === this.appConfig.secret2FA) {
+    // Restore the TOTP seed only when the client omits it (sanitized responses never
+    // include it, so an echo would otherwise wipe it). An explicit value is the settings
+    // UI's enable/disable flow and is honored.
+    if (config.secret2FA === undefined) {
       config.secret2FA = this.appConfig.secret2FA;
     }
     const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
@@ -370,10 +384,11 @@ export class CommonService {
     this.logger.log({ selectedNode: selectedNode, level: 'ERROR', fileName: fileName, msg: errMsg, error: (typeof err === 'object' ? JSON.stringify(err) : err) });
     let newErrorObj = { statusCode: 500, message: '', error: '' };
     if (err.code && err.code === 'ENOENT') {
+      // The absolute path stays in the server log above but is not echoed to clients.
       newErrorObj = {
         statusCode: 500,
-        message: 'No such file or directory ' + (err.path ? err.path : ''),
-        error: 'No such file or directory ' + (err.path ? err.path : '')
+        message: 'No such file or directory',
+        error: 'No such file or directory'
       };
     } else {
       newErrorObj = {

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -27,32 +27,37 @@ export class CommonService {
   constructor() {}
 
   public maskPasswords = (obj) => {
-    const keys = Object.keys(obj);
-    const length = keys.length;
-    if (length !== 0) {
-      for (let i = 0; i < length; i++) {
-        // Header maps always carry credentials in this codebase (macaroon, rune, basic
-        // auth). Key-substring matching cannot catch them without also hiding the *Path
-        // fields the settings UI legitimately shows, so mask the whole map.
-        if (keys[i] === 'headers' && obj[keys[i]] && typeof obj[keys[i]] === 'object') {
-          Object.keys(obj[keys[i]]).forEach((headerKey) => { obj[keys[i]][headerKey] = '*'.repeat(20); });
-        } else if (obj[keys[i]] && typeof obj[keys[i]] === 'object') {
-          // Truthiness guard: null is 'object' too, and the recursive call mutates in
-          // place — assigning into keys[] here clobbered the key list for numeric keys.
-          this.maskPasswords(obj[keys[i]]);
-        }
-        if (typeof keys[i] === 'string' &&
-          ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
-            keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
-            keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('secret2fa') ||
-            keys[i].toLowerCase().includes('cookievalue') || keys[i].toLowerCase().includes('rtlpass') ||
-            keys[i].toLowerCase().includes('runevalue'))
-        ) {
-          obj[keys[i]] = '*'.repeat(20);
+    // Clone up front: masking a live config object must not blank the credentials LN
+    // requests authenticate with (mirrors removeSecureData).
+    const masked = JSON.parse(JSON.stringify(obj));
+    const maskRecursive = (current) => {
+      const keys = Object.keys(current);
+      const length = keys.length;
+      if (length !== 0) {
+        for (let i = 0; i < length; i++) {
+          // Header maps always carry credentials in this codebase (macaroon, rune, basic
+          // auth). Key-substring matching cannot catch them without also hiding the *Path
+          // fields the settings UI legitimately shows, so mask the whole map.
+          if (keys[i] === 'headers' && current[keys[i]] && typeof current[keys[i]] === 'object') {
+            Object.keys(current[keys[i]]).forEach((headerKey) => { current[keys[i]][headerKey] = '*'.repeat(20); });
+          } else if (current[keys[i]] && typeof current[keys[i]] === 'object') {
+            // Truthiness guard: null is 'object' too and must not reach Object.keys.
+            maskRecursive(current[keys[i]]);
+          }
+          if (typeof keys[i] === 'string' &&
+            ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
+              keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
+              keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('rpcauth') ||
+              keys[i].toLowerCase().includes('secret2fa') || keys[i].toLowerCase().includes('cookievalue') ||
+              keys[i].toLowerCase().includes('rtlpass') || keys[i].toLowerCase().includes('runevalue'))
+          ) {
+            current[keys[i]] = '*'.repeat(20);
+          }
         }
       }
-    }
-    return obj;
+      return current;
+    };
+    return maskRecursive(masked);
   };
 
   public removeAuthSecureData = (node: SelectedNode) => {
@@ -84,20 +89,30 @@ export class CommonService {
   public addSecureData = (config: ApplicationConfig) => {
     config.rtlConfFilePath = this.appConfig.rtlConfFilePath;
     config.rtlPass = this.appConfig.rtlPass;
-    config.multiPassHashed = this.appConfig.multiPassHashed;
+    // Pin the hash only when the server holds one: on a default install's first boot the
+    // file already has multiPassHashed but the in-memory config does not, and pinning
+    // undefined would erase the only password from the file on save, bricking the boot.
+    if (this.appConfig.multiPassHashed) {
+      config.multiPassHashed = this.appConfig.multiPassHashed;
+    } else {
+      delete config.multiPassHashed;
+    }
     // Deployment-level switches are pinned to server-held values: the settings API must
-    // not flip the authentication mode (disableAuth, SSO) or move SSO fields, and no UI
-    // flow writes them. Pinning the whole object also means a trimmed or missing SSO
-    // object can never wipe server state.
+    // not flip the authentication mode (disableAuth, SSO) or move SSO fields, the
+    // password policy, or the database location; no UI flow writes them. Pinning the
+    // whole SSO object also means a trimmed or missing SSO object can never wipe server
+    // state.
     config.disableAuth = this.appConfig.disableAuth;
+    config.allowPasswordUpdate = this.appConfig.allowPasswordUpdate;
+    config.dbDirectoryPath = this.appConfig.dbDirectoryPath;
     config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
     }
     // Restore the TOTP seed when the client omits it — and when it sends an empty seed
-    // while still claiming 2FA is on (the pre-login config response carries that shape).
-    // An explicit non-empty seed is the settings UI's enable flow and is honored; an
-    // empty seed with enable2FA false is its disable flow and is honored too.
+    // while still claiming 2FA is on (an inconsistent pair no honest flow produces).
+    // The settings UI's enable flow sends a non-empty seed; its disable flow sends an
+    // empty seed with enable2FA false. Both are honored.
     if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
       config.secret2FA = this.appConfig.secret2FA;
     }

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -37,7 +37,8 @@ export class CommonService {
         if (typeof keys[i] === 'string' &&
           ((keys[i].toLowerCase().includes('password') && keys[i] !== 'allowPasswordUpdate') || keys[i].toLowerCase().includes('multipass') ||
             keys[i].toLowerCase().includes('rpcpass') || keys[i].toLowerCase().includes('rpcpassword') ||
-            keys[i].toLowerCase().includes('rpcuser'))
+            keys[i].toLowerCase().includes('rpcuser') || keys[i].toLowerCase().includes('secret2fa') ||
+            keys[i].toLowerCase().includes('cookievalue'))
         ) {
           obj[keys[i]] = '*'.repeat(20);
         }
@@ -63,6 +64,8 @@ export class CommonService {
     delete config.multiPass;
     delete config.multiPassHashed;
     delete config.secret2FA;
+    // The SSO cookie is a live bearer credential; it must never leave the server.
+    if (config.SSO) { delete config.SSO.cookieValue; }
     config.nodes?.forEach((node) => this.removeAuthSecureData(node));
     return config;
   };
@@ -72,6 +75,9 @@ export class CommonService {
     config.rtlPass = this.appConfig.rtlPass;
     config.multiPassHashed = this.appConfig.multiPassHashed;
     config.SSO.rtlCookiePath = this.appConfig.SSO.rtlCookiePath;
+    // cookieValue is stripped from client responses, so a settings save can never echo it;
+    // restore the server-held value or the save would silently wipe the live SSO cookie.
+    config.SSO.cookieValue = this.appConfig.SSO.cookieValue;
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
     }
@@ -112,7 +118,7 @@ export class CommonService {
         this.logger.log({ selectedNode: this.selectedNode, level: 'ERROR', fileName: 'Common', msg: 'Loop macaroon Error', error: err });
       }
     }
-    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Swap Options', data: swapOptions });
+    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Swap Options Set' });
     return swapOptions;
   };
 
@@ -130,7 +136,7 @@ export class CommonService {
         this.logger.log({ selectedNode: this.selectedNode, level: 'ERROR', fileName: 'Common', msg: 'Boltz macaroon Error', error: err });
       }
     }
-    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Boltz Options', data: boltzOptions });
+    this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Boltz Options Set' });
     return boltzOptions;
   };
 
@@ -179,7 +185,7 @@ export class CommonService {
         }
       }
       if (req.session.selectedNode) {
-        this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Updated Node Options for ' + req.session.selectedNode.lnNode, data: req.session.selectedNode.authentication.options });
+        this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Updated Node Options for ' + req.session.selectedNode.lnNode });
       }
       return { status: 200, message: 'Updated Successfully' };
     } catch (err) {
@@ -247,7 +253,7 @@ export class CommonService {
             form: ''
           };
         }
-        this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Set Node Options for ' + node.lnNode, data: node.authentication.options });
+        this.logger.log({ selectedNode: this.selectedNode, level: 'INFO', fileName: 'Common', msg: 'Set Node Options for ' + node.lnNode });
       });
       this.updateSelectedNodeOptions(req);
     }

--- a/server/utils/config.ts
+++ b/server/utils/config.ts
@@ -284,7 +284,9 @@ export class ConfigService {
           this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'Config', msg: 'Something went wrong while creating the backup directory: \n' + err });
         }
         this.common.nodes[idx].settings.logFile = config.rtlConfFilePath + '/logs/RTL-Node-' + node.index + '.log';
-        this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.nodes[idx]) });
+        // maskPasswords keeps paths visible for debugging while redacting lnApiPassword
+        // and any other credential fields before they reach the log file.
+        this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(JSON.parse(JSON.stringify(this.common.nodes[idx])))) });
         const log_file = this.common.nodes[idx].settings.logFile;
         if (fs.existsSync(log_file || '')) {
           fs.writeFile((log_file || ''), '', () => { });

--- a/server/utils/config.ts
+++ b/server/utils/config.ts
@@ -286,7 +286,7 @@ export class ConfigService {
         this.common.nodes[idx].settings.logFile = config.rtlConfFilePath + '/logs/RTL-Node-' + node.index + '.log';
         // maskPasswords keeps paths visible for debugging while redacting credential
         // fields such as lnApiPassword before they reach the log file.
-        this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(JSON.parse(JSON.stringify(this.common.nodes[idx])))) });
+        this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(this.common.nodes[idx])) });
         const log_file = this.common.nodes[idx].settings.logFile;
         if (fs.existsSync(log_file || '')) {
           fs.writeFile((log_file || ''), '', () => { });

--- a/server/utils/config.ts
+++ b/server/utils/config.ts
@@ -284,8 +284,8 @@ export class ConfigService {
           this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'Config', msg: 'Something went wrong while creating the backup directory: \n' + err });
         }
         this.common.nodes[idx].settings.logFile = config.rtlConfFilePath + '/logs/RTL-Node-' + node.index + '.log';
-        // maskPasswords keeps paths visible for debugging while redacting lnApiPassword
-        // and any other credential fields before they reach the log file.
+        // maskPasswords keeps paths visible for debugging while redacting credential
+        // fields such as lnApiPassword before they reach the log file.
         this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'Config', msg: 'Node Config: ' + JSON.stringify(this.common.maskPasswords(JSON.parse(JSON.stringify(this.common.nodes[idx])))) });
         const log_file = this.common.nodes[idx].settings.logFile;
         if (fs.existsSync(log_file || '')) {

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -161,3 +161,49 @@ test('addSecureData honors an explicit seed wipe only when 2FA is disabled', () 
   assert.equal(config.secret2FA, '');
   assert.equal(config.enable2FA, false);
 });
+
+test('addSecureData does not pin an undefined multiPassHashed over the persisted one', () => {
+  // First-boot state of a default install: the file already holds multiPassHashed (the
+  // boot converted it), but the in-memory appConfig still holds plaintext multiPass and
+  // no hash. Pinning undefined here would erase the only password from the file on save
+  // and brick the next boot.
+  seedAppConfig();
+  Common.appConfig.multiPassHashed = undefined;
+  Common.appConfig.multiPass = 'password';
+  const config = Common.addSecureData({ nodes: [] });
+  assert.equal(Object.prototype.hasOwnProperty.call(config, 'multiPassHashed'), false);
+  assert.equal(config.multiPass, 'password');
+});
+
+test('addSecureData pins multiPassHashed when the server holds one', () => {
+  seedAppConfig();
+  Common.appConfig.multiPassHashed = 'server-hash-value';
+  const config = Common.addSecureData({ multiPassHashed: 'client-value', nodes: [] });
+  assert.equal(config.multiPassHashed, 'server-hash-value');
+});
+
+test('addSecureData pins allowPasswordUpdate and dbDirectoryPath to server-held values', () => {
+  // allowPasswordUpdate is false precisely when the password is environment-managed, and
+  // dbDirectoryPath redirects the runtime database — neither is writable from the UI.
+  seedAppConfig();
+  Common.appConfig.allowPasswordUpdate = false;
+  Common.appConfig.dbDirectoryPath = '/server-db';
+  const config = Common.addSecureData({ allowPasswordUpdate: true, dbDirectoryPath: '/client-db', nodes: [] });
+  assert.equal(config.allowPasswordUpdate, false);
+  assert.equal(config.dbDirectoryPath, '/server-db');
+});
+
+test('maskPasswords masks bitcoind rpcauth', () => {
+  const config = { rpcauth: 'user:salt$hmac', rpcuser: 'user', rpcpassword: 'pass' };
+  const masked = Common.maskPasswords(config);
+  assert.equal(masked.rpcauth, '*'.repeat(20));
+  assert.equal(masked.rpcuser, '*'.repeat(20));
+  assert.equal(masked.rpcpassword, '*'.repeat(20));
+});
+
+test('maskPasswords does not mutate its input', () => {
+  // Masking a live object must not blank the credentials LN requests authenticate with.
+  const config = { authentication: { options: { headers: { 'Grpc-Metadata-macaroon': 'deadbeef' } } } };
+  Common.maskPasswords(config);
+  assert.equal(config.authentication.options.headers['Grpc-Metadata-macaroon'], 'deadbeef');
+});

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -75,3 +75,89 @@ test('handleError does not echo the absolute file path to the caller', () => {
   assert.equal(err.error.includes('/secret/dir'), false);
   assert.equal(err.message.includes('/secret/dir'), false);
 });
+
+test('handleError keeps the absolute path out of controller-wrapped errors too', () => {
+  // RTLConf handlers pass { statusCode, message, error: errRes } wrappers; the response
+  // must resolve to the caller's generic message, never the wrapped fs error's path.
+  const err = Common.handleError(
+    { statusCode: 500, message: 'Reading File Error', error: { code: 'ENOENT', path: '/secret/dir/x.bak' } },
+    'Test', 'Reading File Error', { lnImplementation: 'LND', settings: {} }
+  );
+  assert.equal(err.error.includes('/secret/dir'), false);
+  assert.equal(err.message.includes('/secret/dir'), false);
+});
+
+test('maskPasswords masks every value under a headers key', () => {
+  // Header values are always credential carriers here (macaroon, rune, basic auth), and
+  // key-substring matching cannot catch them without also hiding *Path fields.
+  const config = {
+    authentication: {
+      macaroonPath: '/visible/path',
+      options: { headers: { 'Grpc-Metadata-macaroon': 'deadbeef', rune: 'cln-rune', authorization: 'Basic xyz' } }
+    }
+  };
+  const masked = Common.maskPasswords(config);
+  assert.equal(masked.authentication.options.headers['Grpc-Metadata-macaroon'], '*'.repeat(20));
+  assert.equal(masked.authentication.options.headers.rune, '*'.repeat(20));
+  assert.equal(masked.authentication.options.headers.authorization, '*'.repeat(20));
+  assert.equal(masked.authentication.macaroonPath, '/visible/path');
+});
+
+const seedAppConfig = () => {
+  Common.appConfig = {
+    defaultNodeIndex: 0,
+    selectedNodeIndex: 0,
+    rtlConfFilePath: '/conf',
+    dbDirectoryPath: '/db',
+    rtlPass: 'server-hash',
+    allowPasswordUpdate: true,
+    enable2FA: true,
+    secret2FA: 'server-seed',
+    disableAuth: false,
+    SSO: { rtlSSO: 0, rtlCookiePath: '/server-cookie', logoutRedirectLink: 'https://server-logout', cookieValue: 'server-cookie' },
+    nodes: []
+  };
+  Common.selectedNode = null;
+  Common.nodes = [];
+};
+
+test('addSecureData pins disableAuth and the SSO object to server-held values', () => {
+  // The settings API must not be able to flip the authentication mode or move SSO fields;
+  // client-supplied values for these are deployment-level switches, not settings.
+  seedAppConfig();
+  const config = Common.addSecureData({
+    disableAuth: true,
+    SSO: { rtlSSO: 1, rtlCookiePath: '/client-path', logoutRedirectLink: 'https://client', cookieValue: 'client-cookie' },
+    secret2FA: 'client-seed',
+    nodes: []
+  });
+  assert.equal(config.disableAuth, false);
+  assert.deepEqual(config.SSO, { rtlSSO: 0, rtlCookiePath: '/server-cookie', logoutRedirectLink: 'https://server-logout', cookieValue: 'server-cookie' });
+  // An explicit non-empty seed is the settings UI's enable flow and is honored.
+  assert.equal(config.secret2FA, 'client-seed');
+  assert.equal(config.enable2FA, true);
+});
+
+test('addSecureData restores an omitted TOTP seed and derives enable2FA from the seed', () => {
+  seedAppConfig();
+  const config = Common.addSecureData({ nodes: [] });
+  assert.equal(config.secret2FA, 'server-seed');
+  assert.equal(config.enable2FA, true);
+});
+
+test('addSecureData treats an empty seed with 2FA claimed on as an omission', () => {
+  // The pre-login config response shape carries secret2FA: ''; echoing it must not wipe
+  // the seed while enable2FA stays on.
+  seedAppConfig();
+  const config = Common.addSecureData({ secret2FA: '', enable2FA: true, nodes: [] });
+  assert.equal(config.secret2FA, 'server-seed');
+  assert.equal(config.enable2FA, true);
+});
+
+test('addSecureData honors an explicit seed wipe only when 2FA is disabled', () => {
+  // The settings UI's disable flow sends secret2FA: '' together with enable2FA: false.
+  seedAppConfig();
+  const config = Common.addSecureData({ secret2FA: '', enable2FA: false, nodes: [] });
+  assert.equal(config.secret2FA, '');
+  assert.equal(config.enable2FA, false);
+});

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Common } from '../../backend/utils/common.js';
+
+test('maskPasswords masks TOTP and SSO cookie secrets along with passwords', () => {
+  const config = {
+    secret2FA: 'JBSWY3DPEHPK3PXP',
+    multiPassHashed: 'password-hash',
+    SSO: { rtlSSO: 1, rtlCookiePath: '/cookie-path', cookieValue: 'live-sso-cookie' },
+    nodes: [{ index: 1, authentication: { lnApiPassword: 'eclair-pass', macaroonPath: '/macaroon/path' } }]
+  };
+  const masked = Common.maskPasswords(config);
+  assert.equal(masked.secret2FA, '*'.repeat(20));
+  assert.equal(masked.SSO.cookieValue, '*'.repeat(20));
+  assert.equal(masked.multiPassHashed, '*'.repeat(20));
+  assert.equal(masked.nodes[0].authentication.lnApiPassword, '*'.repeat(20));
+  // Paths are configuration, not secrets — they must stay visible for the settings UI.
+  assert.equal(masked.nodes[0].authentication.macaroonPath, '/macaroon/path');
+  assert.equal(masked.SSO.rtlCookiePath, '/cookie-path');
+});
+
+test('removeSecureData strips the SSO cookie along with the other secrets', () => {
+  const config = {
+    rtlConfFilePath: '/conf',
+    rtlPass: 'password-hash',
+    multiPassHashed: 'password-hash',
+    secret2FA: 'JBSWY3DPEHPK3PXP',
+    SSO: { rtlSSO: 1, rtlCookiePath: '/cookie-path', logoutRedirectLink: '', cookieValue: 'live-sso-cookie' },
+    nodes: [{ index: 1, authentication: { macaroonPath: '/macaroon/path', runeValue: 'rune', options: {} } }]
+  };
+  const cleaned = Common.removeSecureData(config);
+  assert.equal(cleaned.rtlConfFilePath, undefined);
+  assert.equal(cleaned.rtlPass, undefined);
+  assert.equal(cleaned.multiPassHashed, undefined);
+  assert.equal(cleaned.secret2FA, undefined);
+  assert.equal(cleaned.SSO.cookieValue, undefined);
+  // Non-secret SSO settings survive — the settings UI renders them.
+  assert.equal(cleaned.SSO.rtlCookiePath, '/cookie-path');
+  assert.equal(cleaned.nodes[0].authentication.macaroonPath, undefined);
+});

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -39,3 +39,39 @@ test('removeSecureData strips the SSO cookie along with the other secrets', () =
   assert.equal(cleaned.SSO.rtlCookiePath, '/cookie-path');
   assert.equal(cleaned.nodes[0].authentication.macaroonPath, undefined);
 });
+
+test('removeSecureData does not mutate its input', () => {
+  // cookieValue is runtime-only: if a caller ever passes the live appConfig, an in-place
+  // delete would wipe SSO state with no way to restore it. The function must clone.
+  const config = { rtlPass: 'password-hash', SSO: { cookieValue: 'live-sso-cookie' }, nodes: [] };
+  Common.removeSecureData(config);
+  assert.equal(config.rtlPass, 'password-hash');
+  assert.equal(config.SSO.cookieValue, 'live-sso-cookie');
+});
+
+test('maskPasswords masks rtlPass and runeValue', () => {
+  const config = {
+    rtlPass: 'login-hash',
+    nodes: [{ index: 1, authentication: { runeValue: 'cln-rune' } }]
+  };
+  const masked = Common.maskPasswords(config);
+  assert.equal(masked.rtlPass, '*'.repeat(20));
+  assert.equal(masked.nodes[0].authentication.runeValue, '*'.repeat(20));
+});
+
+test('maskPasswords tolerates null values and numeric keys without skipping secrets', () => {
+  // Integer-like keys order first; the recursion must not clobber its own key list, and
+  // typeof null === 'object' must not send it into Object.keys(null).
+  const config = { '1': { nested: 'value' }, lnApiPassword: 'eclair-pass', nothing: null };
+  const masked = Common.maskPasswords(config);
+  assert.equal(masked.lnApiPassword, '*'.repeat(20));
+  assert.equal(masked.nothing, null);
+  assert.deepEqual(masked['1'], { nested: 'value' });
+});
+
+test('handleError does not echo the absolute file path to the caller', () => {
+  // The path belongs in the server log, not in the API response.
+  const err = Common.handleError({ code: 'ENOENT', path: '/secret/dir/RTL-Config.json' }, 'Test', 'Reading Config Error', { lnImplementation: 'LND', settings: {} });
+  assert.equal(err.error.includes('/secret/dir'), false);
+  assert.equal(err.message.includes('/secret/dir'), false);
+});

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -137,3 +137,74 @@ test('updateApplicationSettings preserves indexed node auth and sanitizes only p
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
+
+test('updateApplicationSettings keeps the SSO cookie server-side without exposing or persisting it', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-sso-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 1, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    SSO: { rtlSSO: 1, rtlCookiePath: '/cookie-path', logoutRedirectLink: '', cookieValue: 'live-sso-cookie' }
+  });
+  // The request carries only what the sanitized client can have seen: no cookieValue.
+  // The server must re-attach it — a settings save must never wipe the live cookie —
+  // while keeping it out of both the response and the persisted file.
+  const requestBody = {
+    ...clone(oldConfig),
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    SSO: { rtlSSO: 1, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' }
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    let responseBody;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return {
+            json: (body) => {
+              responseBody = body;
+            }
+          };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.SSO.cookieValue, 'live-sso-cookie');
+    assert.equal(Common.appConfig.SSO.rtlCookiePath, '/cookie-path');
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.equal(fileConfig.SSO.cookieValue, undefined);
+    assert.equal(responseBody.SSO.cookieValue, undefined);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import test from 'node:test';
 
-import { updateApplicationSettings } from '../../backend/controllers/shared/RTLConf.js';
+import { updateApplicationSettings, getFile } from '../../backend/controllers/shared/RTLConf.js';
 import { Common } from '../../backend/utils/common.js';
 import { WSServer } from '../../backend/utils/webSocketServer.js';
 
@@ -324,6 +324,117 @@ test('updateApplicationSettings tolerates a request body without an SSO object',
 
     assert.equal(responseStatus, 201);
     assert.equal(typeof Common.appConfig.SSO, 'object');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings leaves the runtime config untouched when the file write fails', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-writefail-'));
+  const confPath = join(tempDir, 'RTL-Config.json');
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    secret2FA: 'live-totp-seed',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '', cookieValue: 'live-sso-cookie' }
+  });
+  const requestBody = {
+    ...clone(oldConfig),
+    selectedNodeIndex: 0,
+    SSO: { rtlSSO: 0 },
+    nodes: [{ ...clone(oldConfig.nodes[0]), settings: { themeMode: 'NIGHT' } }]
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(confPath, JSON.stringify(oldConfig, null, 2), 'utf-8');
+    chmodSync(tempDir, 0o555); // read-only dir: temp-file create and rename both fail
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 500);
+    // The failed write must not have committed the prospective config in memory either.
+    assert.equal(Common.appConfig.secret2FA, 'live-totp-seed');
+    assert.equal(Common.appConfig.SSO.cookieValue, 'live-sso-cookie');
+    assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
+    // And the on-disk file still parses as the pre-call config.
+    const onDisk = JSON.parse(readFileSync(confPath, 'utf-8'));
+    assert.equal(onDisk.nodes.length, 1);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    chmodSync(tempDir, 0o755);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getFile contains caller paths to the channel backup directory', async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-getfile-'));
+  const backupDir = join(tempDir, 'backups');
+  mkdirSync(backupDir);
+  writeFileSync(join(tempDir, 'secret.bak'), 'top-secret', 'utf-8');
+  writeFileSync(join(backupDir, 'channel-1x2x3.bak'), 'backup-data', 'utf-8');
+  const session = { selectedNode: { lnImplementation: 'LND', settings: { channelBackupPath: backupDir } } };
+  const mockRes = () => {
+    const res = { statusCode: null, body: null };
+    res.status = (code) => {
+      res.statusCode = code;
+      return { json: (body) => { res.body = body; } };
+    };
+    return res;
+  };
+
+  try {
+    // An escaping path is rejected before any read.
+    const rejected = mockRes();
+    getFile({ query: { path: join(tempDir, 'secret.bak') }, session }, rejected, null);
+    assert.equal(rejected.statusCode, 403);
+
+    // A contained path is served.
+    const served = mockRes();
+    await new Promise((resolve) => {
+      const res = { status: (code) => { served.statusCode = code; return { json: (body) => { served.body = body; resolve(); } }; } };
+      getFile({ query: { path: join(backupDir, 'channel-1x2x3.bak') }, session }, res, null);
+    });
+    assert.equal(served.statusCode, 200);
+    assert.equal(served.body, 'backup-data');
+
+    // A contained but missing file returns a path-free error (the ENOENT branch).
+    const missing = mockRes();
+    await new Promise((resolve) => {
+      const res = { status: (code) => { missing.statusCode = code; return { json: (body) => { missing.body = body; resolve(); } }; } };
+      getFile({ query: { path: join(backupDir, 'channel-missing.bak') }, session }, res, null);
+    });
+    assert.equal(missing.statusCode, 500);
+    assert.equal(JSON.stringify(missing.body).includes(backupDir), false);
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import test from 'node:test';
 
-import { updateApplicationSettings, getFile } from '../../backend/controllers/shared/RTLConf.js';
+import { updateApplicationSettings, updateNodeSettings, getFile } from '../../backend/controllers/shared/RTLConf.js';
 import { Common } from '../../backend/utils/common.js';
 import { WSServer } from '../../backend/utils/webSocketServer.js';
 
@@ -367,7 +367,10 @@ test('updateApplicationSettings leaves the runtime config untouched when the fil
     Common.nodes = clone(runtimeConfig.nodes);
     Common.selectedNode = Common.nodes[0];
     writeFileSync(confPath, JSON.stringify(oldConfig, null, 2), 'utf-8');
-    chmodSync(tempDir, 0o555); // read-only dir: temp-file create and rename both fail
+    // Both write paths must fail: a read-only dir defeats the temp-file write, and a
+    // read-only file defeats the in-place fallback.
+    chmodSync(confPath, 0o444);
+    chmodSync(tempDir, 0o555);
 
     let responseStatus = null;
     updateApplicationSettings(
@@ -391,7 +394,164 @@ test('updateApplicationSettings leaves the runtime config untouched when the fil
     assert.equal(onDisk.nodes.length, 1);
   } finally {
     clearInterval(WSServer.pingInterval);
+    chmodSync(confPath, 0o644);
     chmodSync(tempDir, 0o755);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings preserves the config file mode across the atomic write', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-mode-'));
+  const confPath = join(tempDir, 'RTL-Config.json');
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(confPath, JSON.stringify(oldConfig, null, 2), 'utf-8');
+    chmodSync(confPath, 0o600); // operator-hardened; must not be silently downgraded
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      { body: clone(oldConfig), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(statSync(confPath).mode & 0o777, 0o600);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings falls back to an in-place write when the rename fails', () => {
+  // Single-file bind mounts and symlinks cannot be renamed over; the save must still work.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-fallback-'));
+  const confPath = join(tempDir, 'RTL-Config.json');
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(confPath, JSON.stringify(oldConfig, null, 2), 'utf-8');
+    chmodSync(confPath, 0o600);
+    mkdirSync(confPath + '.tmp'); // forces the temp write to fail, exercising the fallback
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      { body: clone(oldConfig), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(statSync(confPath).mode & 0o777, 0o600); // in-place write keeps the inode
+    assert.deepEqual(JSON.parse(readFileSync(confPath, 'utf-8')).nodes.length, 1);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateNodeSettings pins channelBackupPath to the server-held value', () => {
+  // channelBackupPath anchors getFile's containment root; accepting it from the request
+  // would let the caller being contained choose the containment base.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nodesettings-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', channelBackupPath: '/server/backups' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({ ...oldConfig, rtlConfFilePath: tempDir });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateNodeSettings(
+      {
+        body: { settings: { themeMode: 'NIGHT', channelBackupPath: tempDir } },
+        session: { selectedNode: Common.nodes[0] }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    const fileNode = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
+    assert.equal(fileNode.settings.channelBackupPath, '/server/backups');
+    assert.equal(fileNode.settings.themeMode, 'NIGHT'); // other settings still merge
+    assert.equal(Common.nodes[0].settings.channelBackupPath, '/server/backups');
+  } finally {
+    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -208,3 +208,124 @@ test('updateApplicationSettings keeps the SSO cookie server-side without exposin
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
+
+test('updateApplicationSettings restores omitted secret2FA and merges a trimmed SSO object', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-secrets-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: 'https://logout.example' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    enable2FA: true,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    secret2FA: 'live-totp-seed',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: 'https://logout.example', cookieValue: 'live-sso-cookie' }
+  });
+  // Sanitized responses carry neither secret2FA nor cookieValue, so an echoing client
+  // omits both; a trimmed SSO object also lacks logoutRedirectLink. All three must
+  // survive the save server-side.
+  const requestBody = {
+    ...clone(oldConfig),
+    selectedNodeIndex: 0,
+    enable2FA: true,
+    allowPasswordUpdate: true,
+    SSO: { rtlSSO: 0 }
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.secret2FA, 'live-totp-seed');
+    assert.equal(Common.appConfig.enable2FA, true);
+    assert.equal(Common.appConfig.SSO.cookieValue, 'live-sso-cookie');
+    assert.equal(Common.appConfig.SSO.logoutRedirectLink, 'https://logout.example');
+    assert.equal(Common.appConfig.SSO.rtlSSO, 0);
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.equal(fileConfig.SSO.cookieValue, undefined);
+    assert.equal(fileConfig.secret2FA, 'live-totp-seed');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings tolerates a request body without an SSO object', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nosso-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+  const requestBody = clone(oldConfig);
+  delete requestBody.SSO;
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    updateApplicationSettings(
+      { body: requestBody, session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(typeof Common.appConfig.SSO, 'object');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Tightens redaction of authentication material in node logs and configuration API responses, and keeps runtime-only SSO state out of the persisted config file. Users are encouraged to update promptly.

## What changed

- Redaction helpers now cover the full set of server-held secrets; nothing credential-bearing is written to node logs at INFO/DEBUG level anymore.
- Runtime SSO state is stripped from client-facing responses and from the persisted config file, while remaining intact server-side across settings saves.
- Regression coverage added (`test/backend/common.test.mjs`, plus a settings round-trip case in `rtlconf.test.mjs`).

## Verification

- Backend: `npm run testbackend` — 15/15 pass (3 new tests failed on the pre-fix code, confirming each finding)
- `npm run lint` — green
- Frontend: no `src/` changes; karma inputs identical to the previously green run (204/204)
- End-to-end against the docker regtest fixture with a branch-built image (`rtl:pr`): verified for LND, CLN and Eclair nodes that no credential material appears in node logs at INFO level, that configuration endpoints redact secrets, and that SSO authentication survives a sanitized settings save

Release-notes entry included with `#TBD`; the PR number will be filled in a follow-up commit.