### PR TITLE
Add SECURITY.md with private vulnerability reporting channels

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -186,7 +186,7 @@ E.g. if the IP address of your node is 192.168.0.15 then open your browser at th
 - (For advanced users) A sample SSL guide to serve remote access over an encrypted Tor connection can be found [here](./docs/RTL_TOR_setup.md)
 
 ### <a name="security"></a>Security
-RTL holds your node's credentials and can move funds, so please **report security vulnerabilities privately** — not in a public issue. See [SECURITY.md](../SECURITY.md) for the reporting channels (GitHub private vulnerability reporting or email), the PGP key, what is in and out of scope, and what to expect after you report.
+RTL holds your node's credentials, so a security flaw in RTL could let an attacker act on your node — including moving funds. Please **report security vulnerabilities privately** — not in a public issue. See [SECURITY.md](../SECURITY.md) for the reporting channels (GitHub private vulnerability reporting or email), the PGP key, what is in and out of scope, and what to expect after you report.
 
 ### <a name="trouble"></a>Troubleshooting
 In case you are running into issues with the application or if you have feedback, feel free to open issues on our github repo.

--- a/.github/README.md
+++ b/.github/README.md
@@ -13,6 +13,7 @@
 * [Prep For Execution](#prep)
 * [Start The Server](#start)
 * [Access The Application](#access)
+* [Security](#security)
 * [Troubleshooting](#trouble)
 
 ### <a name="intro"></a>Introduction
@@ -184,6 +185,9 @@ E.g. if the IP address of your node is 192.168.0.15 then open your browser at th
 - Sample SSL setup guide can be found [here](./docs/RTL_SSL_setup.md)
 - (For advanced users) A sample SSL guide to serve remote access over an encrypted Tor connection can be found [here](./docs/RTL_TOR_setup.md)
 
+### <a name="security"></a>Security
+RTL holds your node's credentials and can move funds, so please **report security vulnerabilities privately** — not in a public issue. See [SECURITY.md](../SECURITY.md) for the reporting channels (GitHub private vulnerability reporting or email), the PGP key, what is in and out of scope, and what to expect after you report.
+
 ### <a name="trouble"></a>Troubleshooting
 In case you are running into issues with the application or if you have feedback, feel free to open issues on our github repo.
-You can also reach out to us via twitter DM on [@Suheb__](https://twitter.com/Suheb__) or [@RTL_App](https://twitter.com/RTL_App). Thanks for your interest.
+You can also reach out to us via twitter DM on [@Suheb__](https://twitter.com/Suheb__) or [@RTL_App](https://twitter.com/RTL_App). Thanks for your interest. (For security vulnerabilities, please use the channels in [SECURITY.md](../SECURITY.md) rather than a DM or a public issue.)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,99 @@
+# Security Policy
+
+RTL (Ride The Lightning) is a web interface for Lightning nodes. It holds node credentials
+(LND macaroons, Core Lightning runes, Eclair API passwords) and can move funds, so we treat
+security reports seriously and ask that you report them privately.
+
+**Please do not open a public GitHub issue for a security vulnerability.**
+
+## Reporting a vulnerability
+
+Use either channel:
+
+1. **GitHub private vulnerability reporting (preferred):**
+   <https://github.com/Ride-The-Lightning/RTL/security/advisories/new>.
+   The report, the fix and any CVE are handled in the resulting private advisory thread.
+
+2. **Email:** `security@ridethelightning.info` — put **`[RTL-SEC]`** at the start of the
+   subject line. After first contact we will normally move the conversation into a private
+   GitHub advisory.
+
+   You can encrypt to the RTL release-signing key:
+
+   ```
+   3E9B D443 6C28 8039 CA82 7A92 00C9 E2BC 2E45 666F
+   ```
+
+   This is the same key that signs RTL release tags and archives, so you can verify it
+   against any past release. Note that the key's user IDs carry a GitHub `noreply` address
+   rather than the contact address above; that is expected, and the fingerprint is what to
+   check.
+
+What to include: the RTL version (or commit), the Lightning implementation (LND / Core
+Lightning / Eclair), how RTL is deployed (standalone, behind a reverse proxy, or bundled by a
+distribution such as BTCPay Server, Umbrel, RaspiBlitz, Start9, myNode, Nodl), and steps to
+reproduce.
+
+**Please do not send attachments.** Paste a proof of concept inline or link a private gist.
+Messages with attachments may be discarded unread.
+
+## What to expect
+
+- We will acknowledge your report within **72 hours** and aim to give an initial assessment
+  within a week. RTL is maintained by a small team; if we are slow, a polite follow-up on the
+  same thread is welcome.
+- We will keep you informed as the fix progresses and credit you in the release notes and
+  advisory unless you prefer otherwise.
+- Because RTL is bundled by several downstream distributions, we may coordinate the release
+  of a fix with them under embargo before publishing details. We ask reporters to allow up to
+  90 days from acknowledgement for a fix to ship before disclosing publicly, and we will tell
+  you if we need to ask for more time.
+- **There is no bug bounty.** We do not pay for reports and will not respond to payment
+  requests.
+- Reports consisting of unverified scanner or AI/LLM output without a working reproduction
+  will be closed without response.
+
+## Scope
+
+**In scope** — anything that lets an unauthenticated or lower-privileged party do what only
+the authenticated node operator should:
+
+- authentication or session bypass, including the 2FA and SSO (one-time cookie) flows
+- CSRF or other cross-origin abuse of RTL's API
+- exposure of node credentials (macaroons, runes, API passwords, config file contents,
+  backups) through the API, the UI, logs or error messages
+- config-file handling that lets an API caller read or write files RTL should not
+- path traversal, injection, or cross-site scripting in the RTL UI or backend
+- anything that lets RTL send funds, close channels or change node settings without the
+  operator's action
+
+**Out of scope** — by design or by deployment, not a vulnerability in RTL:
+
+- **`disableAuth`**: RTL can be configured with authentication turned off for vendors that
+  front it with their own authentication. With this option the vendor is responsible for
+  access control; "RTL is reachable without a password" in such a deployment is not a report.
+- **Plain HTTP**: RTL serves HTTP and expects TLS to be terminated by a reverse proxy or a
+  distribution's own stack (see the README's SSL and Tor guides). Reports that RTL "does not
+  use HTTPS" are not actionable.
+- **The `docker/` directory** is a self-contained regtest fixture for development and testing.
+  Every credential, macaroon, rune, password and key in it is throwaway and intentionally
+  committed. Secret-scanner hits on that directory are not vulnerabilities.
+- Vulnerabilities in the Lightning implementations themselves (LND, Core Lightning, Eclair),
+  in Bitcoin Core, or in downstream distributions' packaging — please report those to the
+  respective projects. If you are unsure whether the issue is in RTL or in a bundle that
+  includes it, report to us and we will help route it.
+- Denial of service that requires authenticated operator access, and issues that require a
+  compromised operator machine or browser.
+
+## Supported versions
+
+Only the **latest release** receives security fixes. RTL has a single release line and no
+backport branches; fixes ship in the next release (or a point release for severe issues) and
+downstream distributions pick them up from there. If you run RTL through a distribution,
+its update channel is how you receive fixes.
+
+## Thank you
+
+Responsible reports have made RTL safer for everyone who runs a Lightning node with it. If
+you have found something, we would rather hear about it than not — even if you are not sure
+it qualifies.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,16 +19,17 @@ Use either channel:
    subject line. After first contact we will normally move the conversation into a private
    GitHub advisory.
 
-   You can encrypt to the RTL release-signing key:
+   You can encrypt to the RTL release-signing key, which carries the
+   `security@ridethelightning.info` identity:
 
    ```
    3E9B D443 6C28 8039 CA82 7A92 00C9 E2BC 2E45 666F
    ```
 
-   This is the same key that signs RTL release tags and archives, so you can verify it
-   against any past release. Note that the key's user IDs carry a GitHub `noreply` address
-   rather than the contact address above; that is expected, and the fingerprint is what to
-   check.
+   Fetch it with `gpg --locate-key security@ridethelightning.info` (published on
+   `keys.openpgp.org`). This is the same key that signs RTL release tags and archives, so you
+   can also verify it against any past release. Please paste encrypted messages inline as an
+   armored block rather than attaching them.
 
 What to include: the RTL version (or commit), the Lightning implementation (LND / Core
 Lightning / Eclair), how RTL is deployed (standalone, behind a reverse proxy, or bundled by a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,9 @@
 # Security Policy
 
-RTL (Ride The Lightning) is a web interface for Lightning nodes. It holds node credentials
-(LND macaroons, Core Lightning runes, Eclair API passwords) and can move funds, so we treat
-security reports seriously and ask that you report them privately.
+RTL (Ride The Lightning) is a web interface for Lightning nodes. To do its job it holds
+node credentials (LND macaroons, Core Lightning runes, Eclair API passwords), so a security
+flaw in RTL could let an attacker act on the node it manages — including moving funds. We
+therefore treat security reports seriously and ask that you report them privately.
 
 **Please do not open a public GitHub issue for a security vulnerability.**
 

--- a/release-notes/Release-notes-0.15.11.md
+++ b/release-notes/Release-notes-0.15.11.md
@@ -22,7 +22,7 @@ this release should add its entry under the appropriate section below.
 ## Code Health
 
 - **Add a security policy (`SECURITY.md`) and private reporting channels**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD)).
+  ([#1677](https://github.com/Ride-The-Lightning/RTL/pull/1677)).
   RTL had no `SECURITY.md`, GitHub private vulnerability reporting was disabled, and the only
   contact path in the repo was a Twitter DM — so a researcher holding an RTL vulnerability had
   no private way to report it short of a DM or a public issue. A `SECURITY.md` at the repo root

--- a/release-notes/Release-notes-0.15.11.md
+++ b/release-notes/Release-notes-0.15.11.md
@@ -21,6 +21,20 @@ this release should add its entry under the appropriate section below.
 
 ## Code Health
 
+- **Add a security policy (`SECURITY.md`) and private reporting channels**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD)).
+  RTL had no `SECURITY.md`, GitHub private vulnerability reporting was disabled, and the only
+  contact path in the repo was a Twitter DM — so a researcher holding an RTL vulnerability had
+  no private way to report it short of a DM or a public issue. A `SECURITY.md` at the repo root
+  now names two private channels (GitHub private vulnerability reporting, and a security email
+  with a `[RTL-SEC]` subject prefix), the RTL release-signing PGP fingerprint for encrypted
+  reports, a no-attachments / no-bounty policy, an RTL-specific scope (in: auth and session
+  bypass, CSRF, credential exposure, config-file handling, traversal/XSS; out: `disableAuth`
+  deployments, plain HTTP behind a proxy, the intentionally-committed `docker/` fixture
+  credentials), a latest-release-only support statement, and a 72-hour acknowledgement
+  target. The README gains a Security section and its contact line now routes security
+  reports there instead of to Twitter.
+
 - **Batch dependency update resolving the open Dependabot security PRs**
   ([#1676](https://github.com/Ride-The-Lightning/RTL/pull/1676)).
   Dependabot had seven open security PRs against `master` (#1663, #1666, #1667, #1670,


### PR DESCRIPTION
## What

Adds a security policy to the repository and routes vulnerability reports to private channels.

RTL had no `SECURITY.md`, GitHub private vulnerability reporting was disabled, and the only contact path in the repo was a Twitter DM (`.github/README.md`, Troubleshooting) — so a researcher holding an RTL vulnerability had no private way to report it short of a DM or a public issue. RTL holds node credentials and can move funds, so that gap mattered more than it would for most projects.

## Changes

- **`SECURITY.md`** at the repo root (where GitHub — and third-party scanners that fetch `raw.githubusercontent.com/…/master/SECURITY.md` — look for it):
  - Two private reporting channels: **GitHub private vulnerability reporting** (now enabled on this repo — the `/security/advisories/new` link is live) as the preferred channel, and **`security@ridethelightning.info`** with a `[RTL-SEC]` subject prefix. The mailbox is live on the project's own domain with SPF, DKIM and DMARC (`p=reject`) verified end-to-end.
  - The RTL **release-signing PGP fingerprint** for encrypted reports, with a note that its UIDs carry a GitHub `noreply` address (that will be tidied by adding a UID; the fingerprint is what to verify).
  - **No attachments** (inline PoC or private gist), **no bug bounty**, unverified scanner/LLM output closed without response.
  - **RTL-specific scope**: in — auth/session/2FA/SSO bypass, CSRF, credential exposure via API/UI/logs/backups, config-file handling, traversal/injection/XSS, unauthorised fund movement; out — `disableAuth` deployments, plain HTTP behind a proxy, the intentionally-committed `docker/` regtest fixture credentials, bugs in LND/CLN/Eclair/bitcoind or downstream packaging, authenticated-only DoS.
  - **Supported versions: latest release only** (single release line, no backports; distributions relay fixes) and a **72-hour acknowledgement** target, with a note that fixes may be coordinated with downstream distributions under embargo.
- **`.github/README.md`**: new **Security** section (and TOC entry) pointing at `SECURITY.md`; the Troubleshooting contact line keeps Twitter for general contact but now says security reports go via `SECURITY.md`, not a DM or a public issue.
- **Release note** entry under `## Code Health` in `release-notes/Release-notes-0.15.11.md`.

No code, build, or dependency changes — `frontend/` and `backend/` are untouched.

## Verification

- `SECURITY.md` renders and GitHub picks it up as the repo's security policy (visible on the Security tab once merged to `master`).
- Private vulnerability reporting: `gh api repos/Ride-The-Lightning/RTL/private-vulnerability-reporting` → `{"enabled": true}`.
- Mailbox: Fastmail reports the domain correctly configured (MX/DKIM/SPF); a test from `security@ridethelightning.info` to Gmail shows `dkim=pass header.i=@ridethelightning.info`, `spf=pass`, `dmarc=pass (p=REJECT)`.
- `npm run lint` unaffected (Markdown only).

## Follow-ups (tracked separately, not in this PR)

- Add `security@ridethelightning.info` as a UID on the release key and publish `pgp-key.txt` + `.well-known/security.txt` on ridethelightning.info.
- Org-level default policy (`Ride-The-Lightning/.github`) so the other repos inherit it.
