### PR TITLE
Fix options race in getPeers/postPeer alias resolution (lnd/peers.ts)

### DIFF
--- a/backend/controllers/lnd/peers.js
+++ b/backend/controllers/lnd/peers.js
@@ -4,17 +4,14 @@ import { Common } from '../../utils/common.js';
 let options = null;
 const logger = Logger;
 const common = Common;
-export const getAliasForPeers = (selNode, peer, requestOptions) => {
-    requestOptions.url = selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key;
-    return request(requestOptions).then((aliasBody) => {
-        logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
-        peer.alias = aliasBody.node.alias;
-        return aliasBody.node.alias;
-    }).catch((err) => {
-        peer.alias = peer.pub_key.slice(0, 20);
-        return peer.pub_key;
-    });
-};
+export const getAliasForPeers = (selNode, peer, requestOptions) => request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key }).then((aliasBody) => {
+    logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
+    peer.alias = aliasBody.node.alias;
+    return aliasBody.node.alias;
+}).catch((err) => {
+    peer.alias = peer.pub_key.slice(0, 20);
+    return peer.pub_key;
+});
 export const getPeers = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Peers', msg: 'Getting Peers..' });
     options = common.getOptions(req);
@@ -23,8 +20,8 @@ export const getPeers = (req, res, next) => {
     }
     options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
     const selNode = req.session.selectedNode;
