### PR TITLE
Declare a minimum Node.js version

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -45,7 +45,7 @@ Docker Image: https://hub.docker.com/r/shahanafarooqui/rtl
 
 ### <a name="prereq"></a>Prerequisites
 * Functioning and synced LND lightning node.
-* Node.js, which can be downloaded [here](https://nodejs.org/en/download/)
+* Node.js v20.19 or above, which can be downloaded [here](https://nodejs.org/en/download/)
 * Recommended Browsers: Chrome, Firefox, MS Edge
 
 ### <a name="install"></a>Installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Contributions via code is the most sought after contribution and something we en
 * Pull the code from the release (current eg Release-0.12.2) branch into your local workspace via github commandline/GUI.
 
 ##### Install Dependencies
-* Assuming that nodejs (v14 & above) and npm are already installed on your local machine. Go into your RTL root folder and run `npm ci`. 
+* Assuming that nodejs (v20.19 & above) and npm are already installed on your local machine. Go into your RTL root folder and run `npm ci`. 
 * Use `npm ci --legacy-peer-deps` if there is any dependency conflict.
 * Sometimes after installation, user receives a message from npm to fix dependency vulnerability by running `npm audit fix`. Please do not follow this step as it can break some of the working RTL code on your machine. We audit and fix these vulnerabilities as soon as possible at our end.
 	

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,9 @@
         "roboto-fontface": "0.10.0",
         "ts-node": "10.9.2",
         "typescript": "5.8.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint"
   },
   "private": true,
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "dependencies": {
     "@ngrx/effects": "21.0.1",
     "@ngrx/store": "21.0.1",

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -6,7 +6,7 @@ this release should add its entry under the appropriate section below.
 ## Developer Tooling
 
 - **Declare a minimum Node.js version**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), closes
+  ([#1681](https://github.com/Ride-The-Lightning/RTL/pull/1681), closes
   [#1220](https://github.com/Ride-The-Lightning/RTL/issues/1220)).
   `package.json` carried no `engines` field, so npm installed RTL on any Node.js version
   without a word, and an unsupported runtime only showed up later as a confusing failure at

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -1,0 +1,19 @@
+# Release Notes — 0.15.12
+
+This document collects the changes that go into the 0.15.12 release. Each PR merged for
+this release should add its entry under the appropriate section below.
+
+## Developer Tooling
+
+- **Declare a minimum Node.js version**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), closes
+  [#1220](https://github.com/Ride-The-Lightning/RTL/issues/1220)).
+  `package.json` carried no `engines` field, so npm installed RTL on any Node.js version
+  without a word, and an unsupported runtime only showed up later as a confusing failure at
+  `node rtl` — as in #1220, where two users on Node 19.x/20.0.0 got `Cannot find module
+  'request-promise'` from an install that had reported success, and both were fixed by
+  dropping to Node 18.15. (The dependency behind that particular report is gone: #1638
+  replaced `request`/`request-promise` with axios in 0.15.9.) `engines.node` is now
+  `>=20.19.0`, the floor the Angular 20 toolchain requires, so npm prints an `EBADENGINE`
+  warning at install time instead. The docs said `v14 & above` in `CONTRIBUTING.md` and gave
+  no version at all in the README; both now state the same floor.


### PR DESCRIPTION
`package.json` carried no `engines` field, so npm installed RTL on any Node.js version without a word, and an unsupported runtime only surfaced later as a confusing failure at `node rtl` — as in #1220, where two users on Node 19.x/20.0.0 got `Cannot find module 'request-promise'` from an install that had reported success, and both were fixed by dropping to Node 18.15. (The dependency behind that particular report is gone: #1638 replaced `request`/`request-promise` with axios in 0.15.9.)

This sets `engines.node` to `>=20.19.0`, the floor the Angular 20 toolchain requires, so npm prints an `EBADENGINE` warning at install time instead. The docs disagreed with each other as well — `CONTRIBUTING.md` said "v14 & above" and the README gave no version at all; both now state the same floor.

### Judgment call

I used the plain `>=20.19.0` floor rather than Angular's exact `^20.19.0 || ^22.12.0 || >=24.0.0`, so odd-numbered Node lines (21, 23) don't emit a warning on every install. It still rejects the versions that broke #1220. This is advisory only — no `.npmrc` with `engine-strict`, so npm warns and continues rather than blocking anyone on a working-but-unusual Node.

### Verification

- `npm run lint` — clean
- backend tests — 40/40 pass
- frontend specs — 205/205 pass

No `frontend/` or `backend/` change: nothing under `server/` or `src/` was touched and the app version is unchanged, so neither artifact moves.