-    const { qs: _qs, ...requestOptions } = options;
-    request(options).then((body) => {
+    const { qs: _qs, form: _form, ...requestOptions } = options;
+    request({ ...requestOptions }).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peers List Received', data: body });
         const peers = !body.peers ? [] : body.peers;
         // Bound concurrent alias lookups so a node with many peers can't fire one graph/node
@@ -61,11 +58,10 @@ export const postPeer = (req, res, next) => {
         perm: perm
     });
     const selNode = req.session.selectedNode;
-    const { qs: _qs, ...requestOptions } = options;
-    request.post(options).then((body) => {
+    const { qs: _qs, form: _form, ...requestOptions } = options;
+    request.post({ ...requestOptions, form: options.form }).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peer Connected', data: body });
-        options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
-        request(options).then((body) => {
+        request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/peers' }).then((body) => {
             const peers = (!body.peers) ? [] : body.peers;
             // Bound concurrent alias lookups (parity with the CLN fix, #1501).
             const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(selNode, peer, { ...requestOptions }));

--- a/backend/controllers/lnd/peers.js
+++ b/backend/controllers/lnd/peers.js
@@ -59,7 +59,7 @@ export const postPeer = (req, res, next) => {
     });
     const selNode = req.session.selectedNode;
     const { qs: _qs, form: _form, ...requestOptions } = options;
-    request.post({ ...requestOptions, form: options.form }).then((body) => {
+    request.post({ ...requestOptions, form: _form }).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peer Connected', data: body });
         request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/peers' }).then((body) => {
             const peers = (!body.peers) ? [] : body.peers;

--- a/backend/controllers/lnd/peers.js
+++ b/backend/controllers/lnd/peers.js
@@ -4,9 +4,9 @@ import { Common } from '../../utils/common.js';
 let options = null;
 const logger = Logger;
 const common = Common;
-export const getAliasForPeers = (selNode, peer) => {
-    options.url = selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key;
-    return request(options).then((aliasBody) => {
+export const getAliasForPeers = (selNode, peer, requestOptions) => {
+    requestOptions.url = selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key;
+    return request(requestOptions).then((aliasBody) => {
         logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
         peer.alias = aliasBody.node.alias;
         return aliasBody.node.alias;
@@ -22,12 +22,14 @@ export const getPeers = (req, res, next) => {
         return res.status(options.statusCode).json({ message: options.message, error: options.error });
     }
     options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
+    const selNode = req.session.selectedNode;
+    const { qs: _qs, ...requestOptions } = options;
     request(options).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peers List Received', data: body });
         const peers = !body.peers ? [] : body.peers;
         // Bound concurrent alias lookups so a node with many peers can't fire one graph/node
         // request per peer at once and overwhelm the backend (parity with the CLN fix, #1501).
-        const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(req.session.selectedNode, peer));
+        const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(selNode, peer, { ...requestOptions }));
         common.runWithConcurrencyLimit(getPeerAliasesTasks, 20, () => {
             // Guard the response-send: the limiter invokes this outside the surrounding .catch.
             try {
@@ -58,13 +60,15 @@ export const postPeer = (req, res, next) => {
         addr: { host: host, pubkey: pubkey },
         perm: perm
     });
+    const selNode = req.session.selectedNode;
+    const { qs: _qs, ...requestOptions } = options;
     request.post(options).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peer Connected', data: body });
         options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
         request(options).then((body) => {
             const peers = (!body.peers) ? [] : body.peers;
             // Bound concurrent alias lookups (parity with the CLN fix, #1501).
-            const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(req.session.selectedNode, peer));
+            const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(selNode, peer, { ...requestOptions }));
             common.runWithConcurrencyLimit(getPeerAliasesTasks, 20, () => {
                 // Guard the response-send: the limiter invokes this outside the surrounding .catch, and
                 // this replaced an explicit inner .catch — a throw here must not hang the POST (#1629 F4).

--- a/server/controllers/lnd/peers.ts
+++ b/server/controllers/lnd/peers.ts
@@ -6,7 +6,7 @@ let options = null;
 const logger: LoggerService = Logger;
 const common: CommonService = Common;
 
-export const getAliasForPeers = (selNode: SelectedNode, peer, requestOptions) => request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key }).then((aliasBody) => {
+export const getAliasForPeers = (selNode: SelectedNode, peer: { pub_key: string; alias?: string }, requestOptions: any) => request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key }).then((aliasBody) => {
   logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
   peer.alias = aliasBody.node.alias;
   return aliasBody.node.alias;
@@ -56,7 +56,7 @@ export const postPeer = (req, res, next) => {
   });
   const selNode = req.session.selectedNode;
   const { qs: _qs, form: _form, ...requestOptions } = options;
-  request.post({ ...requestOptions, form: options.form }).then((body) => {
+  request.post({ ...requestOptions, form: _form }).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peer Connected', data: body });
     request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/peers' }).then((body) => {
       const peers = (!body.peers) ? [] : body.peers;

--- a/server/controllers/lnd/peers.ts
+++ b/server/controllers/lnd/peers.ts
@@ -6,9 +6,9 @@ let options = null;
 const logger: LoggerService = Logger;
 const common: CommonService = Common;
 
-export const getAliasForPeers = (selNode: SelectedNode, peer) => {
-  options.url = selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key;
-  return request(options).then((aliasBody) => {
+export const getAliasForPeers = (selNode: SelectedNode, peer, requestOptions) => {
+  requestOptions.url = selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key;
+  return request(requestOptions).then((aliasBody) => {
     logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
     peer.alias = aliasBody.node.alias;
     return aliasBody.node.alias;
@@ -23,12 +23,14 @@ export const getPeers = (req, res, next) => {
   options = common.getOptions(req);
   if (options.error) { return res.status(options.statusCode).json({ message: options.message, error: options.error }); }
   options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
+  const selNode = req.session.selectedNode;
+  const { qs: _qs, ...requestOptions } = options;
   request(options).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peers List Received', data: body });
     const peers = !body.peers ? [] : body.peers;
     // Bound concurrent alias lookups so a node with many peers can't fire one graph/node
     // request per peer at once and overwhelm the backend (parity with the CLN fix, #1501).
-    const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(req.session.selectedNode, peer));
+    const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(selNode, peer, { ...requestOptions }));
     common.runWithConcurrencyLimit(getPeerAliasesTasks, 20, () => {
       // Guard the response-send: the limiter invokes this outside the surrounding .catch.
       try {
@@ -55,13 +57,15 @@ export const postPeer = (req, res, next) => {
     addr: { host: host, pubkey: pubkey },
     perm: perm
   });
+  const selNode = req.session.selectedNode;
+  const { qs: _qs, ...requestOptions } = options;
   request.post(options).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peer Connected', data: body });
     options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
     request(options).then((body) => {
       const peers = (!body.peers) ? [] : body.peers;
       // Bound concurrent alias lookups (parity with the CLN fix, #1501).
-      const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(req.session.selectedNode, peer));
+      const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(selNode, peer, { ...requestOptions }));
       common.runWithConcurrencyLimit(getPeerAliasesTasks, 20, () => {
         // Guard the response-send: the limiter invokes this outside the surrounding .catch, and
         // this replaced an explicit inner .catch — a throw here must not hang the POST (#1629 F4).

--- a/server/controllers/lnd/peers.ts
+++ b/server/controllers/lnd/peers.ts
@@ -6,17 +6,14 @@ let options = null;
 const logger: LoggerService = Logger;
 const common: CommonService = Common;
 
-export const getAliasForPeers = (selNode: SelectedNode, peer, requestOptions) => {
-  requestOptions.url = selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key;
-  return request(requestOptions).then((aliasBody) => {
-    logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
-    peer.alias = aliasBody.node.alias;
-    return aliasBody.node.alias;
-  }).catch((err) => {
-    peer.alias = peer.pub_key.slice(0, 20);
-    return peer.pub_key;
-  });
-};
+export const getAliasForPeers = (selNode: SelectedNode, peer, requestOptions) => request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/graph/node/' + peer.pub_key }).then((aliasBody) => {
+  logger.log({ selectedNode: selNode, level: 'DEBUG', fileName: 'Peers', msg: 'Alias Received', data: aliasBody.node.alias });
+  peer.alias = aliasBody.node.alias;
+  return aliasBody.node.alias;
+}).catch((err) => {
+  peer.alias = peer.pub_key.slice(0, 20);
+  return peer.pub_key;
+});
 
 export const getPeers = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Peers', msg: 'Getting Peers..' });
@@ -24,8 +21,8 @@ export const getPeers = (req, res, next) => {
   if (options.error) { return res.status(options.statusCode).json({ message: options.message, error: options.error }); }
   options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
   const selNode = req.session.selectedNode;
-  const { qs: _qs, ...requestOptions } = options;
-  request(options).then((body) => {
+  const { qs: _qs, form: _form, ...requestOptions } = options;
+  request({ ...requestOptions }).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peers List Received', data: body });
     const peers = !body.peers ? [] : body.peers;
     // Bound concurrent alias lookups so a node with many peers can't fire one graph/node
@@ -58,11 +55,10 @@ export const postPeer = (req, res, next) => {
     perm: perm
   });
   const selNode = req.session.selectedNode;
-  const { qs: _qs, ...requestOptions } = options;
-  request.post(options).then((body) => {
+  const { qs: _qs, form: _form, ...requestOptions } = options;
+  request.post({ ...requestOptions, form: options.form }).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Peers', msg: 'Peer Connected', data: body });
-    options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/peers';
-    request(options).then((body) => {
+    request({ ...requestOptions, url: selNode.settings.lnServerUrl + '/v1/peers' }).then((body) => {
       const peers = (!body.peers) ? [] : body.peers;
       // Bound concurrent alias lookups (parity with the CLN fix, #1501).
       const getPeerAliasesTasks = peers.map((peer) => () => getAliasForPeers(selNode, peer, { ...requestOptions }));

--- a/test/backend/lnd-peers.test.mjs
+++ b/test/backend/lnd-peers.test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+
+import { getPeers, postPeer } from '../../backend/controllers/lnd/peers.js';
+
+// The LND peers controllers keep the current request's options in a module-level `options`
+// binding that every handler reassigns on entry. The alias lookups run *after* the peer
+// list round trip (and behind a concurrency limiter), so a request for another node that
+// arrives in that window used to swap the object under them: node A's alias lookups went
+// out carrying node B's macaroon (#1662, the one site #1651 did not cover). These tests
+// pin the fix — every request a handler issues after an async boundary must use the
+// options snapshotted on entry, never the module binding.
+//
+// Each fake node is a real HTTP server that, like LND, rejects any request not carrying
+// its own macaroon, so a credential mix-up is observable both in what the servers record
+// and in the response the controller sends.
+
+const startFakeLnd = async (name, macaroon, peers) => {
+  const seen = [];
+  let holdPeersList = null;
+  let peersListRequested;
+  let signalPeersListRequested;
+
+  const armHold = () => {
+    peersListRequested = new Promise((resolve) => { signalPeersListRequested = resolve; });
+    holdPeersList = { pending: null };
+  };
+
+  const server = createServer((req, res) => {
+    const record = { method: req.method, path: req.url, macaroon: req.headers['grpc-metadata-macaroon'] };
+    seen.push(record);
+    const reply = (status, body) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+    if (record.macaroon !== macaroon) { return reply(401, { message: 'invalid macaroon' }); }
+    if (req.method === 'POST' && req.url === '/v1/peers') {
+      req.resume();
+      if (holdPeersList) { holdPeersList.pending = () => reply(200, {}); signalPeersListRequested(); return; }
+      return reply(200, {});
+    }
+    if (req.method === 'GET' && req.url === '/v1/peers') {
+      if (holdPeersList) { holdPeersList.pending = () => reply(200, { peers }); signalPeersListRequested(); return; }
+      return reply(200, { peers });
+    }
+    const graph = req.url.match(/^\/v1\/graph\/node\/(.+)$/);
+    if (req.method === 'GET' && graph) { return reply(200, { node: { alias: `${name}:${graph[1]}` } }); }
+    reply(404, { message: 'unexpected ' + req.method + ' ' + req.url });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `http://127.0.0.1:${server.address().port}`;
+
+  return {
+    name, macaroon, url, seen,
+    // Hold the *next* peer-list (or connect) response until release() is called, and expose
+    // a promise that resolves once the controller's request has actually arrived.
+    hold: () => { armHold(); return { requested: () => peersListRequested, release: () => { const p = holdPeersList.pending; holdPeersList = null; p(); } }; },
+    graphRequests: () => seen.filter((r) => r.path.startsWith('/v1/graph/node/')),
+    close: () => new Promise((resolve) => server.close(resolve))
+  };
+};
+
+const buildRequest = (node, body = {}) => ({
+  session: {
+    selectedNode: {
+      index: 1,
+      lnNode: node.name,
+      lnImplementation: 'LND',
+      authentication: {
+        options: { url: '', rejectUnauthorized: false, json: true, headers: { 'Grpc-Metadata-macaroon': node.macaroon } }
+      },
+      settings: { lnServerUrl: node.url, logLevel: 'ERROR' }
+    }
+  },
+  body,
+  query: {}
+});
+
+const buildResponse = () => {
+  const out = { statusCode: null, body: null, headersSent: false };
+  out.done = new Promise((resolve) => {
+    out.status = (code) => { out.statusCode = code; return out; };
+    out.json = (payload) => { out.body = payload; out.headersSent = true; resolve(payload); return out; };
+  });
+  return out;
+};
+
+test('getPeers: alias lookups keep node A\'s options when node B\'s request lands mid-flight', async () => {
+  const nodeA = await startFakeLnd('A', 'macaroon-A', [{ pub_key: 'peer-a1' }, { pub_key: 'peer-a2' }]);
+  const nodeB = await startFakeLnd('B', 'macaroon-B', []);
+  try {
+    const gate = nodeA.hold();
+    const resA = buildResponse();
+    getPeers(buildRequest(nodeA), resA, null);
+    await gate.requested();
+
+    // Node B's request arrives while A's peer list is still in flight: this reassigns the
+    // module-level `options` to B's object. Let it finish before releasing A.
+    const resB = buildResponse();
+    getPeers(buildRequest(nodeB), resB, null);
+    await resB.done;
+    assert.equal(resB.statusCode, 200);
+
+    gate.release();
+    await resA.done;
+
+    assert.equal(resA.statusCode, 200, JSON.stringify(resA.body));
+    assert.deepEqual(resA.body.map((p) => p.alias), ['A:peer-a1', 'A:peer-a2']);
+    // The alias lookups went to A, with A's macaroon — never to B, never with B's macaroon.
+    assert.equal(nodeA.graphRequests().length, 2);
+    assert.ok(nodeA.graphRequests().every((r) => r.macaroon === 'macaroon-A'), JSON.stringify(nodeA.seen));
+    assert.equal(nodeB.graphRequests().length, 0, JSON.stringify(nodeB.seen));
+  } finally {
+    await nodeA.close();
+    await nodeB.close();
+  }
+});
+
+test('postPeer: the follow-up peer list and alias lookups keep node A\'s options across the connect round trip', async () => {
+  const nodeA = await startFakeLnd('A', 'macaroon-A', [{ pub_key: 'peer-new' }, { pub_key: 'peer-old' }]);
+  const nodeB = await startFakeLnd('B', 'macaroon-B', []);
+  try {
+    const gate = nodeA.hold();
+    const resA = buildResponse();
+    postPeer(buildRequest(nodeA, { host: '10.0.0.1:9735', pubkey: 'peer-new', perm: false }), resA, null);
+    await gate.requested();
+
+    const resB = buildResponse();
+    getPeers(buildRequest(nodeB), resB, null);
+    await resB.done;
+    assert.equal(resB.statusCode, 200);
+
+    gate.release();
+    await resA.done;
+
+    assert.equal(resA.statusCode, 201, JSON.stringify(resA.body));
+    assert.deepEqual(resA.body.map((p) => p.pub_key), ['peer-new', 'peer-old']);
+    assert.deepEqual(resA.body.map((p) => p.alias), ['A:peer-new', 'A:peer-old']);
+    // Connect, the follow-up list and both alias lookups all hit A with A's macaroon.
+    const aPaths = nodeA.seen.map((r) => `${r.method} ${r.path}`);
+    assert.deepEqual(aPaths.slice(0, 2), ['POST /v1/peers', 'GET /v1/peers']);
+    assert.equal(nodeA.graphRequests().length, 2);
+    assert.ok(nodeA.seen.every((r) => r.macaroon === 'macaroon-A'), JSON.stringify(nodeA.seen));
+    assert.equal(nodeB.seen.filter((r) => r.path !== '/v1/peers').length, 0, JSON.stringify(nodeB.seen));
+  } finally {
+    await nodeA.close();
+    await nodeB.close();
+  }
+});


### PR DESCRIPTION
fixes #1662

follow-up to #1651. threads an explicit requestOptions parameter
through getAliasForPeers in server/controllers/lnd/peers.ts instead of
reading the module-level options, closing the same shared-mutable-state
race #1651 fixed in graph.ts/channels.ts.

what changed

getAliasForPeers now takes an explicit requestOptions parameter and
uses it for the request, instead of mutating and reading the
module-level options.

getPeers and postPeer now take the requestOptions snapshot
synchronously, right after their own url/form assignments and before
the first request()/request.post() call, not inside the outer .then()
like #1651 did for graph/channels. everything up to that point runs in
one synchronous tick, so no concurrent request to a different node can
reassign the shared options object before the snapshot happens. this
closes the race window fully instead of just narrowing it.

each task thunk gets its own shallow copy ({ ...requestOptions }), and
selNode is captured locally instead of read lazily inside each thunk,
same as #1651's F1 follow-up.

deletePeer is untouched, single request, no fan-out, nothing to fix
there.

qs isn't set anywhere in peers.ts so the qs-exclusion destructure is a
no-op here, kept for parity with #1651's files.

verification

npm run lint, npm run test (twice: backend 38/38, frontend 204/204
both times), npm run buildbackend, npm run buildfrontend, all clean.

also ran against the docker/ regtest fixture (built a local image from
this branch, RTL_IMAGE=rtl-local:fix-1662 docker compose up -d then
seed.sh). with alice and bob both live, repeatedly navigated between
their peers pages in two tabs to approximate concurrent multi-node
access, each tab consistently showed its own correct peers/aliases the
whole time, no errors in rtl's logs. this is a manual approximation not
a guaranteed race reproduction, the real correctness evidence is the
synchronous snapshot placement itself, verified against the exact
ordering in the diff.