### PR TITLE
fix(settings): allowlist payload fields and pin credential paths (#1660)

### DIFF
--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -298,6 +298,22 @@ export const updateApplicationSettings = (req, res, next) => {
             }
             if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
                 filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+                // Validate blockExplorerUrl to reject obviously malformed values. This is format
+                // validation only — it prevents non-URL strings and non-HTTP schemes from being
+                // persisted, but does not prevent SSRF (pointing at internal IPs). A user-chosen
+                // block explorer is an intended RTL feature (self-hosted mempool instances), so
+                // this field is not pinned to the server-held value.
+                if (filteredNode.settings.blockExplorerUrl !== undefined) {
+                    try {
+                        const parsed = new URL(filteredNode.settings.blockExplorerUrl);
+                        if (!['http:', 'https:'].includes(parsed.protocol)) {
+                            delete filteredNode.settings.blockExplorerUrl;
+                        }
+                    }
+                    catch {
+                        delete filteredNode.settings.blockExplorerUrl;
+                    }
+                }
             }
             return filteredNode;
         });

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -14,6 +14,29 @@ const logger = Logger;
 const common = Common;
 const wsServer = WSServer;
 const databaseService = Database;
+// The settings API echoes the whole config back, so these are the only per-node fields
+// accepted from the request body. Credential paths and runtime-only fields are not here;
+// addSecureData re-pins the credential paths for existing nodes and strips them for new
+// ones. Anything else arriving under authentication/settings is discarded.
+const NODE_SETTINGS_ALLOWLIST = [
+    'blockExplorerUrl', 'logLevel', 'logFile', 'userPersona', 'themeMode', 'themeColor',
+    'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap',
+    'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
+];
+const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
+const indexKey = (node) => +node.index;
+const isValidServerUrl = (url) => {
+    if (typeof url !== 'string' || url.trim() === '') {
+        return false;
+    }
+    try {
+        const parsed = new URL(url);
+        return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && !!parsed.hostname;
+    }
+    catch {
+        return false;
+    }
+};
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
 // otherwise set it to mempool.space
@@ -276,7 +299,19 @@ export const updateApplicationSettings = (req, res, next) => {
     const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
     try {
         const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
-        const config = common.addSecureData(JSON.parse(JSON.stringify(req.body)));
+        // Allowlist the per-node payload before addSecureData runs, so an injected credential
+        // path, runeValue/options or unknown setting can never reach the runtime config or
+        // the file — the same strategy updateNodeSettings applies to its settings merge.
+        const requestBody = JSON.parse(JSON.stringify(req.body));
+        requestBody.nodes?.forEach((node) => {
+            if (node.authentication && typeof node.authentication === 'object') {
+                node.authentication = Object.fromEntries(Object.entries(node.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
+            }
+            if (node.settings && typeof node.settings === 'object') {
+                node.settings = Object.fromEntries(Object.entries(node.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+            }
+        });
+        const config = common.addSecureData(requestBody);
         const runtimeConfig = oldConfig;
         Object.keys(config).forEach((key) => {
             if (key !== 'nodes') {
@@ -285,10 +320,10 @@ export const updateApplicationSettings = (req, res, next) => {
         });
         if (config.nodes && config.nodes.length > 0) {
             const oldNodes = (common.appConfig.nodes && common.appConfig.nodes.length > 0) ? common.appConfig.nodes : (oldConfig.nodes || []);
-            const newNodesMap = new Map(config.nodes.map((node) => [node.index, node]));
+            const newNodesMap = new Map(config.nodes.map((node) => [indexKey(node), node]));
             const updatedAndExistingNodes = oldNodes.map((oldNode) => {
-                const newNode = newNodesMap.get(oldNode.index);
-                newNodesMap.delete(oldNode.index);
+                const newNode = newNodesMap.get(indexKey(oldNode));
+                newNodesMap.delete(indexKey(oldNode));
                 const node = newNode ? {
                     ...oldNode,
                     ...newNode,
@@ -299,9 +334,22 @@ export const updateApplicationSettings = (req, res, next) => {
                     authentication: { ...(oldNode.authentication || {}) },
                     settings: { ...(oldNode.settings || {}) }
                 };
+                node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
                 return node;
             });
-            const newOnlyNodes = [...newNodesMap.values()].map((newNode) => JSON.parse(JSON.stringify(newNode)));
+            const newOnlyNodes = [...newNodesMap.values()].map((newNode) => {
+                const node = JSON.parse(JSON.stringify(newNode));
+                node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
+                return node;
+            });
+            // A node unknown to the server cannot be provisioned with credentials through this
+            // endpoint; validate the only server anchor it may carry before persisting.
+            const invalidNewNode = newOnlyNodes.find((node) => node.settings?.lnServerUrl && !isValidServerUrl(node.settings.lnServerUrl));
+            if (invalidNewNode) {
+                const errMsg = 'Invalid lnServerUrl format for node index ' + invalidNewNode.index;
+                const err = common.handleError({ statusCode: 400, message: errMsg, error: errMsg }, 'RTLConf', 'Update Default Node Error', req.session.selectedNode);
+                return res.status(err.statusCode).json({ message: err.error, error: err.error });
+            }
             runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
         }
         const newAppConfig = JSON.parse(JSON.stringify({

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -390,6 +390,20 @@ export const updateApplicationSettings = (req, res, next) => {
             logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Ignoring unknown node index in application settings; nodes cannot be added through this endpoint', data: { index: node?.index } });
             return false;
         });
+        // defaultNodeIndex and selectedNodeIndex pass TOP_LEVEL_ALLOWLIST but must carry the
+        // same known-index discipline as nodes[]: defaultNodeIndex is persisted (unlike
+        // selectedNodeIndex it is not stripped from the file config), so an unparseable value
+        // or one naming a dropped node would survive a restart. Drop any such value; the
+        // server-held current index wins (selectedNodeIndex falls back in newAppConfig).
+        for (const scalarKey of ['defaultNodeIndex', 'selectedNodeIndex']) {
+            if (requestBody[scalarKey] !== undefined) {
+                const idx = indexKey({ index: requestBody[scalarKey] });
+                if (!Number.isFinite(idx) || !knownIndexes.has(idx)) {
+                    logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: `Ignoring invalid ${scalarKey} in application settings; it must be the index of a known node`, data: { value: requestBody[scalarKey] } });
+                    delete requestBody[scalarKey];
+                }
+            }
+        }
         const config = common.addSecureData(requestBody);
         const runtimeConfig = oldConfig;
         Object.keys(config).forEach((key) => {
@@ -401,7 +415,9 @@ export const updateApplicationSettings = (req, res, next) => {
             const newNodesMap = new Map(config.nodes?.map((node) => [indexKey(node), node]) || []);
             const updatedAndExistingNodes = common.nodes.map((oldNode) => {
                 const newNode = newNodesMap.get(indexKey(oldNode));
-                newNodesMap.delete(indexKey(oldNode));
+                // Unknown-index nodes were dropped above, so every config node has a matching
+                // runtime node; a plain lookup (not a consuming delete) means a duplicate index
+                // in the runtime list cannot leave the payload hanging unmerged.
                 const node = newNode ? {
                     ...oldNode,
                     ...newNode,
@@ -416,6 +432,13 @@ export const updateApplicationSettings = (req, res, next) => {
                 return node;
             });
             runtimeConfig.nodes = updatedAndExistingNodes;
+        }
+        else {
+            // No live runtime nodes to merge with (cannot happen after a normal boot:
+            // common.nodes is built from the file at boot and only mutated in place afterwards).
+            // Record the allowlisted-and-pinned payload rather than silently reverting to the
+            // on-disk copy — the save the caller is told about must be what the file records.
+            runtimeConfig.nodes = config.nodes || [];
         }
         const newAppConfig = JSON.parse(JSON.stringify({
             ...runtimeConfig,

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -14,23 +14,31 @@ const logger = Logger;
 const common = Common;
 const wsServer = WSServer;
 const databaseService = Database;
-// The settings API echoes the whole config back, so these are the only per-node fields
-// accepted from the request body. Credential paths, server URLs and runtime-only fields
-// are not here; addSecureData re-pins them to the server-held values for existing nodes.
-// logFile is excluded because config.ts overwrites it unconditionally at boot, so
-// accepting it buys nothing. Anything else arriving under authentication/settings is
-// discarded.
+// The settings API echoes the whole config back, so these are the only per-node settings
+// fields accepted from the request body. Credential paths, server URLs, runtime-only
+// fields (options, runeValue) and logFile (config.ts overwrites it at boot) are not here;
+// addSecureData re-pins them to the server-held values for existing nodes, and strips
+// them from unknown nodes entirely. Anything else arriving under settings is discarded.
 const NODE_SETTINGS_ALLOWLIST = [
     'blockExplorerUrl', 'logLevel', 'userPersona', 'themeMode', 'themeColor',
-    'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap',
-    'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
+    'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap'
 ];
-const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
 // Top-level keys accepted on a node object. authentication and settings are themselves
 // filtered by the allowlists above; any other key (e.g. a root-level macaroonPath) is
 // discarded so it can never be persisted alongside a node in RTL-Config.json.
 const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
-const indexKey = (node) => +node.index;
+// Top-level keys accepted from the request body on the application-settings endpoint.
+// Anything not here is discarded; this prevents caller-invented keys from being persisted
+// into RTL-Config.json and re-parsed at every save and boot.
+const TOP_LEVEL_ALLOWLIST = [
+    'defaultNodeIndex', 'selectedNodeIndex', 'enable2FA', 'allowPasswordUpdate',
+    'dbDirectoryPath', 'disableAuth', 'multiPass', 'multiPassHashed', 'secret2FA',
+    'SSO', 'nodes'
+];
+const indexKey = (node) => {
+    const val = node?.index;
+    return (val !== undefined && val !== null) ? +val : undefined;
+};
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
 // otherwise set it to mempool.space
@@ -234,47 +242,20 @@ export const updateNodeSettings = (req, res, next) => {
         const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
         const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
         if (node && node.settings) {
-            // channelBackupPath anchors getFile's containment root and is documented as a
-            // config-file-only setting; accepting it from the API would let the caller being
-            // contained choose the containment base. Pin it to the server-held value.
-            const serverChannelBackupPath = node.settings.channelBackupPath;
-            node.settings = { ...node.settings, ...req.body.settings };
-            node.settings.channelBackupPath = serverChannelBackupPath;
-            if (node.authentication && req.body.authentication) {
-                if (req.body.authentication.boltzMacaroonPath) {
-                    node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-                }
-                else {
-                    delete node.authentication.boltzMacaroonPath;
-                }
-                if (req.body.authentication.swapMacaroonPath) {
-                    node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-                }
-                else {
-                    delete node.authentication.swapMacaroonPath;
-                }
-            }
+            // Allowlist incoming settings to the same set updateApplicationSettings uses, then
+            // pin file-read and credentialed-request anchors so the caller cannot re-point
+            // credential file reads (bitcoindConfigPath), the channel-backup containment root
+            // (channelBackupPath), or credentialed HTTP destinations (lnServerUrl, swapServerUrl,
+            // boltzServerUrl). These fields are not in NODE_SETTINGS_ALLOWLIST, so the
+            // allowlisting above already strips them; the runtime merge below pins them too.
+            const allowedSettings = Object.fromEntries(Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+            node.settings = { ...node.settings, ...allowedSettings };
         }
         fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
         const selectedNode = common.findNode(req.session.selectedNode.index);
         if (selectedNode && selectedNode.settings) {
-            const serverChannelBackupPath = selectedNode.settings.channelBackupPath;
-            selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
-            selectedNode.settings.channelBackupPath = serverChannelBackupPath;
-            if (selectedNode.authentication && req.body.authentication) {
-                if (req.body.authentication.boltzMacaroonPath) {
-                    selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-                }
-                else {
-                    delete selectedNode.authentication.boltzMacaroonPath;
-                }
-                if (req.body.authentication.swapMacaroonPath) {
-                    selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-                }
-                else {
-                    delete selectedNode.authentication.swapMacaroonPath;
-                }
-            }
+            const allowedSettings = Object.fromEntries(Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+            selectedNode.settings = { ...selectedNode.settings, ...allowedSettings };
             common.replaceNode(req, selectedNode);
         }
         let responseNode = JSON.parse(JSON.stringify(common.selectedNode));
@@ -295,15 +276,25 @@ export const updateApplicationSettings = (req, res, next) => {
         const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
         // Allowlist the per-node payload before addSecureData runs, so an injected credential
         // path, runeValue/options, unknown setting or unknown top-level node key (such as a
-        // root-level macaroonPath) can never reach the runtime config or the file — the same
-        // strategy updateNodeSettings applies to its settings merge.
+        // root-level macaroonPath) can never reach the runtime config or the file.
         const requestBody = JSON.parse(JSON.stringify(req.body));
+        // Filter top-level keys to prevent caller-invented fields from being persisted into
+        // RTL-Config.json and re-parsed at every save and boot.
+        for (const key of Object.keys(requestBody)) {
+            if (!TOP_LEVEL_ALLOWLIST.includes(key)) {
+                delete requestBody[key];
+            }
+        }
         requestBody.nodes = requestBody.nodes?.map((node) => {
             const filteredNode = (node && typeof node === 'object') ?
                 Object.fromEntries(Object.entries(node).filter(([key]) => NODE_ALLOWLIST.includes(key))) :
                 node;
-            if (filteredNode && filteredNode.authentication && typeof filteredNode.authentication === 'object') {
-                filteredNode.authentication = Object.fromEntries(Object.entries(filteredNode.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
+            // Strip authentication entirely: addSecureData re-pins all credential paths from
+            // the server-held node, so any caller-supplied authentication value (runeValue,
+            // options, macaroonPath, etc.) is dead weight that must not reach the runtime config
+            // or the file.
+            if (filteredNode && typeof filteredNode === 'object') {
+                delete filteredNode.authentication;
             }
             if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
                 filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
@@ -315,9 +306,10 @@ export const updateApplicationSettings = (req, res, next) => {
         // file and loaded back into the runtime nodes at the next restart. Drop any node whose
         // index the server does not already know — addSecureData and the merge below answer
         // known-vs-unknown from this same runtime list.
-        const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)) || []);
+        const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)).filter((idx) => Number.isFinite(idx)) || []);
         requestBody.nodes = requestBody.nodes?.filter((node) => {
-            if (knownIndexes.has(indexKey(node))) {
+            const idx = indexKey(node);
+            if (Number.isFinite(idx) && knownIndexes.has(idx)) {
                 return true;
             }
             logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Ignoring unknown node index in application settings; nodes cannot be added through this endpoint', data: { index: node?.index } });
@@ -330,8 +322,8 @@ export const updateApplicationSettings = (req, res, next) => {
                 runtimeConfig[key] = config[key];
             }
         });
-        if (config.nodes && config.nodes.length > 0) {
-            const newNodesMap = new Map(config.nodes.map((node) => [indexKey(node), node]));
+        if (common.appConfig.nodes && common.appConfig.nodes.length > 0) {
+            const newNodesMap = new Map(config.nodes?.map((node) => [indexKey(node), node]) || []);
             const updatedAndExistingNodes = common.appConfig.nodes.map((oldNode) => {
                 const newNode = newNodesMap.get(indexKey(oldNode));
                 newNodesMap.delete(indexKey(oldNode));

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -15,29 +15,98 @@ const common = Common;
 const wsServer = WSServer;
 const databaseService = Database;
 // The settings API echoes the whole config back, so these are the only per-node settings
-// fields accepted from the request body. Credential paths, server URLs, runtime-only
-// fields (options, runeValue) and logFile (config.ts overwrites it at boot) are not here;
-// addSecureData re-pins them to the server-held values for existing nodes, and strips
-// them from unknown nodes entirely. Anything else arriving under settings is discarded.
+// fields accepted from the application-settings request body. Credential paths, LN server
+// URLs, runtime-only fields (options, runeValue) and logFile (config.ts overwrites it at
+// boot) are not here; addSecureData re-pins credential paths and LN server URLs to the
+// server-held values for existing nodes, and strips them from unknown nodes entirely.
+// Anything else arriving under settings is discarded.
 const NODE_SETTINGS_ALLOWLIST = [
     'blockExplorerUrl', 'logLevel', 'userPersona', 'themeMode', 'themeColor',
     'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap'
 ];
+// Loop and Boltz server URLs are service settings, edited from the node-config Services
+// page through the node-settings endpoint only (their macaroon paths are edited the same
+// way). They are deliberately not in NODE_SETTINGS_ALLOWLIST: the application-settings
+// endpoint re-pins them, so accepting them there would be dead weight.
+const NODE_SERVICE_SETTINGS_ALLOWLIST = ['swapServerUrl', 'boltzServerUrl'];
 // Top-level keys accepted on a node object. authentication and settings are themselves
-// filtered by the allowlists above; any other key (e.g. a root-level macaroonPath) is
-// discarded so it can never be persisted alongside a node in RTL-Config.json.
-const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
+// filtered by the allowlists above; lnImplementation is deliberately absent — it selects
+// which credential the server attaches to the (pinned) LN server URL, so letting the
+// caller rewrite it would silently break the node connection after the next boot. Any
+// other key (e.g. a root-level macaroonPath) is discarded so it can never be persisted
+// alongside a node in RTL-Config.json.
+const NODE_ALLOWLIST = ['index', 'lnNode', 'authentication', 'settings'];
 // Top-level keys accepted from the request body on the application-settings endpoint.
 // Anything not here is discarded; this prevents caller-invented keys from being persisted
-// into RTL-Config.json and re-parsed at every save and boot.
+// into RTL-Config.json and re-parsed at every save and boot. multiPass is not accepted:
+// the plaintext password is hashed into multiPassHashed at boot and never sent back to
+// the client, so no honest flow supplies it (addSecureData also pins it defensively).
 const TOP_LEVEL_ALLOWLIST = [
     'defaultNodeIndex', 'selectedNodeIndex', 'enable2FA', 'allowPasswordUpdate',
-    'dbDirectoryPath', 'disableAuth', 'multiPass', 'multiPassHashed', 'secret2FA',
+    'dbDirectoryPath', 'disableAuth', 'multiPassHashed', 'secret2FA',
     'SSO', 'nodes'
 ];
 const indexKey = (node) => {
     const val = node?.index;
-    return (val !== undefined && val !== null) ? +val : undefined;
+    if (typeof val === 'number') {
+        return val;
+    }
+    // Empty or whitespace-only strings must not coerce to 0 (node 0 is a real node).
+    if (typeof val === 'string' && val.trim() !== '') {
+        return +val;
+    }
+    return undefined;
+};
+// Reject malformed URLs and non-HTTP schemes. User-chosen block explorers and Loop/Boltz
+// servers are intended RTL features (self-hosted instances), so this is format validation
+// only — it does not prevent a caller from pointing at an internal host.
+const isValidHttpUrl = (value) => {
+    if (typeof value !== 'string') {
+        return false;
+    }
+    try {
+        const parsed = new URL(value);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    }
+    catch {
+        return false;
+    }
+};
+// Allowlist a settings payload and drop URL-valued fields that fail isValidHttpUrl.
+// The node-settings endpoint additionally accepts the Loop/Boltz service URLs
+// (allowServiceUrls); the application-settings endpoint does not. Both handlers share this
+// so a malformed blockExplorerUrl/swapServerUrl/boltzServerUrl can never reach the
+// outbound request built from the live node's settings.
+const filterNodeSettings = (settings, allowServiceUrls = false) => {
+    const allowed = Object.fromEntries(Object.entries(settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key) ||
+        (allowServiceUrls && NODE_SERVICE_SETTINGS_ALLOWLIST.includes(key))));
+    for (const urlKey of ['blockExplorerUrl', 'swapServerUrl', 'boltzServerUrl']) {
+        if (allowed[urlKey] !== undefined && !isValidHttpUrl(allowed[urlKey])) {
+            delete allowed[urlKey];
+        }
+    }
+    return allowed;
+};
+// The Loop/Boltz service macaroon paths are edited from the Services page and remain
+// writable through the node-settings endpoint; an absent or empty value clears the field.
+// The LN credential paths (macaroonPath, runePath, lnApiPassword, configPath) are not
+// handled here and can never be set through this endpoint.
+const applyWritableServiceMacaroonPaths = (target, source) => {
+    if (!target || !source) {
+        return;
+    }
+    if (source.boltzMacaroonPath) {
+        target.boltzMacaroonPath = source.boltzMacaroonPath;
+    }
+    else {
+        delete target.boltzMacaroonPath;
+    }
+    if (source.swapMacaroonPath) {
+        target.swapMacaroonPath = source.swapMacaroonPath;
+    }
+    else {
+        delete target.swapMacaroonPath;
+    }
 };
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
@@ -116,7 +185,11 @@ export const getFile = (req, res, next) => {
         file = resolved;
     }
     else {
-        file = channelBackupPath + sep + 'channel-' + req.query.channel?.replace(':', '-') + '.bak';
+        // The channel value is concatenated into the backup file name; neutralize path
+        // separators and '..' so a crafted channel cannot walk out of the backup directory
+        // (the UI only ever sends a channel point, "funding_txid:output").
+        const channel = req.query.channel?.replace(/[:/\\]/g, '-').replace(/\.\./g, '-');
+        file = channelBackupPath + sep + 'channel-' + channel + '.bak';
     }
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'Channel Point', data: req.query.channel });
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'File Path', data: file });
@@ -242,20 +315,20 @@ export const updateNodeSettings = (req, res, next) => {
         const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
         const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
         if (node && node.settings) {
-            // Allowlist incoming settings to the same set updateApplicationSettings uses, then
-            // pin file-read and credentialed-request anchors so the caller cannot re-point
-            // credential file reads (bitcoindConfigPath), the channel-backup containment root
-            // (channelBackupPath), or credentialed HTTP destinations (lnServerUrl, swapServerUrl,
-            // boltzServerUrl). These fields are not in NODE_SETTINGS_ALLOWLIST, so the
-            // allowlisting above already strips them; the runtime merge below pins them too.
-            const allowedSettings = Object.fromEntries(Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
-            node.settings = { ...node.settings, ...allowedSettings };
+            // Allowlist incoming settings to the same set updateApplicationSettings uses, plus
+            // the Loop/Boltz service URLs (swapServerUrl, boltzServerUrl), which the Services
+            // page edits; URL fields get the same http/https format validation. Credential and
+            // LN server anchors — bitcoindConfigPath, channelBackupPath, lnServerUrl, logFile —
+            // stay out of the allowlist, so they are neither edited here nor persisted.
+            node.settings = { ...node.settings, ...filterNodeSettings(req.body.settings, true) };
+            // Loop/Boltz macaroon paths are a Services-page feature and stay editable here.
+            applyWritableServiceMacaroonPaths(node.authentication, req.body.authentication);
         }
         fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
         const selectedNode = common.findNode(req.session.selectedNode.index);
         if (selectedNode && selectedNode.settings) {
-            const allowedSettings = Object.fromEntries(Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
-            selectedNode.settings = { ...selectedNode.settings, ...allowedSettings };
+            selectedNode.settings = { ...selectedNode.settings, ...filterNodeSettings(req.body.settings, true) };
+            applyWritableServiceMacaroonPaths(selectedNode.authentication, req.body.authentication);
             common.replaceNode(req, selectedNode);
         }
         let responseNode = JSON.parse(JSON.stringify(common.selectedNode));
@@ -297,32 +370,18 @@ export const updateApplicationSettings = (req, res, next) => {
                 delete filteredNode.authentication;
             }
             if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
-                filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
-                // Validate blockExplorerUrl to reject obviously malformed values. This is format
-                // validation only — it prevents non-URL strings and non-HTTP schemes from being
-                // persisted, but does not prevent SSRF (pointing at internal IPs). A user-chosen
-                // block explorer is an intended RTL feature (self-hosted mempool instances), so
-                // this field is not pinned to the server-held value.
-                if (filteredNode.settings.blockExplorerUrl !== undefined) {
-                    try {
-                        const parsed = new URL(filteredNode.settings.blockExplorerUrl);
-                        if (!['http:', 'https:'].includes(parsed.protocol)) {
-                            delete filteredNode.settings.blockExplorerUrl;
-                        }
-                    }
-                    catch {
-                        delete filteredNode.settings.blockExplorerUrl;
-                    }
-                }
+                filteredNode.settings = filterNodeSettings(filteredNode.settings);
             }
             return filteredNode;
         });
         // Nodes are never provisioned through this endpoint: there is no add-node UI for it,
         // and a caller-supplied credential path or server URL would be persisted to the config
         // file and loaded back into the runtime nodes at the next restart. Drop any node whose
-        // index the server does not already know — addSecureData and the merge below answer
-        // known-vs-unknown from this same runtime list.
-        const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)).filter((idx) => Number.isFinite(idx)) || []);
+        // index the server does not already know. Known-vs-unknown resolves against the single
+        // authoritative runtime list (common.nodes) — the same list addSecureData pins from and
+        // updateNodeSettings mutates in place. common.appConfig.nodes is a fresh clone after
+        // every save and goes stale, so resolving against it would misclassify nodes.
+        const knownIndexes = new Set(common.nodes?.map((node) => indexKey(node)).filter((idx) => Number.isFinite(idx)) || []);
         requestBody.nodes = requestBody.nodes?.filter((node) => {
             const idx = indexKey(node);
             if (Number.isFinite(idx) && knownIndexes.has(idx)) {
@@ -338,9 +397,9 @@ export const updateApplicationSettings = (req, res, next) => {
                 runtimeConfig[key] = config[key];
             }
         });
-        if (common.appConfig.nodes && common.appConfig.nodes.length > 0) {
+        if (common.nodes && common.nodes.length > 0) {
             const newNodesMap = new Map(config.nodes?.map((node) => [indexKey(node), node]) || []);
-            const updatedAndExistingNodes = common.appConfig.nodes.map((oldNode) => {
+            const updatedAndExistingNodes = common.nodes.map((oldNode) => {
                 const newNode = newNodesMap.get(indexKey(oldNode));
                 newNodesMap.delete(indexKey(oldNode));
                 const node = newNode ? {

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -15,11 +15,13 @@ const common = Common;
 const wsServer = WSServer;
 const databaseService = Database;
 // The settings API echoes the whole config back, so these are the only per-node fields
-// accepted from the request body. Credential paths and runtime-only fields are not here;
-// addSecureData re-pins the credential paths for existing nodes and strips them for new
-// ones. Anything else arriving under authentication/settings is discarded.
+// accepted from the request body. Credential paths, server URLs and runtime-only fields
+// are not here; addSecureData re-pins them to the server-held values for existing nodes.
+// logFile is excluded because config.ts overwrites it unconditionally at boot, so
+// accepting it buys nothing. Anything else arriving under authentication/settings is
+// discarded.
 const NODE_SETTINGS_ALLOWLIST = [
-    'blockExplorerUrl', 'logLevel', 'logFile', 'userPersona', 'themeMode', 'themeColor',
+    'blockExplorerUrl', 'logLevel', 'userPersona', 'themeMode', 'themeColor',
     'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap',
     'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
 ];
@@ -29,18 +31,6 @@ const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
 // discarded so it can never be persisted alongside a node in RTL-Config.json.
 const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
 const indexKey = (node) => +node.index;
-const isValidServerUrl = (url) => {
-    if (typeof url !== 'string' || url.trim() === '') {
-        return false;
-    }
-    try {
-        const parsed = new URL(url);
-        return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && !!parsed.hostname;
-    }
-    catch {
-        return false;
-    }
-};
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
 // otherwise set it to mempool.space
@@ -320,6 +310,19 @@ export const updateApplicationSettings = (req, res, next) => {
             }
             return filteredNode;
         });
+        // Nodes are never provisioned through this endpoint: there is no add-node UI for it,
+        // and a caller-supplied credential path or server URL would be persisted to the config
+        // file and loaded back into the runtime nodes at the next restart. Drop any node whose
+        // index the server does not already know — addSecureData and the merge below answer
+        // known-vs-unknown from this same runtime list.
+        const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)) || []);
+        requestBody.nodes = requestBody.nodes?.filter((node) => {
+            if (knownIndexes.has(indexKey(node))) {
+                return true;
+            }
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Ignoring unknown node index in application settings; nodes cannot be added through this endpoint', data: { index: node?.index } });
+            return false;
+        });
         const config = common.addSecureData(requestBody);
         const runtimeConfig = oldConfig;
         Object.keys(config).forEach((key) => {
@@ -328,9 +331,8 @@ export const updateApplicationSettings = (req, res, next) => {
             }
         });
         if (config.nodes && config.nodes.length > 0) {
-            const oldNodes = (common.appConfig.nodes && common.appConfig.nodes.length > 0) ? common.appConfig.nodes : (oldConfig.nodes || []);
             const newNodesMap = new Map(config.nodes.map((node) => [indexKey(node), node]));
-            const updatedAndExistingNodes = oldNodes.map((oldNode) => {
+            const updatedAndExistingNodes = common.appConfig.nodes.map((oldNode) => {
                 const newNode = newNodesMap.get(indexKey(oldNode));
                 newNodesMap.delete(indexKey(oldNode));
                 const node = newNode ? {
@@ -346,20 +348,7 @@ export const updateApplicationSettings = (req, res, next) => {
                 node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
                 return node;
             });
-            const newOnlyNodes = [...newNodesMap.values()].map((newNode) => {
-                const node = JSON.parse(JSON.stringify(newNode));
-                node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
-                return node;
-            });
-            // A node unknown to the server cannot be provisioned with credentials through this
-            // endpoint; validate the only server anchor it may carry before persisting.
-            const invalidNewNode = newOnlyNodes.find((node) => node.settings?.lnServerUrl && !isValidServerUrl(node.settings.lnServerUrl));
-            if (invalidNewNode) {
-                const errMsg = 'Invalid lnServerUrl format for node index ' + invalidNewNode.index;
-                const err = common.handleError({ statusCode: 400, message: errMsg, error: errMsg }, 'RTLConf', 'Update Default Node Error', req.session.selectedNode);
-                return res.status(err.statusCode).json({ message: err.error, error: err.error });
-            }
-            runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
+            runtimeConfig.nodes = updatedAndExistingNodes;
         }
         const newAppConfig = JSON.parse(JSON.stringify({
             ...runtimeConfig,

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -24,6 +24,10 @@ const NODE_SETTINGS_ALLOWLIST = [
     'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
 ];
 const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
+// Top-level keys accepted on a node object. authentication and settings are themselves
+// filtered by the allowlists above; any other key (e.g. a root-level macaroonPath) is
+// discarded so it can never be persisted alongside a node in RTL-Config.json.
+const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
 const indexKey = (node) => +node.index;
 const isValidServerUrl = (url) => {
     if (typeof url !== 'string' || url.trim() === '') {
@@ -300,16 +304,21 @@ export const updateApplicationSettings = (req, res, next) => {
     try {
         const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
         // Allowlist the per-node payload before addSecureData runs, so an injected credential
-        // path, runeValue/options or unknown setting can never reach the runtime config or
-        // the file — the same strategy updateNodeSettings applies to its settings merge.
+        // path, runeValue/options, unknown setting or unknown top-level node key (such as a
+        // root-level macaroonPath) can never reach the runtime config or the file — the same
+        // strategy updateNodeSettings applies to its settings merge.
         const requestBody = JSON.parse(JSON.stringify(req.body));
-        requestBody.nodes?.forEach((node) => {
-            if (node.authentication && typeof node.authentication === 'object') {
-                node.authentication = Object.fromEntries(Object.entries(node.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
+        requestBody.nodes = requestBody.nodes?.map((node) => {
+            const filteredNode = (node && typeof node === 'object') ?
+                Object.fromEntries(Object.entries(node).filter(([key]) => NODE_ALLOWLIST.includes(key))) :
+                node;
+            if (filteredNode && filteredNode.authentication && typeof filteredNode.authentication === 'object') {
+                filteredNode.authentication = Object.fromEntries(Object.entries(filteredNode.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
             }
-            if (node.settings && typeof node.settings === 'object') {
-                node.settings = Object.fromEntries(Object.entries(node.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+            if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
+                filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
             }
+            return filteredNode;
         });
         const config = common.addSecureData(requestBody);
         const runtimeConfig = oldConfig;

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -108,22 +108,21 @@ const applyWritableServiceMacaroonPaths = (target, source) => {
         delete target.swapMacaroonPath;
     }
 };
-// Set local block explorer URL after first API call
-// if the selected node block explorer has working REST API suite
-// otherwise set it to mempool.space
-let blockExplorerUrl = '';
+// Remember, per node, which block explorer answered the last call: the node's own once
+// its REST API suite has worked, mempool.space after a failure. Keyed by node index so one
+// node's explorer (or its fallback) is never reused for another node or session.
+const explorerUrlByNode = new Map();
+const explorerBaseUrl = (req) => explorerUrlByNode.get(req.session.selectedNode.index) || req.session.selectedNode.settings.blockExplorerUrl;
 export const getExplorerFeesRecommended = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting Recommended Fee Rates..' });
-    options.url = (blockExplorerUrl === '') ?
-        req.session.selectedNode.settings.blockExplorerUrl + '/api/v1/fees/recommended' :
-        blockExplorerUrl + '/api/v1/fees/recommended';
+    options.url = explorerBaseUrl(req) + '/api/v1/fees/recommended';
     request(options).then((body) => {
-        blockExplorerUrl = req.session.selectedNode.settings.blockExplorerUrl;
+        explorerUrlByNode.set(req.session.selectedNode.index, req.session.selectedNode.settings.blockExplorerUrl);
         logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Recommended Fee Rates Received', data: body });
         res.status(200).json(JSON.parse(body));
     }).catch((errRes) => {
-        blockExplorerUrl = 'https://mempool.space';
-        options.url = blockExplorerUrl + '/api/v1/fees/recommended';
+        explorerUrlByNode.set(req.session.selectedNode.index, 'https://mempool.space');
+        options.url = 'https://mempool.space/api/v1/fees/recommended';
         return request(options).then((body) => {
             logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Recommended Fee Rates Received', data: body });
             res.status(200).json(JSON.parse(body));
@@ -136,16 +135,17 @@ export const getExplorerFeesRecommended = (req, res, next) => {
 };
 export const getExplorerTransaction = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting Transaction From Block Explorer..' });
-    options.url = (blockExplorerUrl === '') ?
-        req.session.selectedNode.settings.blockExplorerUrl + '/api/tx/' + req.params.txid :
-        blockExplorerUrl + '/api/tx/' + req.params.txid;
+    // The txid is caller-supplied and the explorer's reply is returned to the caller, so
+    // encode it: it must stay a single path segment and cannot carry a query or a '..'.
+    const txid = encodeURIComponent(req.params.txid);
+    options.url = explorerBaseUrl(req) + '/api/tx/' + txid;
     request(options).then((body) => {
-        blockExplorerUrl = req.session.selectedNode.settings.blockExplorerUrl;
+        explorerUrlByNode.set(req.session.selectedNode.index, req.session.selectedNode.settings.blockExplorerUrl);
         logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Transaction From Block Explorer Received', data: body });
         res.status(200).json(JSON.parse(body));
     }).catch((errRes) => {
-        blockExplorerUrl = 'https://mempool.space';
-        options.url = blockExplorerUrl + '/api/tx/' + req.params.txid;
+        explorerUrlByNode.set(req.session.selectedNode.index, 'https://mempool.space');
+        options.url = 'https://mempool.space/api/tx/' + txid;
         return request(options).then((body) => {
             logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Transaction From Block Explorer Received', data: body });
             res.status(200).json(JSON.parse(body));
@@ -171,6 +171,14 @@ export const getCurrencyRates = (req, res, next) => {
 export const getFile = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting File..' });
     const channelBackupPath = req.session.selectedNode.settings.channelBackupPath;
+    // config.ts always assigns a backup path at boot, but resolve('') is the working
+    // directory, so an unset root would silently make the install tree the containment
+    // root. Refuse rather than read from there.
+    if (typeof channelBackupPath !== 'string' || channelBackupPath.trim() === '') {
+        const errMsg = 'Reading File Error';
+        const err = common.handleError({ statusCode: 500, message: errMsg, error: 'Channel backup path is not configured' }, 'RTLConf', errMsg, req.session.selectedNode);
+        return res.status(err.statusCode).json({ message: err.message, error: err.error });
+    }
     let file = '';
     if (req.query.path) {
         // The UI only ever requests channel backup files; contain caller paths to the node's
@@ -185,10 +193,17 @@ export const getFile = (req, res, next) => {
         file = resolved;
     }
     else {
+        // Express parses a repeated key into an array and a bracketed key into an object;
+        // reject anything but a string rather than throwing from the sanitizer below.
+        if (typeof req.query.channel !== 'string') {
+            const errMsg = 'Reading File Error';
+            const err = common.handleError({ statusCode: 400, message: errMsg, error: 'Channel must be a string' }, 'RTLConf', errMsg, req.session.selectedNode);
+            return res.status(err.statusCode).json({ message: err.message, error: err.error });
+        }
         // The channel value is concatenated into the backup file name; neutralize path
         // separators and '..' so a crafted channel cannot walk out of the backup directory
         // (the UI only ever sends a channel point, "funding_txid:output").
-        const channel = req.query.channel?.replace(/[:/\\]/g, '-').replace(/\.\./g, '-');
+        const channel = req.query.channel.replace(/[:/\\]/g, '-').replace(/\.\./g, '-');
         file = channelBackupPath + sep + 'channel-' + channel + '.bak';
     }
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'Channel Point', data: req.query.channel });
@@ -253,7 +268,8 @@ export const updateSelectedNode = (req, res, next) => {
             databaseService.loadDatabase(req.session);
         }
     }
-    blockExplorerUrl = '';
+    // Retry the node's own explorer on the next call after a switch, as before.
+    explorerUrlByNode.delete(req.session.selectedNode.index);
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Selected Node Updated To ' + req.session.selectedNode.lnNode || '' });
     res.status(200).json(common.removeAuthSecureData(JSON.parse(JSON.stringify(req.session.selectedNode))));
 };
@@ -418,11 +434,22 @@ export const updateApplicationSettings = (req, res, next) => {
                 // Unknown-index nodes were dropped above, so every config node has a matching
                 // runtime node; a plain lookup (not a consuming delete) means a duplicate index
                 // in the runtime list cannot leave the payload hanging unmerged.
+                if (newNode) {
+                    // Publish the allowlisted edit to the live runtime node as well: common.nodes is
+                    // what the session, the explorer requests and the next save read from, so a
+                    // setting left only in common.appConfig would take effect after a restart and be
+                    // reverted by the following save. Credential anchors in newNode.settings were
+                    // pinned from this very node by addSecureData, so this cannot move them.
+                    if (newNode.lnNode !== undefined) {
+                        oldNode.lnNode = newNode.lnNode;
+                    }
+                    oldNode.settings = { ...oldNode.settings, ...(newNode.settings || {}) };
+                }
                 const node = newNode ? {
                     ...oldNode,
                     ...newNode,
                     authentication: { ...(oldNode.authentication || {}), ...(newNode.authentication || {}) },
-                    settings: { ...(oldNode.settings || {}), ...(newNode.settings || {}) }
+                    settings: { ...(oldNode.settings || {}) }
                 } : {
                     ...oldNode,
                     authentication: { ...(oldNode.authentication || {}) },
@@ -433,13 +460,11 @@ export const updateApplicationSettings = (req, res, next) => {
             });
             runtimeConfig.nodes = updatedAndExistingNodes;
         }
-        else {
-            // No live runtime nodes to merge with (cannot happen after a normal boot:
-            // common.nodes is built from the file at boot and only mutated in place afterwards).
-            // Record the allowlisted-and-pinned payload rather than silently reverting to the
-            // on-disk copy — the save the caller is told about must be what the file records.
-            runtimeConfig.nodes = config.nodes || [];
-        }
+        // Otherwise there are no live runtime nodes to merge against (cannot happen after a
+        // normal boot: common.nodes is built from the file at boot and only mutated in place
+        // afterwards). knownIndexes was empty too, so every payload node was dropped above and
+        // there is nothing to record; runtimeConfig keeps the on-disk node list untouched
+        // rather than overwriting it with an empty array.
         const newAppConfig = JSON.parse(JSON.stringify({
             ...runtimeConfig,
             selectedNodeIndex: config.selectedNodeIndex !== undefined ?
@@ -469,12 +494,14 @@ export const updateApplicationSettings = (req, res, next) => {
         // Persist atomically (temp file + rename, so a mid-write failure cannot truncate the
         // config) and only then adopt the new runtime config, so a failed write leaves the
         // process on the old one. The temp file inherits the existing file's mode so a
-        // hardened 0600 is not silently downgraded; a fresh file gets 0600. Symlinks and
+        // hardened 0600 is not silently downgraded; a fresh file gets 0600. The temp file is
+        // created 0600 so the secrets it carries (2FA seed, password hash, credential paths)
+        // are never world-readable, even for the instant before chmod. Symlinks and
         // single-file bind mounts cannot be renamed over — fall back to an in-place write,
         // which preserves inode and mode.
         const tempConfigFile = RTLConfFile + '.tmp';
         try {
-            fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+            fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), { encoding: 'utf-8', mode: 0o600 });
             fs.chmodSync(tempConfigFile, fs.existsSync(RTLConfFile) ? (fs.statSync(RTLConfFile).mode & 0o777) : 0o600);
             fs.renameSync(tempConfigFile, RTLConfFile);
         }

--- a/backend/controllers/shared/RTLConf.js
+++ b/backend/controllers/shared/RTLConf.js
@@ -410,13 +410,18 @@ export const updateApplicationSettings = (req, res, next) => {
         // same known-index discipline as nodes[]: defaultNodeIndex is persisted (unlike
         // selectedNodeIndex it is not stripped from the file config), so an unparseable value
         // or one naming a dropped node would survive a restart. Drop any such value; the
-        // server-held current index wins (selectedNodeIndex falls back in newAppConfig).
+        // server-held current index wins (selectedNodeIndex falls back in newAppConfig). A
+        // valid value is stored as a number: every consumer compares strictly (findNode,
+        // getApplicationSettings), so a persisted string would match no node after a restart.
         for (const scalarKey of ['defaultNodeIndex', 'selectedNodeIndex']) {
             if (requestBody[scalarKey] !== undefined) {
                 const idx = indexKey({ index: requestBody[scalarKey] });
                 if (!Number.isFinite(idx) || !knownIndexes.has(idx)) {
                     logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: `Ignoring invalid ${scalarKey} in application settings; it must be the index of a known node`, data: { value: requestBody[scalarKey] } });
                     delete requestBody[scalarKey];
+                }
+                else {
+                    requestBody[scalarKey] = idx;
                 }
             }
         }

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -164,6 +164,10 @@ export class CommonService {
                     node.authentication.runePath = runtimeNode.authentication?.runePath;
                     node.authentication.lnApiPassword = runtimeNode.authentication?.lnApiPassword;
                     node.authentication.configPath = runtimeNode.authentication?.configPath;
+                    // runeValue is CLN's live rune (setOptions sends it verbatim as the request
+                    // header with no file read), so it is pinned like the other credentials even
+                    // though the persisted file is stripped of it at save time.
+                    node.authentication.runeValue = runtimeNode.authentication?.runeValue;
                     // swap/boltz macaroon paths are read from disk and sent as auth headers to their
                     // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
                     // like every other credential anchor here; this endpoint cannot edit them, the
@@ -186,6 +190,8 @@ export class CommonService {
                         delete node.authentication.runePath;
                         delete node.authentication.lnApiPassword;
                         delete node.authentication.configPath;
+                        // The live rune value must be stripped too, not just the path pointer.
+                        delete node.authentication.runeValue;
                         delete node.authentication.swapMacaroonPath;
                         delete node.authentication.boltzMacaroonPath;
                     }

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -125,39 +125,47 @@ export class CommonService {
             config.enable2FA = !!config.secret2FA;
             // Node indexes arrive as strings in JSON payloads; normalize them to numbers so the
             // map lookups below (and the persisted config) use a single representation.
-            const indexKey = (node) => +node.index;
-            const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [indexKey(node), node]) || []);
+            const indexKey = (node) => {
+                const val = node?.index;
+                return (val !== undefined && val !== null) ? +val : undefined;
+            };
+            // Pin from the authoritative runtime node list (this.nodes), not this.appConfig.nodes.
+            // After the first application-settings save, common.appConfig is a fresh clone while
+            // common.nodes retains the live state (options, runeValue) and is updated in place by
+            // updateNodeSettings via replaceNode — so pinning from appConfig.nodes would silently
+            // revert a user's legitimate Node Settings edit to the previous value.
+            const runtimeNodes = new Map(this.nodes?.map((node) => [indexKey(node), node]) || []);
             config.nodes?.forEach((node) => {
                 node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
-                const appConfigNode = appConfigNodes.get(indexKey(node));
-                if (appConfigNode) {
+                const runtimeNode = runtimeNodes.get(indexKey(node));
+                if (runtimeNode) {
                     // Existing node: pin credential paths and credentialed-request anchors to the
                     // server-held values. The client only ever echoes these (removeSecureData strips
                     // the credentials, so a client cannot have a legitimate new value for them), and
                     // accepting them would let an authenticated caller re-point credential file reads
                     // or credentialed requests — the confused-deputy vector this pins down.
                     node.authentication = node.authentication || {};
-                    node.authentication.macaroonPath = appConfigNode.authentication?.macaroonPath;
-                    node.authentication.runePath = appConfigNode.authentication?.runePath;
-                    node.authentication.lnApiPassword = appConfigNode.authentication?.lnApiPassword;
-                    node.authentication.configPath = appConfigNode.authentication?.configPath;
+                    node.authentication.macaroonPath = runtimeNode.authentication?.macaroonPath;
+                    node.authentication.runePath = runtimeNode.authentication?.runePath;
+                    node.authentication.lnApiPassword = runtimeNode.authentication?.lnApiPassword;
+                    node.authentication.configPath = runtimeNode.authentication?.configPath;
                     // swap/boltz macaroon paths are read from disk and sent as auth headers to their
                     // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
                     // like every other credential anchor here; the node settings endpoint is where
                     // they are legitimately edited.
-                    node.authentication.swapMacaroonPath = appConfigNode.authentication?.swapMacaroonPath;
-                    node.authentication.boltzMacaroonPath = appConfigNode.authentication?.boltzMacaroonPath;
+                    node.authentication.swapMacaroonPath = runtimeNode.authentication?.swapMacaroonPath;
+                    node.authentication.boltzMacaroonPath = runtimeNode.authentication?.boltzMacaroonPath;
                     node.settings = (node.settings || {});
-                    node.settings.lnServerUrl = appConfigNode.settings?.lnServerUrl;
-                    node.settings.swapServerUrl = appConfigNode.settings?.swapServerUrl;
-                    node.settings.boltzServerUrl = appConfigNode.settings?.boltzServerUrl;
-                    node.settings.bitcoindConfigPath = appConfigNode.settings?.bitcoindConfigPath;
-                    node.settings.channelBackupPath = appConfigNode.settings?.channelBackupPath;
+                    node.settings.lnServerUrl = runtimeNode.settings?.lnServerUrl;
+                    node.settings.swapServerUrl = runtimeNode.settings?.swapServerUrl;
+                    node.settings.boltzServerUrl = runtimeNode.settings?.boltzServerUrl;
+                    node.settings.bitcoindConfigPath = runtimeNode.settings?.bitcoindConfigPath;
+                    node.settings.channelBackupPath = runtimeNode.settings?.channelBackupPath;
                 }
                 else {
-                    // New node: this endpoint never provisions nodes (the controller drops unknown
-                    // indexes before we get here), so any credential path that still arrives can only
-                    // be an injection; strip it.
+                    // Unknown node: this endpoint never provisions nodes (the controller drops
+                    // unknown indexes before we get here), so any credential path or settings anchor
+                    // that still arrives can only be an injection; strip them all.
                     if (node.authentication) {
                         delete node.authentication.macaroonPath;
                         delete node.authentication.runePath;
@@ -165,6 +173,13 @@ export class CommonService {
                         delete node.authentication.configPath;
                         delete node.authentication.swapMacaroonPath;
                         delete node.authentication.boltzMacaroonPath;
+                    }
+                    if (node.settings) {
+                        delete node.settings.lnServerUrl;
+                        delete node.settings.swapServerUrl;
+                        delete node.settings.boltzServerUrl;
+                        delete node.settings.bitcoindConfigPath;
+                        delete node.settings.channelBackupPath;
                     }
                 }
             });

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -104,6 +104,12 @@ export class CommonService {
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
             }
+            else {
+                // Normal post-boot state has no plaintext password (it is hashed into
+                // multiPassHashed); a caller-supplied multiPass must never survive into the live
+                // auth config. The control layer also rejects the key, this is the defense in depth.
+                delete config.multiPass;
+            }
             // A live TOTP seed must never be swapped for a client-supplied one: only the settings
             // UI's disable flow (an empty seed with enable2FA false) may wipe it, and an empty
             // seed while 2FA is still claimed on is an omission that restores the server seed.
@@ -124,16 +130,25 @@ export class CommonService {
             // so the two fields can never diverge after a save.
             config.enable2FA = !!config.secret2FA;
             // Node indexes arrive as strings in JSON payloads; normalize them to numbers so the
-            // map lookups below (and the persisted config) use a single representation.
+            // map lookups below (and the persisted config) use a single representation. Empty or
+            // non-numeric values must not coerce to 0 — that is a real node index.
             const indexKey = (node) => {
                 const val = node?.index;
-                return (val !== undefined && val !== null) ? +val : undefined;
+                if (typeof val === 'number') {
+                    return val;
+                }
+                if (typeof val === 'string' && val.trim() !== '') {
+                    return +val;
+                }
+                return undefined;
             };
             // Pin from the authoritative runtime node list (this.nodes), not this.appConfig.nodes.
             // After the first application-settings save, common.appConfig is a fresh clone while
             // common.nodes retains the live state (options, runeValue) and is updated in place by
             // updateNodeSettings via replaceNode — so pinning from appConfig.nodes would silently
-            // revert a user's legitimate Node Settings edit to the previous value.
+            // revert a user's legitimate Node Settings edit to the previous value. The controller
+            // answers known-vs-unknown from this same list (common.nodes), so the two layers can
+            // never disagree about which node is which.
             const runtimeNodes = new Map(this.nodes?.map((node) => [indexKey(node), node]) || []);
             config.nodes?.forEach((node) => {
                 node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
@@ -151,8 +166,8 @@ export class CommonService {
                     node.authentication.configPath = runtimeNode.authentication?.configPath;
                     // swap/boltz macaroon paths are read from disk and sent as auth headers to their
                     // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
-                    // like every other credential anchor here; the node settings endpoint is where
-                    // they are legitimately edited.
+                    // like every other credential anchor here; this endpoint cannot edit them, the
+                    // node-config Services page can (through updateNodeSettings on /node).
                     node.authentication.swapMacaroonPath = runtimeNode.authentication?.swapMacaroonPath;
                     node.authentication.boltzMacaroonPath = runtimeNode.authentication?.boltzMacaroonPath;
                     node.settings = (node.settings || {});

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -141,6 +141,12 @@ export class CommonService {
                     node.authentication.runePath = appConfigNode.authentication?.runePath;
                     node.authentication.lnApiPassword = appConfigNode.authentication?.lnApiPassword;
                     node.authentication.configPath = appConfigNode.authentication?.configPath;
+                    // swap/boltz macaroon paths are read from disk and sent as auth headers to their
+                    // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
+                    // like every other credential anchor here; the node settings endpoint is where
+                    // they are legitimately edited.
+                    node.authentication.swapMacaroonPath = appConfigNode.authentication?.swapMacaroonPath;
+                    node.authentication.boltzMacaroonPath = appConfigNode.authentication?.boltzMacaroonPath;
                     node.settings = (node.settings || {});
                     node.settings.lnServerUrl = appConfigNode.settings?.lnServerUrl;
                     node.settings.swapServerUrl = appConfigNode.settings?.swapServerUrl;
@@ -149,13 +155,16 @@ export class CommonService {
                     node.settings.channelBackupPath = appConfigNode.settings?.channelBackupPath;
                 }
                 else {
-                    // New node: there is no UI "add node" flow through the settings API, so no
-                    // credential path can be legitimately supplied here; strip any that arrive.
+                    // New node: this endpoint never provisions nodes (the controller drops unknown
+                    // indexes before we get here), so any credential path that still arrives can only
+                    // be an injection; strip it.
                     if (node.authentication) {
                         delete node.authentication.macaroonPath;
                         delete node.authentication.runePath;
                         delete node.authentication.lnApiPassword;
                         delete node.authentication.configPath;
+                        delete node.authentication.swapMacaroonPath;
+                        delete node.authentication.boltzMacaroonPath;
                     }
                 }
             });

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -104,29 +104,58 @@ export class CommonService {
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
             }
-            // Restore the TOTP seed when the client omits it — and when it sends an empty seed
-            // while still claiming 2FA is on (an inconsistent pair no honest flow produces).
-            // The settings UI's enable flow sends a non-empty seed; its disable flow sends an
-            // empty seed with enable2FA false. Both are honored.
-            if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
+            // A live TOTP seed must never be swapped for a client-supplied one: only the settings
+            // UI's disable flow (an empty seed with enable2FA false) may wipe it, and an empty
+            // seed while 2FA is still claimed on is an omission that restores the server seed.
+            // The enable flow sends a non-empty seed and only ever runs while 2FA is off, so a
+            // non-empty seed reaching a live seed means the seed is being overwritten — pin it.
+            if (this.appConfig.secret2FA) {
+                if (config.secret2FA === '' && !config.enable2FA) {
+                    config.secret2FA = '';
+                }
+                else {
+                    config.secret2FA = this.appConfig.secret2FA;
+                }
+            }
+            else if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
                 config.secret2FA = this.appConfig.secret2FA;
             }
             // enable2FA derives from the seed, matching the boot-time derivation in config.ts,
             // so the two fields can never diverge after a save.
             config.enable2FA = !!config.secret2FA;
-            const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
+            // Node indexes arrive as strings in JSON payloads; normalize them to numbers so the
+            // map lookups below (and the persisted config) use a single representation.
+            const indexKey = (node) => +node.index;
+            const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [indexKey(node), node]) || []);
             config.nodes?.forEach((node) => {
-                const appConfigNode = appConfigNodes.get(node.index);
-                if (appConfigNode?.authentication) {
+                node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
+                const appConfigNode = appConfigNodes.get(indexKey(node));
+                if (appConfigNode) {
+                    // Existing node: pin credential paths and credentialed-request anchors to the
+                    // server-held values. The client only ever echoes these (removeSecureData strips
+                    // the credentials, so a client cannot have a legitimate new value for them), and
+                    // accepting them would let an authenticated caller re-point credential file reads
+                    // or credentialed requests — the confused-deputy vector this pins down.
                     node.authentication = node.authentication || {};
-                    if (appConfigNode.authentication.macaroonPath) {
-                        node.authentication.macaroonPath = appConfigNode.authentication.macaroonPath;
-                    }
-                    if (appConfigNode.authentication.runePath) {
-                        node.authentication.runePath = appConfigNode.authentication.runePath;
-                    }
-                    if (appConfigNode.authentication.lnApiPassword) {
-                        node.authentication.lnApiPassword = appConfigNode.authentication.lnApiPassword;
+                    node.authentication.macaroonPath = appConfigNode.authentication?.macaroonPath;
+                    node.authentication.runePath = appConfigNode.authentication?.runePath;
+                    node.authentication.lnApiPassword = appConfigNode.authentication?.lnApiPassword;
+                    node.authentication.configPath = appConfigNode.authentication?.configPath;
+                    node.settings = (node.settings || {});
+                    node.settings.lnServerUrl = appConfigNode.settings?.lnServerUrl;
+                    node.settings.swapServerUrl = appConfigNode.settings?.swapServerUrl;
+                    node.settings.boltzServerUrl = appConfigNode.settings?.boltzServerUrl;
+                    node.settings.bitcoindConfigPath = appConfigNode.settings?.bitcoindConfigPath;
+                    node.settings.channelBackupPath = appConfigNode.settings?.channelBackupPath;
+                }
+                else {
+                    // New node: there is no UI "add node" flow through the settings API, so no
+                    // credential path can be legitimately supplied here; strip any that arrive.
+                    if (node.authentication) {
+                        delete node.authentication.macaroonPath;
+                        delete node.authentication.runePath;
+                        delete node.authentication.lnApiPassword;
+                        delete node.authentication.configPath;
                     }
                 }
             });

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -168,6 +168,10 @@ export class CommonService {
                     // header with no file read), so it is pinned like the other credentials even
                     // though the persisted file is stripped of it at save time.
                     node.authentication.runeValue = runtimeNode.authentication?.runeValue;
+                    // options.headers carries LND's macaroon hex and ECL's Basic authorization value —
+                    // the credential itself for those two implementations, as runeValue is for CLN —
+                    // so it is pinned the same way (the persisted file is stripped of it at save time).
+                    node.authentication.options = runtimeNode.authentication?.options;
                     // swap/boltz macaroon paths are read from disk and sent as auth headers to their
                     // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
                     // like every other credential anchor here; this endpoint cannot edit them, the
@@ -192,6 +196,7 @@ export class CommonService {
                         delete node.authentication.configPath;
                         // The live rune value must be stripped too, not just the path pointer.
                         delete node.authentication.runeValue;
+                        delete node.authentication.options;
                         delete node.authentication.swapMacaroonPath;
                         delete node.authentication.boltzMacaroonPath;
                     }

--- a/release-notes/Release-notes-0.15.11.md
+++ b/release-notes/Release-notes-0.15.11.md
@@ -20,21 +20,6 @@ this release should add its entry under the appropriate section below.
   state. Two backend regression tests (`test/backend/lnd-peers.test.mjs`) reproduce the race
   against fake LND nodes and fail on the pre-fix code.
 
-- **Hardening: application-settings save can no longer re-point credentials or server URLs**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), fixes
-  [#1660](https://github.com/Ride-The-Lightning/RTL/issues/1660)).
-  `updateApplicationSettings` merged the request body's per-node `authentication` and
-  `settings` wholesale, so an authenticated caller could inject a `macaroonPath`, `runePath`,
-  `lnApiPassword`, `configPath` or `lnServerUrl` and re-point credentialed requests or the
-  `getConfig`/`getFile` file reads at attacker-controlled values — a confused-deputy vector.
-  The endpoint now allowlists the node fields it accepts from the body (mirroring
-  `updateNodeSettings`), pins server URLs and credential paths to the server-held values for
-  existing nodes, strips credential paths from any node the server does not already know,
-  and rejects a malformed `lnServerUrl` on such a node. Node indexes are normalized to
-  numbers so a string-indexed payload merges into the existing node instead of duplicating
-  it, and a live 2FA seed can no longer be overwritten by a request-supplied seed. Backend
-  regression tests cover the allowlist, the index normalization and the 2FA-seed guard.
-
 ## Enhancements
 
 - **2FA login: password managers can offer the one-time code**

--- a/release-notes/Release-notes-0.15.11.md
+++ b/release-notes/Release-notes-0.15.11.md
@@ -20,6 +20,21 @@ this release should add its entry under the appropriate section below.
   state. Two backend regression tests (`test/backend/lnd-peers.test.mjs`) reproduce the race
   against fake LND nodes and fail on the pre-fix code.
 
+- **Hardening: application-settings save can no longer re-point credentials or server URLs**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), fixes
+  [#1660](https://github.com/Ride-The-Lightning/RTL/issues/1660)).
+  `updateApplicationSettings` merged the request body's per-node `authentication` and
+  `settings` wholesale, so an authenticated caller could inject a `macaroonPath`, `runePath`,
+  `lnApiPassword`, `configPath` or `lnServerUrl` and re-point credentialed requests or the
+  `getConfig`/`getFile` file reads at attacker-controlled values — a confused-deputy vector.
+  The endpoint now allowlists the node fields it accepts from the body (mirroring
+  `updateNodeSettings`), pins server URLs and credential paths to the server-held values for
+  existing nodes, strips credential paths from any node the server does not already know,
+  and rejects a malformed `lnServerUrl` on such a node. Node indexes are normalized to
+  numbers so a string-indexed payload merges into the existing node instead of duplicating
+  it, and a live 2FA seed can no longer be overwritten by a request-supplied seed. Backend
+  regression tests cover the allowlist, the index normalization and the 2FA-seed guard.
+
 ## Enhancements
 
 - **2FA login: password managers can offer the one-time code**

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -56,7 +56,7 @@ this release should add its entry under the appropriate section below.
   trusted-proxy configuration and is left open.
 
 - **Hardening: application-settings save can no longer re-point credentials or server URLs**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), fixes
+  ([#1683](https://github.com/Ride-The-Lightning/RTL/pull/1683), fixes
   [#1660](https://github.com/Ride-The-Lightning/RTL/issues/1660)).
   `updateApplicationSettings` merged the request body's per-node `authentication` and
   `settings` wholesale, so an authenticated caller could inject a `macaroonPath`, `runePath`,
@@ -72,7 +72,12 @@ this release should add its entry under the appropriate section below.
   are normalized to numbers so a string-indexed payload merges into the existing node
   instead of duplicating it, and a live 2FA seed can no longer be overwritten by a
   request-supplied seed. Backend regression tests cover the allowlist, the unknown-node
-  drop, the index normalization and the 2FA-seed guard.
+  drop, the index normalization and the 2FA-seed guard. The Node Settings endpoint
+  (Services page) continues to accept the Loop/Boltz server URLs and macaroon paths, which
+  are intentionally editable features, but now runs them through the same `http(s)` format
+  validation; a plaintext `multiPass` in the body is discarded, and a crafted channel value
+  on the channel-backup file read is sanitized so it can no longer walk out of the backup
+  directory.
 
 ## Enhancements
 

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -72,7 +72,11 @@ this release should add its entry under the appropriate section below.
   are normalized to numbers so a string-indexed payload merges into the existing node
   instead of duplicating it, and a live 2FA seed can no longer be overwritten by a
   request-supplied seed. Backend regression tests cover the allowlist, the unknown-node
-  drop, the index normalization and the 2FA-seed guard. The Node Settings endpoint
+  drop, the index normalization and the 2FA-seed guard. The `defaultNodeIndex` and
+  `selectedNodeIndex` scalars are validated against the known node set like the node
+  entries themselves, so an out-of-range value cannot be persisted and survive a restart.
+  CLN's live rune (`authentication.runeValue`) is pinned for existing nodes and stripped
+  for unknown nodes like every other credential. The Node Settings endpoint
   (Services page) continues to accept the Loop/Boltz server URLs and macaroon paths, which
   are intentionally editable features, but now runs them through the same `http(s)` format
   validation; a plaintext `multiPass` in the body is discarded, and a crafted channel value

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -55,6 +55,25 @@ this release should add its entry under the appropriate section below.
   `X-Forwarded-For`, which a client can rotate to dodge the limit — needs a decision on
   trusted-proxy configuration and is left open.
 
+- **Hardening: application-settings save can no longer re-point credentials or server URLs**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), fixes
+  [#1660](https://github.com/Ride-The-Lightning/RTL/issues/1660)).
+  `updateApplicationSettings` merged the request body's per-node `authentication` and
+  `settings` wholesale, so an authenticated caller could inject a `macaroonPath`, `runePath`,
+  `lnApiPassword`, `configPath` or `lnServerUrl` and re-point credentialed requests or the
+  `getConfig`/`getFile` file reads at attacker-controlled values — a confused-deputy vector.
+  The endpoint now allowlists the node fields it accepts from the body (mirroring
+  `updateNodeSettings`) and pins server URLs and credential paths — including the swap and
+  Boltz macaroon paths, which reach outbound requests as auth headers — to the server-held
+  values for existing nodes. A node whose index the server does not already know is dropped
+  with a warning instead of being provisioned: there is no add-node flow through this
+  endpoint, and a caller-chosen path or URL would otherwise be persisted to
+  `RTL-Config.json` and loaded back into the runtime nodes at the next restart. Node indexes
+  are normalized to numbers so a string-indexed payload merges into the existing node
+  instead of duplicating it, and a live 2FA seed can no longer be overwritten by a
+  request-supplied seed. Backend regression tests cover the allowlist, the unknown-node
+  drop, the index normalization and the 2FA-seed guard.
+
 ## Enhancements
 
 - **LND: open a channel with the entire wallet balance**

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -81,7 +81,14 @@ this release should add its entry under the appropriate section below.
   are intentionally editable features, but now runs them through the same `http(s)` format
   validation; a plaintext `multiPass` in the body is discarded, and a crafted channel value
   on the channel-backup file read is sanitized so it can no longer walk out of the backup
-  directory.
+  directory. A saved node setting is now applied to the live runtime node as well as the
+  config, so it takes effect without a restart and a later save cannot revert it; with no
+  runtime nodes to merge against the on-disk node list is left untouched instead of being
+  emptied. The channel-backup read refuses an unset backup path (which would otherwise
+  resolve to the working directory) and a non-string `channel` query (which threw), the
+  block-explorer transaction lookup URL-encodes the caller-supplied txid and caches the
+  working explorer per node rather than in one process-wide variable, and the config temp
+  file is created `0600` rather than narrowed after the fact.
 
 ## Enhancements
 

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -88,7 +88,9 @@ this release should add its entry under the appropriate section below.
   resolve to the working directory) and a non-string `channel` query (which threw), the
   block-explorer transaction lookup URL-encodes the caller-supplied txid and caches the
   working explorer per node rather than in one process-wide variable, and the config temp
-  file is created `0600` rather than narrowed after the fact.
+  file is created `0600` rather than narrowed after the fact. `defaultNodeIndex` and
+  `selectedNodeIndex` are stored as numbers when they arrive as strings, and the live
+  request headers (`authentication.options`) are pinned and stripped like `runeValue`.
 
 ## Enhancements
 

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -15,6 +15,26 @@ const logger: LoggerService = Logger;
 const common: CommonService = Common;
 const wsServer = WSServer;
 const databaseService: DatabaseService = Database;
+// The settings API echoes the whole config back, so these are the only per-node fields
+// accepted from the request body. Credential paths and runtime-only fields are not here;
+// addSecureData re-pins the credential paths for existing nodes and strips them for new
+// ones. Anything else arriving under authentication/settings is discarded.
+const NODE_SETTINGS_ALLOWLIST = [
+  'blockExplorerUrl', 'logLevel', 'logFile', 'userPersona', 'themeMode', 'themeColor',
+  'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap',
+  'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
+];
+const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
+const indexKey = (node) => +node.index;
+const isValidServerUrl = (url) => {
+  if (typeof url !== 'string' || url.trim() === '') { return false; }
+  try {
+    const parsed = new URL(url);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && !!parsed.hostname;
+  } catch {
+    return false;
+  }
+};
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
 // otherwise set it to mempool.space
@@ -275,7 +295,19 @@ export const updateApplicationSettings = (req, res, next) => {
   const RTLConfFile = common.appConfig.rtlConfFilePath + sep + 'RTL-Config.json';
   try {
     const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
-    const config = common.addSecureData(JSON.parse(JSON.stringify(req.body)));
+    // Allowlist the per-node payload before addSecureData runs, so an injected credential
+    // path, runeValue/options or unknown setting can never reach the runtime config or
+    // the file — the same strategy updateNodeSettings applies to its settings merge.
+    const requestBody = JSON.parse(JSON.stringify(req.body));
+    requestBody.nodes?.forEach((node) => {
+      if (node.authentication && typeof node.authentication === 'object') {
+        node.authentication = Object.fromEntries(Object.entries(node.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
+      }
+      if (node.settings && typeof node.settings === 'object') {
+        node.settings = Object.fromEntries(Object.entries(node.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+      }
+    });
+    const config = common.addSecureData(requestBody);
     const runtimeConfig = oldConfig;
     Object.keys(config).forEach((key) => {
       if (key !== 'nodes') {
@@ -284,10 +316,10 @@ export const updateApplicationSettings = (req, res, next) => {
     });
     if (config.nodes && config.nodes.length > 0) {
       const oldNodes = (common.appConfig.nodes && common.appConfig.nodes.length > 0) ? common.appConfig.nodes : (oldConfig.nodes || []);
-      const newNodesMap = new Map(config.nodes.map((node) => [node.index, node]));
+      const newNodesMap = new Map(config.nodes.map((node) => [indexKey(node), node]));
       const updatedAndExistingNodes = oldNodes.map((oldNode) => {
-        const newNode = newNodesMap.get(oldNode.index);
-        newNodesMap.delete(oldNode.index);
+        const newNode = newNodesMap.get(indexKey(oldNode));
+        newNodesMap.delete(indexKey(oldNode));
         const node = newNode ? {
           ...oldNode,
           ...newNode,
@@ -298,9 +330,22 @@ export const updateApplicationSettings = (req, res, next) => {
           authentication: { ...(oldNode.authentication || {}) },
           settings: { ...(oldNode.settings || {}) }
         };
+        node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
         return node;
       });
-      const newOnlyNodes = [...newNodesMap.values()].map((newNode) => JSON.parse(JSON.stringify(newNode)));
+      const newOnlyNodes = [...newNodesMap.values()].map((newNode) => {
+        const node = JSON.parse(JSON.stringify(newNode));
+        node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
+        return node;
+      });
+      // A node unknown to the server cannot be provisioned with credentials through this
+      // endpoint; validate the only server anchor it may carry before persisting.
+      const invalidNewNode = newOnlyNodes.find((node) => node.settings?.lnServerUrl && !isValidServerUrl(node.settings.lnServerUrl));
+      if (invalidNewNode) {
+        const errMsg = 'Invalid lnServerUrl format for node index ' + invalidNewNode.index;
+        const err = common.handleError({ statusCode: 400, message: errMsg, error: errMsg }, 'RTLConf', 'Update Default Node Error', req.session.selectedNode);
+        return res.status(err.statusCode).json({ message: err.error, error: err.error });
+      }
       runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
     }
     const newAppConfig = JSON.parse(JSON.stringify({

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -305,6 +305,21 @@ export const updateApplicationSettings = (req, res, next) => {
       }
       if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
         filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+        // Validate blockExplorerUrl to reject obviously malformed values. This is format
+        // validation only — it prevents non-URL strings and non-HTTP schemes from being
+        // persisted, but does not prevent SSRF (pointing at internal IPs). A user-chosen
+        // block explorer is an intended RTL feature (self-hosted mempool instances), so
+        // this field is not pinned to the server-held value.
+        if (filteredNode.settings.blockExplorerUrl !== undefined) {
+          try {
+            const parsed = new URL(filteredNode.settings.blockExplorerUrl);
+            if (!['http:', 'https:'].includes(parsed.protocol)) {
+              delete filteredNode.settings.blockExplorerUrl;
+            }
+          } catch {
+            delete filteredNode.settings.blockExplorerUrl;
+          }
+        }
       }
       return filteredNode;
     });

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -16,11 +16,13 @@ const common: CommonService = Common;
 const wsServer = WSServer;
 const databaseService: DatabaseService = Database;
 // The settings API echoes the whole config back, so these are the only per-node fields
-// accepted from the request body. Credential paths and runtime-only fields are not here;
-// addSecureData re-pins the credential paths for existing nodes and strips them for new
-// ones. Anything else arriving under authentication/settings is discarded.
+// accepted from the request body. Credential paths, server URLs and runtime-only fields
+// are not here; addSecureData re-pins them to the server-held values for existing nodes.
+// logFile is excluded because config.ts overwrites it unconditionally at boot, so
+// accepting it buys nothing. Anything else arriving under authentication/settings is
+// discarded.
 const NODE_SETTINGS_ALLOWLIST = [
-  'blockExplorerUrl', 'logLevel', 'logFile', 'userPersona', 'themeMode', 'themeColor',
+  'blockExplorerUrl', 'logLevel', 'userPersona', 'themeMode', 'themeColor',
   'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap',
   'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
 ];
@@ -30,15 +32,6 @@ const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
 // discarded so it can never be persisted alongside a node in RTL-Config.json.
 const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
 const indexKey = (node) => +node.index;
-const isValidServerUrl = (url) => {
-  if (typeof url !== 'string' || url.trim() === '') { return false; }
-  try {
-    const parsed = new URL(url);
-    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && !!parsed.hostname;
-  } catch {
-    return false;
-  }
-};
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
 // otherwise set it to mempool.space
@@ -316,6 +309,17 @@ export const updateApplicationSettings = (req, res, next) => {
       }
       return filteredNode;
     });
+    // Nodes are never provisioned through this endpoint: there is no add-node UI for it,
+    // and a caller-supplied credential path or server URL would be persisted to the config
+    // file and loaded back into the runtime nodes at the next restart. Drop any node whose
+    // index the server does not already know — addSecureData and the merge below answer
+    // known-vs-unknown from this same runtime list.
+    const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)) || []);
+    requestBody.nodes = requestBody.nodes?.filter((node) => {
+      if (knownIndexes.has(indexKey(node))) { return true; }
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Ignoring unknown node index in application settings; nodes cannot be added through this endpoint', data: { index: node?.index } });
+      return false;
+    });
     const config = common.addSecureData(requestBody);
     const runtimeConfig = oldConfig;
     Object.keys(config).forEach((key) => {
@@ -324,9 +328,8 @@ export const updateApplicationSettings = (req, res, next) => {
       }
     });
     if (config.nodes && config.nodes.length > 0) {
-      const oldNodes = (common.appConfig.nodes && common.appConfig.nodes.length > 0) ? common.appConfig.nodes : (oldConfig.nodes || []);
       const newNodesMap = new Map(config.nodes.map((node) => [indexKey(node), node]));
-      const updatedAndExistingNodes = oldNodes.map((oldNode) => {
+      const updatedAndExistingNodes = common.appConfig.nodes.map((oldNode) => {
         const newNode = newNodesMap.get(indexKey(oldNode));
         newNodesMap.delete(indexKey(oldNode));
         const node = newNode ? {
@@ -342,20 +345,7 @@ export const updateApplicationSettings = (req, res, next) => {
         node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
         return node;
       });
-      const newOnlyNodes = [...newNodesMap.values()].map((newNode) => {
-        const node = JSON.parse(JSON.stringify(newNode));
-        node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
-        return node;
-      });
-      // A node unknown to the server cannot be provisioned with credentials through this
-      // endpoint; validate the only server anchor it may carry before persisting.
-      const invalidNewNode = newOnlyNodes.find((node) => node.settings?.lnServerUrl && !isValidServerUrl(node.settings.lnServerUrl));
-      if (invalidNewNode) {
-        const errMsg = 'Invalid lnServerUrl format for node index ' + invalidNewNode.index;
-        const err = common.handleError({ statusCode: 400, message: errMsg, error: errMsg }, 'RTLConf', 'Update Default Node Error', req.session.selectedNode);
-        return res.status(err.statusCode).json({ message: err.error, error: err.error });
-      }
-      runtimeConfig.nodes = [...updatedAndExistingNodes, ...newOnlyNodes];
+      runtimeConfig.nodes = updatedAndExistingNodes;
     }
     const newAppConfig = JSON.parse(JSON.stringify({
       ...runtimeConfig,

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -15,23 +15,31 @@ const logger: LoggerService = Logger;
 const common: CommonService = Common;
 const wsServer = WSServer;
 const databaseService: DatabaseService = Database;
-// The settings API echoes the whole config back, so these are the only per-node fields
-// accepted from the request body. Credential paths, server URLs and runtime-only fields
-// are not here; addSecureData re-pins them to the server-held values for existing nodes.
-// logFile is excluded because config.ts overwrites it unconditionally at boot, so
-// accepting it buys nothing. Anything else arriving under authentication/settings is
-// discarded.
+// The settings API echoes the whole config back, so these are the only per-node settings
+// fields accepted from the request body. Credential paths, server URLs, runtime-only
+// fields (options, runeValue) and logFile (config.ts overwrites it at boot) are not here;
+// addSecureData re-pins them to the server-held values for existing nodes, and strips
+// them from unknown nodes entirely. Anything else arriving under settings is discarded.
 const NODE_SETTINGS_ALLOWLIST = [
   'blockExplorerUrl', 'logLevel', 'userPersona', 'themeMode', 'themeColor',
-  'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap',
-  'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
+  'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap'
 ];
-const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
 // Top-level keys accepted on a node object. authentication and settings are themselves
 // filtered by the allowlists above; any other key (e.g. a root-level macaroonPath) is
 // discarded so it can never be persisted alongside a node in RTL-Config.json.
 const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
-const indexKey = (node) => +node.index;
+// Top-level keys accepted from the request body on the application-settings endpoint.
+// Anything not here is discarded; this prevents caller-invented keys from being persisted
+// into RTL-Config.json and re-parsed at every save and boot.
+const TOP_LEVEL_ALLOWLIST = [
+  'defaultNodeIndex', 'selectedNodeIndex', 'enable2FA', 'allowPasswordUpdate',
+  'dbDirectoryPath', 'disableAuth', 'multiPass', 'multiPassHashed', 'secret2FA',
+  'SSO', 'nodes'
+];
+const indexKey = (node) => {
+  const val = node?.index;
+  return (val !== undefined && val !== null) ? +val : undefined;
+};
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
 // otherwise set it to mempool.space
@@ -237,43 +245,24 @@ export const updateNodeSettings = (req, res, next) => {
     const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
     if (node && node.settings) {
-      // channelBackupPath anchors getFile's containment root and is documented as a
-      // config-file-only setting; accepting it from the API would let the caller being
-      // contained choose the containment base. Pin it to the server-held value.
-      const serverChannelBackupPath = node.settings.channelBackupPath;
-      node.settings = { ...node.settings, ...req.body.settings };
-      node.settings.channelBackupPath = serverChannelBackupPath;
-      if (node.authentication && req.body.authentication) {
-        if (req.body.authentication.boltzMacaroonPath) {
-          node.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-        } else {
-          delete node.authentication.boltzMacaroonPath;
-        }
-        if (req.body.authentication.swapMacaroonPath) {
-          node.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-        } else {
-          delete node.authentication.swapMacaroonPath;
-        }
-      }
+      // Allowlist incoming settings to the same set updateApplicationSettings uses, then
+      // pin file-read and credentialed-request anchors so the caller cannot re-point
+      // credential file reads (bitcoindConfigPath), the channel-backup containment root
+      // (channelBackupPath), or credentialed HTTP destinations (lnServerUrl, swapServerUrl,
+      // boltzServerUrl). These fields are not in NODE_SETTINGS_ALLOWLIST, so the
+      // allowlisting above already strips them; the runtime merge below pins them too.
+      const allowedSettings = Object.fromEntries(
+        Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key))
+      );
+      node.settings = { ...node.settings, ...allowedSettings };
     }
     fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
     const selectedNode = common.findNode(req.session.selectedNode.index);
     if (selectedNode && selectedNode.settings) {
-      const serverChannelBackupPath = selectedNode.settings.channelBackupPath;
-      selectedNode.settings = { ...selectedNode.settings, ...req.body.settings };
-      selectedNode.settings.channelBackupPath = serverChannelBackupPath;
-      if (selectedNode.authentication && req.body.authentication) {
-        if (req.body.authentication.boltzMacaroonPath) {
-          selectedNode.authentication.boltzMacaroonPath = req.body.authentication.boltzMacaroonPath;
-        } else {
-          delete selectedNode.authentication.boltzMacaroonPath;
-        }
-        if (req.body.authentication.swapMacaroonPath) {
-          selectedNode.authentication.swapMacaroonPath = req.body.authentication.swapMacaroonPath;
-        } else {
-          delete selectedNode.authentication.swapMacaroonPath;
-        }
-      }
+      const allowedSettings = Object.fromEntries(
+        Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key))
+      );
+      selectedNode.settings = { ...selectedNode.settings, ...allowedSettings };
       common.replaceNode(req, selectedNode);
     }
     let responseNode = JSON.parse(JSON.stringify(common.selectedNode));
@@ -294,15 +283,25 @@ export const updateApplicationSettings = (req, res, next) => {
     const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     // Allowlist the per-node payload before addSecureData runs, so an injected credential
     // path, runeValue/options, unknown setting or unknown top-level node key (such as a
-    // root-level macaroonPath) can never reach the runtime config or the file — the same
-    // strategy updateNodeSettings applies to its settings merge.
+    // root-level macaroonPath) can never reach the runtime config or the file.
     const requestBody = JSON.parse(JSON.stringify(req.body));
+    // Filter top-level keys to prevent caller-invented fields from being persisted into
+    // RTL-Config.json and re-parsed at every save and boot.
+    for (const key of Object.keys(requestBody)) {
+      if (!TOP_LEVEL_ALLOWLIST.includes(key)) {
+        delete requestBody[key];
+      }
+    }
     requestBody.nodes = requestBody.nodes?.map((node) => {
       const filteredNode = (node && typeof node === 'object') ?
         Object.fromEntries(Object.entries(node).filter(([key]) => NODE_ALLOWLIST.includes(key))) :
         node;
-      if (filteredNode && filteredNode.authentication && typeof filteredNode.authentication === 'object') {
-        filteredNode.authentication = Object.fromEntries(Object.entries(filteredNode.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
+      // Strip authentication entirely: addSecureData re-pins all credential paths from
+      // the server-held node, so any caller-supplied authentication value (runeValue,
+      // options, macaroonPath, etc.) is dead weight that must not reach the runtime config
+      // or the file.
+      if (filteredNode && typeof filteredNode === 'object') {
+        delete filteredNode.authentication;
       }
       if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
         filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
@@ -314,9 +313,10 @@ export const updateApplicationSettings = (req, res, next) => {
     // file and loaded back into the runtime nodes at the next restart. Drop any node whose
     // index the server does not already know — addSecureData and the merge below answer
     // known-vs-unknown from this same runtime list.
-    const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)) || []);
+    const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)).filter((idx) => Number.isFinite(idx)) || []);
     requestBody.nodes = requestBody.nodes?.filter((node) => {
-      if (knownIndexes.has(indexKey(node))) { return true; }
+      const idx = indexKey(node);
+      if (Number.isFinite(idx) && knownIndexes.has(idx)) { return true; }
       logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Ignoring unknown node index in application settings; nodes cannot be added through this endpoint', data: { index: node?.index } });
       return false;
     });
@@ -327,8 +327,8 @@ export const updateApplicationSettings = (req, res, next) => {
         runtimeConfig[key] = config[key];
       }
     });
-    if (config.nodes && config.nodes.length > 0) {
-      const newNodesMap = new Map(config.nodes.map((node) => [indexKey(node), node]));
+    if (common.appConfig.nodes && common.appConfig.nodes.length > 0) {
+      const newNodesMap = new Map(config.nodes?.map((node) => [indexKey(node), node]) || []);
       const updatedAndExistingNodes = common.appConfig.nodes.map((oldNode) => {
         const newNode = newNodesMap.get(indexKey(oldNode));
         newNodesMap.delete(indexKey(oldNode));

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -16,29 +16,89 @@ const common: CommonService = Common;
 const wsServer = WSServer;
 const databaseService: DatabaseService = Database;
 // The settings API echoes the whole config back, so these are the only per-node settings
-// fields accepted from the request body. Credential paths, server URLs, runtime-only
-// fields (options, runeValue) and logFile (config.ts overwrites it at boot) are not here;
-// addSecureData re-pins them to the server-held values for existing nodes, and strips
-// them from unknown nodes entirely. Anything else arriving under settings is discarded.
+// fields accepted from the application-settings request body. Credential paths, LN server
+// URLs, runtime-only fields (options, runeValue) and logFile (config.ts overwrites it at
+// boot) are not here; addSecureData re-pins credential paths and LN server URLs to the
+// server-held values for existing nodes, and strips them from unknown nodes entirely.
+// Anything else arriving under settings is discarded.
 const NODE_SETTINGS_ALLOWLIST = [
   'blockExplorerUrl', 'logLevel', 'userPersona', 'themeMode', 'themeColor',
   'unannouncedChannels', 'fiatConversion', 'currencyUnit', 'enableOffers', 'enablePeerswap'
 ];
+// Loop and Boltz server URLs are service settings, edited from the node-config Services
+// page through the node-settings endpoint only (their macaroon paths are edited the same
+// way). They are deliberately not in NODE_SETTINGS_ALLOWLIST: the application-settings
+// endpoint re-pins them, so accepting them there would be dead weight.
+const NODE_SERVICE_SETTINGS_ALLOWLIST = ['swapServerUrl', 'boltzServerUrl'];
 // Top-level keys accepted on a node object. authentication and settings are themselves
-// filtered by the allowlists above; any other key (e.g. a root-level macaroonPath) is
-// discarded so it can never be persisted alongside a node in RTL-Config.json.
-const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
+// filtered by the allowlists above; lnImplementation is deliberately absent — it selects
+// which credential the server attaches to the (pinned) LN server URL, so letting the
+// caller rewrite it would silently break the node connection after the next boot. Any
+// other key (e.g. a root-level macaroonPath) is discarded so it can never be persisted
+// alongside a node in RTL-Config.json.
+const NODE_ALLOWLIST = ['index', 'lnNode', 'authentication', 'settings'];
 // Top-level keys accepted from the request body on the application-settings endpoint.
 // Anything not here is discarded; this prevents caller-invented keys from being persisted
-// into RTL-Config.json and re-parsed at every save and boot.
+// into RTL-Config.json and re-parsed at every save and boot. multiPass is not accepted:
+// the plaintext password is hashed into multiPassHashed at boot and never sent back to
+// the client, so no honest flow supplies it (addSecureData also pins it defensively).
 const TOP_LEVEL_ALLOWLIST = [
   'defaultNodeIndex', 'selectedNodeIndex', 'enable2FA', 'allowPasswordUpdate',
-  'dbDirectoryPath', 'disableAuth', 'multiPass', 'multiPassHashed', 'secret2FA',
+  'dbDirectoryPath', 'disableAuth', 'multiPassHashed', 'secret2FA',
   'SSO', 'nodes'
 ];
 const indexKey = (node) => {
   const val = node?.index;
-  return (val !== undefined && val !== null) ? +val : undefined;
+  if (typeof val === 'number') { return val; }
+  // Empty or whitespace-only strings must not coerce to 0 (node 0 is a real node).
+  if (typeof val === 'string' && val.trim() !== '') { return +val; }
+  return undefined;
+};
+// Reject malformed URLs and non-HTTP schemes. User-chosen block explorers and Loop/Boltz
+// servers are intended RTL features (self-hosted instances), so this is format validation
+// only — it does not prevent a caller from pointing at an internal host.
+const isValidHttpUrl = (value) => {
+  if (typeof value !== 'string') { return false; }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+// Allowlist a settings payload and drop URL-valued fields that fail isValidHttpUrl.
+// The node-settings endpoint additionally accepts the Loop/Boltz service URLs
+// (allowServiceUrls); the application-settings endpoint does not. Both handlers share this
+// so a malformed blockExplorerUrl/swapServerUrl/boltzServerUrl can never reach the
+// outbound request built from the live node's settings.
+const filterNodeSettings = (settings, allowServiceUrls = false) => {
+  const allowed = Object.fromEntries(
+    Object.entries(settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key) ||
+      (allowServiceUrls && NODE_SERVICE_SETTINGS_ALLOWLIST.includes(key)))
+  );
+  for (const urlKey of ['blockExplorerUrl', 'swapServerUrl', 'boltzServerUrl']) {
+    if (allowed[urlKey] !== undefined && !isValidHttpUrl(allowed[urlKey])) {
+      delete allowed[urlKey];
+    }
+  }
+  return allowed;
+};
+// The Loop/Boltz service macaroon paths are edited from the Services page and remain
+// writable through the node-settings endpoint; an absent or empty value clears the field.
+// The LN credential paths (macaroonPath, runePath, lnApiPassword, configPath) are not
+// handled here and can never be set through this endpoint.
+const applyWritableServiceMacaroonPaths = (target, source) => {
+  if (!target || !source) { return; }
+  if (source.boltzMacaroonPath) {
+    target.boltzMacaroonPath = source.boltzMacaroonPath;
+  } else {
+    delete target.boltzMacaroonPath;
+  }
+  if (source.swapMacaroonPath) {
+    target.swapMacaroonPath = source.swapMacaroonPath;
+  } else {
+    delete target.swapMacaroonPath;
+  }
 };
 // Set local block explorer URL after first API call
 // if the selected node block explorer has working REST API suite
@@ -120,7 +180,11 @@ export const getFile = (req, res, next) => {
     }
     file = resolved;
   } else {
-    file = channelBackupPath + sep + 'channel-' + req.query.channel?.replace(':', '-') + '.bak';
+    // The channel value is concatenated into the backup file name; neutralize path
+    // separators and '..' so a crafted channel cannot walk out of the backup directory
+    // (the UI only ever sends a channel point, "funding_txid:output").
+    const channel = req.query.channel?.replace(/[:/\\]/g, '-').replace(/\.\./g, '-');
+    file = channelBackupPath + sep + 'channel-' + channel + '.bak';
   }
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'Channel Point', data: req.query.channel });
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'File Path', data: file });
@@ -245,24 +309,20 @@ export const updateNodeSettings = (req, res, next) => {
     const config = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     const node = config.nodes.find((node) => (node.index === req.session.selectedNode.index));
     if (node && node.settings) {
-      // Allowlist incoming settings to the same set updateApplicationSettings uses, then
-      // pin file-read and credentialed-request anchors so the caller cannot re-point
-      // credential file reads (bitcoindConfigPath), the channel-backup containment root
-      // (channelBackupPath), or credentialed HTTP destinations (lnServerUrl, swapServerUrl,
-      // boltzServerUrl). These fields are not in NODE_SETTINGS_ALLOWLIST, so the
-      // allowlisting above already strips them; the runtime merge below pins them too.
-      const allowedSettings = Object.fromEntries(
-        Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key))
-      );
-      node.settings = { ...node.settings, ...allowedSettings };
+      // Allowlist incoming settings to the same set updateApplicationSettings uses, plus
+      // the Loop/Boltz service URLs (swapServerUrl, boltzServerUrl), which the Services
+      // page edits; URL fields get the same http/https format validation. Credential and
+      // LN server anchors — bitcoindConfigPath, channelBackupPath, lnServerUrl, logFile —
+      // stay out of the allowlist, so they are neither edited here nor persisted.
+      node.settings = { ...node.settings, ...filterNodeSettings(req.body.settings, true) };
+      // Loop/Boltz macaroon paths are a Services-page feature and stay editable here.
+      applyWritableServiceMacaroonPaths(node.authentication, req.body.authentication);
     }
     fs.writeFileSync(RTLConfFile, JSON.stringify(config, null, 2), 'utf-8');
     const selectedNode = common.findNode(req.session.selectedNode.index);
     if (selectedNode && selectedNode.settings) {
-      const allowedSettings = Object.fromEntries(
-        Object.entries(req.body.settings || {}).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key))
-      );
-      selectedNode.settings = { ...selectedNode.settings, ...allowedSettings };
+      selectedNode.settings = { ...selectedNode.settings, ...filterNodeSettings(req.body.settings, true) };
+      applyWritableServiceMacaroonPaths(selectedNode.authentication, req.body.authentication);
       common.replaceNode(req, selectedNode);
     }
     let responseNode = JSON.parse(JSON.stringify(common.selectedNode));
@@ -304,31 +364,18 @@ export const updateApplicationSettings = (req, res, next) => {
         delete filteredNode.authentication;
       }
       if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
-        filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
-        // Validate blockExplorerUrl to reject obviously malformed values. This is format
-        // validation only — it prevents non-URL strings and non-HTTP schemes from being
-        // persisted, but does not prevent SSRF (pointing at internal IPs). A user-chosen
-        // block explorer is an intended RTL feature (self-hosted mempool instances), so
-        // this field is not pinned to the server-held value.
-        if (filteredNode.settings.blockExplorerUrl !== undefined) {
-          try {
-            const parsed = new URL(filteredNode.settings.blockExplorerUrl);
-            if (!['http:', 'https:'].includes(parsed.protocol)) {
-              delete filteredNode.settings.blockExplorerUrl;
-            }
-          } catch {
-            delete filteredNode.settings.blockExplorerUrl;
-          }
-        }
+        filteredNode.settings = filterNodeSettings(filteredNode.settings);
       }
       return filteredNode;
     });
     // Nodes are never provisioned through this endpoint: there is no add-node UI for it,
     // and a caller-supplied credential path or server URL would be persisted to the config
     // file and loaded back into the runtime nodes at the next restart. Drop any node whose
-    // index the server does not already know — addSecureData and the merge below answer
-    // known-vs-unknown from this same runtime list.
-    const knownIndexes = new Set(common.appConfig.nodes?.map((node) => indexKey(node)).filter((idx) => Number.isFinite(idx)) || []);
+    // index the server does not already know. Known-vs-unknown resolves against the single
+    // authoritative runtime list (common.nodes) — the same list addSecureData pins from and
+    // updateNodeSettings mutates in place. common.appConfig.nodes is a fresh clone after
+    // every save and goes stale, so resolving against it would misclassify nodes.
+    const knownIndexes = new Set(common.nodes?.map((node) => indexKey(node)).filter((idx) => Number.isFinite(idx)) || []);
     requestBody.nodes = requestBody.nodes?.filter((node) => {
       const idx = indexKey(node);
       if (Number.isFinite(idx) && knownIndexes.has(idx)) { return true; }
@@ -342,9 +389,9 @@ export const updateApplicationSettings = (req, res, next) => {
         runtimeConfig[key] = config[key];
       }
     });
-    if (common.appConfig.nodes && common.appConfig.nodes.length > 0) {
+    if (common.nodes && common.nodes.length > 0) {
       const newNodesMap = new Map(config.nodes?.map((node) => [indexKey(node), node]) || []);
-      const updatedAndExistingNodes = common.appConfig.nodes.map((oldNode) => {
+      const updatedAndExistingNodes = common.nodes.map((oldNode) => {
         const newNode = newNodesMap.get(indexKey(oldNode));
         newNodesMap.delete(indexKey(oldNode));
         const node = newNode ? {

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -382,6 +382,20 @@ export const updateApplicationSettings = (req, res, next) => {
       logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: 'Ignoring unknown node index in application settings; nodes cannot be added through this endpoint', data: { index: node?.index } });
       return false;
     });
+    // defaultNodeIndex and selectedNodeIndex pass TOP_LEVEL_ALLOWLIST but must carry the
+    // same known-index discipline as nodes[]: defaultNodeIndex is persisted (unlike
+    // selectedNodeIndex it is not stripped from the file config), so an unparseable value
+    // or one naming a dropped node would survive a restart. Drop any such value; the
+    // server-held current index wins (selectedNodeIndex falls back in newAppConfig).
+    for (const scalarKey of ['defaultNodeIndex', 'selectedNodeIndex']) {
+      if (requestBody[scalarKey] !== undefined) {
+        const idx = indexKey({ index: requestBody[scalarKey] });
+        if (!Number.isFinite(idx) || !knownIndexes.has(idx)) {
+          logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: `Ignoring invalid ${scalarKey} in application settings; it must be the index of a known node`, data: { value: requestBody[scalarKey] } });
+          delete requestBody[scalarKey];
+        }
+      }
+    }
     const config = common.addSecureData(requestBody);
     const runtimeConfig = oldConfig;
     Object.keys(config).forEach((key) => {
@@ -393,7 +407,9 @@ export const updateApplicationSettings = (req, res, next) => {
       const newNodesMap = new Map(config.nodes?.map((node) => [indexKey(node), node]) || []);
       const updatedAndExistingNodes = common.nodes.map((oldNode) => {
         const newNode = newNodesMap.get(indexKey(oldNode));
-        newNodesMap.delete(indexKey(oldNode));
+        // Unknown-index nodes were dropped above, so every config node has a matching
+        // runtime node; a plain lookup (not a consuming delete) means a duplicate index
+        // in the runtime list cannot leave the payload hanging unmerged.
         const node = newNode ? {
           ...oldNode,
           ...newNode,
@@ -408,6 +424,12 @@ export const updateApplicationSettings = (req, res, next) => {
         return node;
       });
       runtimeConfig.nodes = updatedAndExistingNodes;
+    } else {
+      // No live runtime nodes to merge with (cannot happen after a normal boot:
+      // common.nodes is built from the file at boot and only mutated in place afterwards).
+      // Record the allowlisted-and-pinned payload rather than silently reverting to the
+      // on-disk copy — the save the caller is told about must be what the file records.
+      runtimeConfig.nodes = config.nodes || [];
     }
     const newAppConfig = JSON.parse(JSON.stringify({
       ...runtimeConfig,

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -25,6 +25,10 @@ const NODE_SETTINGS_ALLOWLIST = [
   'lnServerUrl', 'swapServerUrl', 'boltzServerUrl', 'bitcoindConfigPath', 'channelBackupPath'
 ];
 const NODE_AUTH_ALLOWLIST = ['swapMacaroonPath', 'boltzMacaroonPath'];
+// Top-level keys accepted on a node object. authentication and settings are themselves
+// filtered by the allowlists above; any other key (e.g. a root-level macaroonPath) is
+// discarded so it can never be persisted alongside a node in RTL-Config.json.
+const NODE_ALLOWLIST = ['index', 'lnNode', 'lnImplementation', 'authentication', 'settings'];
 const indexKey = (node) => +node.index;
 const isValidServerUrl = (url) => {
   if (typeof url !== 'string' || url.trim() === '') { return false; }
@@ -296,16 +300,21 @@ export const updateApplicationSettings = (req, res, next) => {
   try {
     const oldConfig = JSON.parse(fs.readFileSync(RTLConfFile, 'utf-8'));
     // Allowlist the per-node payload before addSecureData runs, so an injected credential
-    // path, runeValue/options or unknown setting can never reach the runtime config or
-    // the file — the same strategy updateNodeSettings applies to its settings merge.
+    // path, runeValue/options, unknown setting or unknown top-level node key (such as a
+    // root-level macaroonPath) can never reach the runtime config or the file — the same
+    // strategy updateNodeSettings applies to its settings merge.
     const requestBody = JSON.parse(JSON.stringify(req.body));
-    requestBody.nodes?.forEach((node) => {
-      if (node.authentication && typeof node.authentication === 'object') {
-        node.authentication = Object.fromEntries(Object.entries(node.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
+    requestBody.nodes = requestBody.nodes?.map((node) => {
+      const filteredNode = (node && typeof node === 'object') ?
+        Object.fromEntries(Object.entries(node).filter(([key]) => NODE_ALLOWLIST.includes(key))) :
+        node;
+      if (filteredNode && filteredNode.authentication && typeof filteredNode.authentication === 'object') {
+        filteredNode.authentication = Object.fromEntries(Object.entries(filteredNode.authentication).filter(([key]) => NODE_AUTH_ALLOWLIST.includes(key)));
       }
-      if (node.settings && typeof node.settings === 'object') {
-        node.settings = Object.fromEntries(Object.entries(node.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
+      if (filteredNode && filteredNode.settings && typeof filteredNode.settings === 'object') {
+        filteredNode.settings = Object.fromEntries(Object.entries(filteredNode.settings).filter(([key]) => NODE_SETTINGS_ALLOWLIST.includes(key)));
       }
+      return filteredNode;
     });
     const config = common.addSecureData(requestBody);
     const runtimeConfig = oldConfig;

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -402,13 +402,17 @@ export const updateApplicationSettings = (req, res, next) => {
     // same known-index discipline as nodes[]: defaultNodeIndex is persisted (unlike
     // selectedNodeIndex it is not stripped from the file config), so an unparseable value
     // or one naming a dropped node would survive a restart. Drop any such value; the
-    // server-held current index wins (selectedNodeIndex falls back in newAppConfig).
+    // server-held current index wins (selectedNodeIndex falls back in newAppConfig). A
+    // valid value is stored as a number: every consumer compares strictly (findNode,
+    // getApplicationSettings), so a persisted string would match no node after a restart.
     for (const scalarKey of ['defaultNodeIndex', 'selectedNodeIndex']) {
       if (requestBody[scalarKey] !== undefined) {
         const idx = indexKey({ index: requestBody[scalarKey] });
         if (!Number.isFinite(idx) || !knownIndexes.has(idx)) {
           logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'RTLConf', msg: `Ignoring invalid ${scalarKey} in application settings; it must be the index of a known node`, data: { value: requestBody[scalarKey] } });
           delete requestBody[scalarKey];
+        } else {
+          requestBody[scalarKey] = idx;
         }
       }
     }

--- a/server/controllers/shared/RTLConf.ts
+++ b/server/controllers/shared/RTLConf.ts
@@ -100,23 +100,22 @@ const applyWritableServiceMacaroonPaths = (target, source) => {
     delete target.swapMacaroonPath;
   }
 };
-// Set local block explorer URL after first API call
-// if the selected node block explorer has working REST API suite
-// otherwise set it to mempool.space
-let blockExplorerUrl = '';
+// Remember, per node, which block explorer answered the last call: the node's own once
+// its REST API suite has worked, mempool.space after a failure. Keyed by node index so one
+// node's explorer (or its fallback) is never reused for another node or session.
+const explorerUrlByNode = new Map();
+const explorerBaseUrl = (req) => explorerUrlByNode.get(req.session.selectedNode.index) || req.session.selectedNode.settings.blockExplorerUrl;
 
 export const getExplorerFeesRecommended = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting Recommended Fee Rates..' });
-  options.url = (blockExplorerUrl === '') ?
-    req.session.selectedNode.settings.blockExplorerUrl + '/api/v1/fees/recommended' :
-    blockExplorerUrl + '/api/v1/fees/recommended';
+  options.url = explorerBaseUrl(req) + '/api/v1/fees/recommended';
   request(options).then((body) => {
-    blockExplorerUrl = req.session.selectedNode.settings.blockExplorerUrl;
+    explorerUrlByNode.set(req.session.selectedNode.index, req.session.selectedNode.settings.blockExplorerUrl);
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Recommended Fee Rates Received', data: body });
     res.status(200).json(JSON.parse(body));
   }).catch((errRes) => {
-    blockExplorerUrl = 'https://mempool.space';
-    options.url = blockExplorerUrl + '/api/v1/fees/recommended';
+    explorerUrlByNode.set(req.session.selectedNode.index, 'https://mempool.space');
+    options.url = 'https://mempool.space/api/v1/fees/recommended';
     return request(options).then((body) => {
       logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Recommended Fee Rates Received', data: body });
       res.status(200).json(JSON.parse(body));
@@ -130,16 +129,17 @@ export const getExplorerFeesRecommended = (req, res, next) => {
 
 export const getExplorerTransaction = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting Transaction From Block Explorer..' });
-  options.url = (blockExplorerUrl === '') ?
-    req.session.selectedNode.settings.blockExplorerUrl + '/api/tx/' + req.params.txid :
-    blockExplorerUrl + '/api/tx/' + req.params.txid;
+  // The txid is caller-supplied and the explorer's reply is returned to the caller, so
+  // encode it: it must stay a single path segment and cannot carry a query or a '..'.
+  const txid = encodeURIComponent(req.params.txid);
+  options.url = explorerBaseUrl(req) + '/api/tx/' + txid;
   request(options).then((body) => {
-    blockExplorerUrl = req.session.selectedNode.settings.blockExplorerUrl;
+    explorerUrlByNode.set(req.session.selectedNode.index, req.session.selectedNode.settings.blockExplorerUrl);
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Transaction From Block Explorer Received', data: body });
     res.status(200).json(JSON.parse(body));
   }).catch((errRes) => {
-    blockExplorerUrl = 'https://mempool.space';
-    options.url = blockExplorerUrl + '/api/tx/' + req.params.txid;
+    explorerUrlByNode.set(req.session.selectedNode.index, 'https://mempool.space');
+    options.url = 'https://mempool.space/api/tx/' + txid;
     return request(options).then((body) => {
       logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Transaction From Block Explorer Received', data: body });
       res.status(200).json(JSON.parse(body));
@@ -167,6 +167,14 @@ export const getCurrencyRates = (req, res, next) => {
 export const getFile = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Getting File..' });
   const channelBackupPath = req.session.selectedNode.settings.channelBackupPath;
+  // config.ts always assigns a backup path at boot, but resolve('') is the working
+  // directory, so an unset root would silently make the install tree the containment
+  // root. Refuse rather than read from there.
+  if (typeof channelBackupPath !== 'string' || channelBackupPath.trim() === '') {
+    const errMsg = 'Reading File Error';
+    const err = common.handleError({ statusCode: 500, message: errMsg, error: 'Channel backup path is not configured' }, 'RTLConf', errMsg, req.session.selectedNode);
+    return res.status(err.statusCode).json({ message: err.message, error: err.error });
+  }
   let file = '';
   if (req.query.path) {
     // The UI only ever requests channel backup files; contain caller paths to the node's
@@ -180,10 +188,17 @@ export const getFile = (req, res, next) => {
     }
     file = resolved;
   } else {
+    // Express parses a repeated key into an array and a bracketed key into an object;
+    // reject anything but a string rather than throwing from the sanitizer below.
+    if (typeof req.query.channel !== 'string') {
+      const errMsg = 'Reading File Error';
+      const err = common.handleError({ statusCode: 400, message: errMsg, error: 'Channel must be a string' }, 'RTLConf', errMsg, req.session.selectedNode);
+      return res.status(err.statusCode).json({ message: err.message, error: err.error });
+    }
     // The channel value is concatenated into the backup file name; neutralize path
     // separators and '..' so a crafted channel cannot walk out of the backup directory
     // (the UI only ever sends a channel point, "funding_txid:output").
-    const channel = req.query.channel?.replace(/[:/\\]/g, '-').replace(/\.\./g, '-');
+    const channel = req.query.channel.replace(/[:/\\]/g, '-').replace(/\.\./g, '-');
     file = channelBackupPath + sep + 'channel-' + channel + '.bak';
   }
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'RTLConf', msg: 'Channel Point', data: req.query.channel });
@@ -247,7 +262,8 @@ export const updateSelectedNode = (req, res, next) => {
       databaseService.loadDatabase(req.session);
     }
   }
-  blockExplorerUrl = '';
+  // Retry the node's own explorer on the next call after a switch, as before.
+  explorerUrlByNode.delete(req.session.selectedNode.index);
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'RTLConf', msg: 'Selected Node Updated To ' + req.session.selectedNode.lnNode || '' });
   res.status(200).json(common.removeAuthSecureData(JSON.parse(JSON.stringify(req.session.selectedNode))));
 };
@@ -410,11 +426,20 @@ export const updateApplicationSettings = (req, res, next) => {
         // Unknown-index nodes were dropped above, so every config node has a matching
         // runtime node; a plain lookup (not a consuming delete) means a duplicate index
         // in the runtime list cannot leave the payload hanging unmerged.
+        if (newNode) {
+          // Publish the allowlisted edit to the live runtime node as well: common.nodes is
+          // what the session, the explorer requests and the next save read from, so a
+          // setting left only in common.appConfig would take effect after a restart and be
+          // reverted by the following save. Credential anchors in newNode.settings were
+          // pinned from this very node by addSecureData, so this cannot move them.
+          if (newNode.lnNode !== undefined) { oldNode.lnNode = newNode.lnNode; }
+          oldNode.settings = { ...oldNode.settings, ...(newNode.settings || {}) };
+        }
         const node = newNode ? {
           ...oldNode,
           ...newNode,
           authentication: { ...(oldNode.authentication || {}), ...(newNode.authentication || {}) },
-          settings: { ...(oldNode.settings || {}), ...(newNode.settings || {}) }
+          settings: { ...(oldNode.settings || {}) }
         } : {
           ...oldNode,
           authentication: { ...(oldNode.authentication || {}) },
@@ -424,13 +449,12 @@ export const updateApplicationSettings = (req, res, next) => {
         return node;
       });
       runtimeConfig.nodes = updatedAndExistingNodes;
-    } else {
-      // No live runtime nodes to merge with (cannot happen after a normal boot:
-      // common.nodes is built from the file at boot and only mutated in place afterwards).
-      // Record the allowlisted-and-pinned payload rather than silently reverting to the
-      // on-disk copy — the save the caller is told about must be what the file records.
-      runtimeConfig.nodes = config.nodes || [];
     }
+    // Otherwise there are no live runtime nodes to merge against (cannot happen after a
+    // normal boot: common.nodes is built from the file at boot and only mutated in place
+    // afterwards). knownIndexes was empty too, so every payload node was dropped above and
+    // there is nothing to record; runtimeConfig keeps the on-disk node list untouched
+    // rather than overwriting it with an empty array.
     const newAppConfig = JSON.parse(JSON.stringify({
       ...runtimeConfig,
       selectedNodeIndex: config.selectedNodeIndex !== undefined ?
@@ -458,12 +482,14 @@ export const updateApplicationSettings = (req, res, next) => {
     // Persist atomically (temp file + rename, so a mid-write failure cannot truncate the
     // config) and only then adopt the new runtime config, so a failed write leaves the
     // process on the old one. The temp file inherits the existing file's mode so a
-    // hardened 0600 is not silently downgraded; a fresh file gets 0600. Symlinks and
+    // hardened 0600 is not silently downgraded; a fresh file gets 0600. The temp file is
+    // created 0600 so the secrets it carries (2FA seed, password hash, credential paths)
+    // are never world-readable, even for the instant before chmod. Symlinks and
     // single-file bind mounts cannot be renamed over — fall back to an in-place write,
     // which preserves inode and mode.
     const tempConfigFile = RTLConfFile + '.tmp';
     try {
-      fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), 'utf-8');
+      fs.writeFileSync(tempConfigFile, JSON.stringify(fileConfig, null, 2), { encoding: 'utf-8', mode: 0o600 });
       fs.chmodSync(tempConfigFile, fs.existsSync(RTLConfFile) ? (fs.statSync(RTLConfFile).mode & 0o777) : 0o600);
       fs.renameSync(tempConfigFile, RTLConfFile);
     } catch {

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import * as crypto from 'crypto';
 import request from './request.js';
 import { Logger, LoggerService } from './logger.js';
-import { ApplicationConfig, SelectedNode } from '../models/config.model.js';
+import { ApplicationConfig, SelectedNode, Settings } from '../models/config.model.js';
 
 export class CommonService {
 
@@ -109,29 +109,55 @@ export class CommonService {
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
     }
-    // Restore the TOTP seed when the client omits it — and when it sends an empty seed
-    // while still claiming 2FA is on (an inconsistent pair no honest flow produces).
-    // The settings UI's enable flow sends a non-empty seed; its disable flow sends an
-    // empty seed with enable2FA false. Both are honored.
-    if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
+    // A live TOTP seed must never be swapped for a client-supplied one: only the settings
+    // UI's disable flow (an empty seed with enable2FA false) may wipe it, and an empty
+    // seed while 2FA is still claimed on is an omission that restores the server seed.
+    // The enable flow sends a non-empty seed and only ever runs while 2FA is off, so a
+    // non-empty seed reaching a live seed means the seed is being overwritten — pin it.
+    if (this.appConfig.secret2FA) {
+      if (config.secret2FA === '' && !config.enable2FA) {
+        config.secret2FA = '';
+      } else {
+        config.secret2FA = this.appConfig.secret2FA;
+      }
+    } else if (config.secret2FA === undefined || (config.secret2FA === '' && config.enable2FA)) {
       config.secret2FA = this.appConfig.secret2FA;
     }
     // enable2FA derives from the seed, matching the boot-time derivation in config.ts,
     // so the two fields can never diverge after a save.
     config.enable2FA = !!config.secret2FA;
-    const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [node.index, node]) || []);
+    // Node indexes arrive as strings in JSON payloads; normalize them to numbers so the
+    // map lookups below (and the persisted config) use a single representation.
+    const indexKey = (node) => +node.index;
+    const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [indexKey(node), node]) || []);
     config.nodes?.forEach((node) => {
-      const appConfigNode = appConfigNodes.get(node.index);
-      if (appConfigNode?.authentication) {
+      node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
+      const appConfigNode = appConfigNodes.get(indexKey(node));
+      if (appConfigNode) {
+        // Existing node: pin credential paths and credentialed-request anchors to the
+        // server-held values. The client only ever echoes these (removeSecureData strips
+        // the credentials, so a client cannot have a legitimate new value for them), and
+        // accepting them would let an authenticated caller re-point credential file reads
+        // or credentialed requests — the confused-deputy vector this pins down.
         node.authentication = node.authentication || {};
-        if (appConfigNode.authentication.macaroonPath) {
-          node.authentication.macaroonPath = appConfigNode.authentication.macaroonPath;
-        }
-        if (appConfigNode.authentication.runePath) {
-          node.authentication.runePath = appConfigNode.authentication.runePath;
-        }
-        if (appConfigNode.authentication.lnApiPassword) {
-          node.authentication.lnApiPassword = appConfigNode.authentication.lnApiPassword;
+        node.authentication.macaroonPath = appConfigNode.authentication?.macaroonPath;
+        node.authentication.runePath = appConfigNode.authentication?.runePath;
+        node.authentication.lnApiPassword = appConfigNode.authentication?.lnApiPassword;
+        node.authentication.configPath = appConfigNode.authentication?.configPath;
+        node.settings = (node.settings || {}) as Settings;
+        node.settings.lnServerUrl = appConfigNode.settings?.lnServerUrl;
+        node.settings.swapServerUrl = appConfigNode.settings?.swapServerUrl;
+        node.settings.boltzServerUrl = appConfigNode.settings?.boltzServerUrl;
+        node.settings.bitcoindConfigPath = appConfigNode.settings?.bitcoindConfigPath;
+        node.settings.channelBackupPath = appConfigNode.settings?.channelBackupPath;
+      } else {
+        // New node: there is no UI "add node" flow through the settings API, so no
+        // credential path can be legitimately supplied here; strip any that arrive.
+        if (node.authentication) {
+          delete node.authentication.macaroonPath;
+          delete node.authentication.runePath;
+          delete node.authentication.lnApiPassword;
+          delete node.authentication.configPath;
         }
       }
     });

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -162,6 +162,10 @@ export class CommonService {
         node.authentication.runePath = runtimeNode.authentication?.runePath;
         node.authentication.lnApiPassword = runtimeNode.authentication?.lnApiPassword;
         node.authentication.configPath = runtimeNode.authentication?.configPath;
+        // runeValue is CLN's live rune (setOptions sends it verbatim as the request
+        // header with no file read), so it is pinned like the other credentials even
+        // though the persisted file is stripped of it at save time.
+        node.authentication.runeValue = runtimeNode.authentication?.runeValue;
         // swap/boltz macaroon paths are read from disk and sent as auth headers to their
         // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
         // like every other credential anchor here; this endpoint cannot edit them, the
@@ -183,6 +187,8 @@ export class CommonService {
           delete node.authentication.runePath;
           delete node.authentication.lnApiPassword;
           delete node.authentication.configPath;
+          // The live rune value must be stripped too, not just the path pointer.
+          delete node.authentication.runeValue;
           delete node.authentication.swapMacaroonPath;
           delete node.authentication.boltzMacaroonPath;
         }

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -128,38 +128,46 @@ export class CommonService {
     config.enable2FA = !!config.secret2FA;
     // Node indexes arrive as strings in JSON payloads; normalize them to numbers so the
     // map lookups below (and the persisted config) use a single representation.
-    const indexKey = (node) => +node.index;
-    const appConfigNodes = new Map(this.appConfig.nodes?.map((node) => [indexKey(node), node]) || []);
+    const indexKey = (node) => {
+      const val = node?.index;
+      return (val !== undefined && val !== null) ? +val : undefined;
+    };
+    // Pin from the authoritative runtime node list (this.nodes), not this.appConfig.nodes.
+    // After the first application-settings save, common.appConfig is a fresh clone while
+    // common.nodes retains the live state (options, runeValue) and is updated in place by
+    // updateNodeSettings via replaceNode — so pinning from appConfig.nodes would silently
+    // revert a user's legitimate Node Settings edit to the previous value.
+    const runtimeNodes = new Map(this.nodes?.map((node) => [indexKey(node), node]) || []);
     config.nodes?.forEach((node) => {
       node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
-      const appConfigNode = appConfigNodes.get(indexKey(node));
-      if (appConfigNode) {
+      const runtimeNode = runtimeNodes.get(indexKey(node));
+      if (runtimeNode) {
         // Existing node: pin credential paths and credentialed-request anchors to the
         // server-held values. The client only ever echoes these (removeSecureData strips
         // the credentials, so a client cannot have a legitimate new value for them), and
         // accepting them would let an authenticated caller re-point credential file reads
         // or credentialed requests — the confused-deputy vector this pins down.
         node.authentication = node.authentication || {};
-        node.authentication.macaroonPath = appConfigNode.authentication?.macaroonPath;
-        node.authentication.runePath = appConfigNode.authentication?.runePath;
-        node.authentication.lnApiPassword = appConfigNode.authentication?.lnApiPassword;
-        node.authentication.configPath = appConfigNode.authentication?.configPath;
+        node.authentication.macaroonPath = runtimeNode.authentication?.macaroonPath;
+        node.authentication.runePath = runtimeNode.authentication?.runePath;
+        node.authentication.lnApiPassword = runtimeNode.authentication?.lnApiPassword;
+        node.authentication.configPath = runtimeNode.authentication?.configPath;
         // swap/boltz macaroon paths are read from disk and sent as auth headers to their
         // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
         // like every other credential anchor here; the node settings endpoint is where
         // they are legitimately edited.
-        node.authentication.swapMacaroonPath = appConfigNode.authentication?.swapMacaroonPath;
-        node.authentication.boltzMacaroonPath = appConfigNode.authentication?.boltzMacaroonPath;
+        node.authentication.swapMacaroonPath = runtimeNode.authentication?.swapMacaroonPath;
+        node.authentication.boltzMacaroonPath = runtimeNode.authentication?.boltzMacaroonPath;
         node.settings = (node.settings || {}) as Settings;
-        node.settings.lnServerUrl = appConfigNode.settings?.lnServerUrl;
-        node.settings.swapServerUrl = appConfigNode.settings?.swapServerUrl;
-        node.settings.boltzServerUrl = appConfigNode.settings?.boltzServerUrl;
-        node.settings.bitcoindConfigPath = appConfigNode.settings?.bitcoindConfigPath;
-        node.settings.channelBackupPath = appConfigNode.settings?.channelBackupPath;
+        node.settings.lnServerUrl = runtimeNode.settings?.lnServerUrl;
+        node.settings.swapServerUrl = runtimeNode.settings?.swapServerUrl;
+        node.settings.boltzServerUrl = runtimeNode.settings?.boltzServerUrl;
+        node.settings.bitcoindConfigPath = runtimeNode.settings?.bitcoindConfigPath;
+        node.settings.channelBackupPath = runtimeNode.settings?.channelBackupPath;
       } else {
-        // New node: this endpoint never provisions nodes (the controller drops unknown
-        // indexes before we get here), so any credential path that still arrives can only
-        // be an injection; strip it.
+        // Unknown node: this endpoint never provisions nodes (the controller drops
+        // unknown indexes before we get here), so any credential path or settings anchor
+        // that still arrives can only be an injection; strip them all.
         if (node.authentication) {
           delete node.authentication.macaroonPath;
           delete node.authentication.runePath;
@@ -167,6 +175,13 @@ export class CommonService {
           delete node.authentication.configPath;
           delete node.authentication.swapMacaroonPath;
           delete node.authentication.boltzMacaroonPath;
+        }
+        if (node.settings) {
+          delete node.settings.lnServerUrl;
+          delete node.settings.swapServerUrl;
+          delete node.settings.boltzServerUrl;
+          delete node.settings.bitcoindConfigPath;
+          delete node.settings.channelBackupPath;
         }
       }
     });

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -108,6 +108,11 @@ export class CommonService {
     config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
+    } else {
+      // Normal post-boot state has no plaintext password (it is hashed into
+      // multiPassHashed); a caller-supplied multiPass must never survive into the live
+      // auth config. The control layer also rejects the key, this is the defense in depth.
+      delete config.multiPass;
     }
     // A live TOTP seed must never be swapped for a client-supplied one: only the settings
     // UI's disable flow (an empty seed with enable2FA false) may wipe it, and an empty
@@ -127,16 +132,21 @@ export class CommonService {
     // so the two fields can never diverge after a save.
     config.enable2FA = !!config.secret2FA;
     // Node indexes arrive as strings in JSON payloads; normalize them to numbers so the
-    // map lookups below (and the persisted config) use a single representation.
+    // map lookups below (and the persisted config) use a single representation. Empty or
+    // non-numeric values must not coerce to 0 — that is a real node index.
     const indexKey = (node) => {
       const val = node?.index;
-      return (val !== undefined && val !== null) ? +val : undefined;
+      if (typeof val === 'number') { return val; }
+      if (typeof val === 'string' && val.trim() !== '') { return +val; }
+      return undefined;
     };
     // Pin from the authoritative runtime node list (this.nodes), not this.appConfig.nodes.
     // After the first application-settings save, common.appConfig is a fresh clone while
     // common.nodes retains the live state (options, runeValue) and is updated in place by
     // updateNodeSettings via replaceNode — so pinning from appConfig.nodes would silently
-    // revert a user's legitimate Node Settings edit to the previous value.
+    // revert a user's legitimate Node Settings edit to the previous value. The controller
+    // answers known-vs-unknown from this same list (common.nodes), so the two layers can
+    // never disagree about which node is which.
     const runtimeNodes = new Map(this.nodes?.map((node) => [indexKey(node), node]) || []);
     config.nodes?.forEach((node) => {
       node.index = Number.isFinite(indexKey(node)) ? indexKey(node) : node.index;
@@ -154,8 +164,8 @@ export class CommonService {
         node.authentication.configPath = runtimeNode.authentication?.configPath;
         // swap/boltz macaroon paths are read from disk and sent as auth headers to their
         // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
-        // like every other credential anchor here; the node settings endpoint is where
-        // they are legitimately edited.
+        // like every other credential anchor here; this endpoint cannot edit them, the
+        // node-config Services page can (through updateNodeSettings on /node).
         node.authentication.swapMacaroonPath = runtimeNode.authentication?.swapMacaroonPath;
         node.authentication.boltzMacaroonPath = runtimeNode.authentication?.boltzMacaroonPath;
         node.settings = (node.settings || {}) as Settings;

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -144,6 +144,12 @@ export class CommonService {
         node.authentication.runePath = appConfigNode.authentication?.runePath;
         node.authentication.lnApiPassword = appConfigNode.authentication?.lnApiPassword;
         node.authentication.configPath = appConfigNode.authentication?.configPath;
+        // swap/boltz macaroon paths are read from disk and sent as auth headers to their
+        // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
+        // like every other credential anchor here; the node settings endpoint is where
+        // they are legitimately edited.
+        node.authentication.swapMacaroonPath = appConfigNode.authentication?.swapMacaroonPath;
+        node.authentication.boltzMacaroonPath = appConfigNode.authentication?.boltzMacaroonPath;
         node.settings = (node.settings || {}) as Settings;
         node.settings.lnServerUrl = appConfigNode.settings?.lnServerUrl;
         node.settings.swapServerUrl = appConfigNode.settings?.swapServerUrl;
@@ -151,13 +157,16 @@ export class CommonService {
         node.settings.bitcoindConfigPath = appConfigNode.settings?.bitcoindConfigPath;
         node.settings.channelBackupPath = appConfigNode.settings?.channelBackupPath;
       } else {
-        // New node: there is no UI "add node" flow through the settings API, so no
-        // credential path can be legitimately supplied here; strip any that arrive.
+        // New node: this endpoint never provisions nodes (the controller drops unknown
+        // indexes before we get here), so any credential path that still arrives can only
+        // be an injection; strip it.
         if (node.authentication) {
           delete node.authentication.macaroonPath;
           delete node.authentication.runePath;
           delete node.authentication.lnApiPassword;
           delete node.authentication.configPath;
+          delete node.authentication.swapMacaroonPath;
+          delete node.authentication.boltzMacaroonPath;
         }
       }
     });

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -166,6 +166,10 @@ export class CommonService {
         // header with no file read), so it is pinned like the other credentials even
         // though the persisted file is stripped of it at save time.
         node.authentication.runeValue = runtimeNode.authentication?.runeValue;
+        // options.headers carries LND's macaroon hex and ECL's Basic authorization value —
+        // the credential itself for those two implementations, as runeValue is for CLN —
+        // so it is pinned the same way (the persisted file is stripped of it at save time).
+        node.authentication.options = runtimeNode.authentication?.options;
         // swap/boltz macaroon paths are read from disk and sent as auth headers to their
         // server URLs (setSwapServerOptions/getBoltzServerOptions), so they are pinned
         // like every other credential anchor here; this endpoint cannot edit them, the
@@ -189,6 +193,7 @@ export class CommonService {
           delete node.authentication.configPath;
           // The live rune value must be stripped too, not just the path pointer.
           delete node.authentication.runeValue;
+          delete node.authentication.options;
           delete node.authentication.swapMacaroonPath;
           delete node.authentication.boltzMacaroonPath;
         }

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -240,6 +240,46 @@ test('addSecureData pins multiPassHashed when the server holds one', () => {
   assert.equal(config.multiPassHashed, 'server-hash-value');
 });
 
+test('addSecureData never persists a caller-supplied multiPass when the server holds no plaintext password', () => {
+  // Normal post-boot state: the password exists only as multiPassHashed, so a multiPass in
+  // the request body is attacker-supplied and must be discarded, not persisted and
+  // re-parsed at the next boot/save.
+  seedAppConfig();
+  Common.appConfig.multiPass = undefined;
+  Common.appConfig.multiPassHashed = 'server-hash-value';
+  const config = Common.addSecureData({ multiPass: 'attacker-password', nodes: [] });
+  assert.equal(config.multiPass, undefined);
+  assert.equal(config.multiPassHashed, 'server-hash-value');
+});
+
+test('addSecureData pins existing-node anchors from the runtime node list, not the stale appConfig copy', () => {
+  // F12/F20: runtimeNodes is built from this.nodes — the live list addSecureData must pin
+  // from — never from this.appConfig.nodes, which is a fresh clone at every save and can
+  // go stale (that is the list the controller's application-settings rebuild also uses).
+  // Pinning from the stale copy would silently regress an edit made through the
+  // node-settings endpoint to the previous value.
+  seedAppConfig();
+  Common.appConfig.nodes = [
+    { index: 1, authentication: { macaroonPath: '/stale/lnd/admin' }, settings: { lnServerUrl: 'https://stale:8080', swapServerUrl: 'https://stale-swap:8081' } }
+  ];
+  Common.nodes = JSON.parse(JSON.stringify(Common.appConfig.nodes));
+  Common.nodes[0].authentication.macaroonPath = '/live/lnd/admin';
+  Common.nodes[0].settings.lnServerUrl = 'https://live:8080';
+  Common.nodes[0].settings.swapServerUrl = 'https://live-swap:8081';
+  const config = Common.addSecureData({
+    nodes: [
+      { index: '1', authentication: { macaroonPath: '/evil/lnd' }, settings: { lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', themeMode: 'NIGHT' } }
+    ]
+  });
+  const node = config.nodes[0];
+  assert.equal(node.index, 1);
+  assert.equal(node.authentication.macaroonPath, '/live/lnd/admin');
+  assert.equal(node.settings.lnServerUrl, 'https://live:8080');
+  assert.equal(node.settings.swapServerUrl, 'https://live-swap:8081');
+  // Non-anchor settings still merge from the payload.
+  assert.equal(node.settings.themeMode, 'NIGHT');
+});
+
 test('addSecureData pins allowPasswordUpdate and dbDirectoryPath to server-held values', () => {
   // allowPasswordUpdate is false precisely when the password is environment-managed, and
   // dbDirectoryPath redirects the runtime database — neither is writable from the UI.

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -280,6 +280,27 @@ test('addSecureData pins existing-node anchors from the runtime node list, not t
   assert.equal(node.settings.themeMode, 'NIGHT');
 });
 
+test('addSecureData pins runeValue symmetrically with the other CLN credentials', () => {
+  // runeValue is CLN's live rune — setOptions sends it verbatim as the request header —
+  // so the known-node pin and the unknown-node strip must cover it like every other
+  // credential, not just the runePath pointer.
+  seedAppConfig();
+  Common.appConfig.nodes = [];
+  Common.nodes = [{ index: 1, authentication: { runePath: '/server/cln/rune', runeValue: 'server-rune-value' } }];
+  const config = Common.addSecureData({
+    nodes: [
+      { index: '1', authentication: { runePath: '/evil/rune', runeValue: 'evil-rune-value' } },
+      { index: '2', authentication: { runePath: '/evil/new', runeValue: 'evil-rune' } }
+    ]
+  });
+  const knownNode = config.nodes[0];
+  assert.equal(knownNode.authentication.runePath, '/server/cln/rune');
+  assert.equal(knownNode.authentication.runeValue, 'server-rune-value');
+  const unknownNode = config.nodes[1];
+  assert.equal(unknownNode.authentication.runePath, undefined);
+  assert.equal(unknownNode.authentication.runeValue, undefined);
+});
+
 test('addSecureData pins allowPasswordUpdate and dbDirectoryPath to server-held values', () => {
   // allowPasswordUpdate is false precisely when the password is environment-managed, and
   // dbDirectoryPath redirects the runtime database — neither is writable from the UI.

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -133,9 +133,56 @@ test('addSecureData pins disableAuth and the SSO object to server-held values', 
   });
   assert.equal(config.disableAuth, false);
   assert.deepEqual(config.SSO, { rtlSSO: 0, rtlCookiePath: '/server-cookie', logoutRedirectLink: 'https://server-logout', cookieValue: 'server-cookie' });
-  // An explicit non-empty seed is the settings UI's enable flow and is honored.
-  assert.equal(config.secret2FA, 'client-seed');
+  // A live server seed must never be swapped for a client-supplied one; only the
+  // explicit disable flow (empty seed + enable2FA false) may wipe it.
+  assert.equal(config.secret2FA, 'server-seed');
   assert.equal(config.enable2FA, true);
+});
+
+test('addSecureData honors a fresh seed only when the server holds no live seed', () => {
+  // The settings UI's enable flow sends a non-empty seed and only ever runs while 2FA is
+  // off; with no live seed server-side, the client seed is the enable flow and is honored.
+  seedAppConfig();
+  Common.appConfig.secret2FA = '';
+  Common.appConfig.enable2FA = false;
+  const config = Common.addSecureData({ secret2FA: 'fresh-seed', enable2FA: true, nodes: [] });
+  assert.equal(config.secret2FA, 'fresh-seed');
+  assert.equal(config.enable2FA, true);
+});
+
+test('addSecureData strips credential paths from new nodes and pins existing-node paths by index', () => {
+  seedAppConfig();
+  Common.appConfig.nodes = [
+    { index: 1, authentication: { macaroonPath: '/server/lnd/admin', configPath: '/server/lnd/lnd.conf' }, settings: { lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' } }
+  ];
+  // index "1" arrives as a string in the JSON payload; it must match the numeric server
+  // index, so the existing node's paths are pinned while the new node keeps none.
+  const config = Common.addSecureData({
+    nodes: [
+      { index: '1', authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', swapMacaroonPath: '/loop/swap' }, settings: { lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', themeMode: 'NIGHT' } },
+      { index: '2', authentication: { macaroonPath: '/evil/new', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd' }, settings: { lnServerUrl: 'https://new.example', themeMode: 'DAY' } }
+    ]
+  });
+  const existingNode = config.nodes[0];
+  assert.equal(existingNode.index, 1);
+  assert.equal(existingNode.authentication.macaroonPath, '/server/lnd/admin');
+  assert.equal(existingNode.authentication.configPath, '/server/lnd/lnd.conf');
+  assert.equal(existingNode.authentication.runePath, undefined);
+  assert.equal(existingNode.authentication.lnApiPassword, undefined);
+  assert.equal(existingNode.authentication.swapMacaroonPath, '/loop/swap');
+  assert.equal(existingNode.settings.lnServerUrl, 'https://server:8080');
+  assert.equal(existingNode.settings.swapServerUrl, 'https://swap:8081');
+  assert.equal(existingNode.settings.boltzServerUrl, 'https://boltz:9003');
+  assert.equal(existingNode.settings.bitcoindConfigPath, '/server/bitcoin.conf');
+  assert.equal(existingNode.settings.channelBackupPath, '/server/backups');
+  assert.equal(existingNode.settings.themeMode, 'NIGHT');
+  const newNode = config.nodes[1];
+  assert.equal(newNode.index, 2);
+  assert.equal(newNode.authentication.macaroonPath, undefined);
+  assert.equal(newNode.authentication.runePath, undefined);
+  assert.equal(newNode.authentication.lnApiPassword, undefined);
+  assert.equal(newNode.authentication.configPath, undefined);
+  assert.equal(newNode.settings.lnServerUrl, 'https://new.example');
 });
 
 test('addSecureData restores an omitted TOTP seed and derives enable2FA from the seed', () => {

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -152,9 +152,11 @@ test('addSecureData honors a fresh seed only when the server holds no live seed'
 
 test('addSecureData strips credential paths from new nodes and pins existing-node paths by index', () => {
   seedAppConfig();
-  Common.appConfig.nodes = [
+  const serverNodes = [
     { index: 1, authentication: { macaroonPath: '/server/lnd/admin', configPath: '/server/lnd/lnd.conf', swapMacaroonPath: '/server/loop' }, settings: { lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' } }
   ];
+  Common.appConfig.nodes = serverNodes;
+  Common.nodes = JSON.parse(JSON.stringify(serverNodes));
   // index "1" arrives as a string in the JSON payload; it must match the numeric server
   // index, so the existing node's paths are pinned while the new node keeps none.
   const config = Common.addSecureData({
@@ -186,7 +188,12 @@ test('addSecureData strips credential paths from new nodes and pins existing-nod
   assert.equal(newNode.authentication.lnApiPassword, undefined);
   assert.equal(newNode.authentication.configPath, undefined);
   assert.equal(newNode.authentication.swapMacaroonPath, undefined);
-  assert.equal(newNode.settings.lnServerUrl, 'https://new.example');
+  // F9: settings anchors are stripped from unknown nodes too, not just auth fields.
+  assert.equal(newNode.settings.lnServerUrl, undefined);
+  assert.equal(newNode.settings.swapServerUrl, undefined);
+  assert.equal(newNode.settings.boltzServerUrl, undefined);
+  assert.equal(newNode.settings.bitcoindConfigPath, undefined);
+  assert.equal(newNode.settings.channelBackupPath, undefined);
 });
 
 test('addSecureData restores an omitted TOTP seed and derives enable2FA from the seed', () => {

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -153,14 +153,14 @@ test('addSecureData honors a fresh seed only when the server holds no live seed'
 test('addSecureData strips credential paths from new nodes and pins existing-node paths by index', () => {
   seedAppConfig();
   Common.appConfig.nodes = [
-    { index: 1, authentication: { macaroonPath: '/server/lnd/admin', configPath: '/server/lnd/lnd.conf' }, settings: { lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' } }
+    { index: 1, authentication: { macaroonPath: '/server/lnd/admin', configPath: '/server/lnd/lnd.conf', swapMacaroonPath: '/server/loop' }, settings: { lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' } }
   ];
   // index "1" arrives as a string in the JSON payload; it must match the numeric server
   // index, so the existing node's paths are pinned while the new node keeps none.
   const config = Common.addSecureData({
     nodes: [
-      { index: '1', authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', swapMacaroonPath: '/loop/swap' }, settings: { lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', themeMode: 'NIGHT' } },
-      { index: '2', authentication: { macaroonPath: '/evil/new', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd' }, settings: { lnServerUrl: 'https://new.example', themeMode: 'DAY' } }
+      { index: '1', authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', swapMacaroonPath: '/loop/swap', boltzMacaroonPath: '/boltz/evil' }, settings: { lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', themeMode: 'NIGHT' } },
+      { index: '2', authentication: { macaroonPath: '/evil/new', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', swapMacaroonPath: '/loop/new' }, settings: { lnServerUrl: 'https://new.example', themeMode: 'DAY' } }
     ]
   });
   const existingNode = config.nodes[0];
@@ -169,7 +169,10 @@ test('addSecureData strips credential paths from new nodes and pins existing-nod
   assert.equal(existingNode.authentication.configPath, '/server/lnd/lnd.conf');
   assert.equal(existingNode.authentication.runePath, undefined);
   assert.equal(existingNode.authentication.lnApiPassword, undefined);
-  assert.equal(existingNode.authentication.swapMacaroonPath, '/loop/swap');
+  // The swap macaroon path is read from disk and sent as an auth header to the swap
+  // server, so it is pinned to the server-held value like every other credential anchor.
+  assert.equal(existingNode.authentication.swapMacaroonPath, '/server/loop');
+  assert.equal(existingNode.authentication.boltzMacaroonPath, undefined);
   assert.equal(existingNode.settings.lnServerUrl, 'https://server:8080');
   assert.equal(existingNode.settings.swapServerUrl, 'https://swap:8081');
   assert.equal(existingNode.settings.boltzServerUrl, 'https://boltz:9003');
@@ -182,6 +185,7 @@ test('addSecureData strips credential paths from new nodes and pins existing-nod
   assert.equal(newNode.authentication.runePath, undefined);
   assert.equal(newNode.authentication.lnApiPassword, undefined);
   assert.equal(newNode.authentication.configPath, undefined);
+  assert.equal(newNode.authentication.swapMacaroonPath, undefined);
   assert.equal(newNode.settings.lnServerUrl, 'https://new.example');
 });
 

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -301,6 +301,28 @@ test('addSecureData pins runeValue symmetrically with the other CLN credentials'
   assert.equal(unknownNode.authentication.runeValue, undefined);
 });
 
+test('addSecureData pins authentication.options symmetrically with runeValue', () => {
+  // authentication.options.headers is where LND's macaroon hex and ECL's Basic
+  // authorization value live — the credential itself, not a pointer to it. The known-node
+  // pin and the unknown-node strip must cover it like runeValue does for CLN.
+  seedAppConfig();
+  Common.appConfig.nodes = [];
+  const serverOptions = { headers: { 'Grpc-Metadata-macaroon': 'server-macaroon-hex' } };
+  Common.nodes = [{ index: 1, authentication: { macaroonPath: '/server/lnd', options: serverOptions } }];
+  const config = Common.addSecureData({
+    nodes: [
+      { index: '1', authentication: { macaroonPath: '/evil/lnd', options: { headers: { 'Grpc-Metadata-macaroon': 'evil-hex' } } } },
+      { index: '2', authentication: { macaroonPath: '/evil/new', options: { headers: { authorization: 'Basic evil' } } } }
+    ]
+  });
+  const knownNode = config.nodes[0];
+  assert.equal(knownNode.authentication.macaroonPath, '/server/lnd');
+  assert.deepEqual(knownNode.authentication.options, serverOptions);
+  const unknownNode = config.nodes[1];
+  assert.equal(unknownNode.authentication.macaroonPath, undefined);
+  assert.equal(unknownNode.authentication.options, undefined);
+});
+
 test('addSecureData pins allowPasswordUpdate and dbDirectoryPath to server-held values', () => {
   // allowPasswordUpdate is false precisely when the password is environment-managed, and
   // dbDirectoryPath redirects the runtime database — neither is writable from the UI.

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -28,7 +28,7 @@ test('updateApplicationSettings preserves indexed node auth and sanitizes only p
         index: 2,
         lnNode: 'cln-secondary',
         lnImplementation: 'CLN',
-        authentication: { runePath: '/cln/rune' },
+        authentication: { runePath: '/cln/rune', swapMacaroonPath: '/loop/cln' },
         settings: { userPersona: 'MERCHANT', themeMode: 'NIGHT', blockExplorerUrl: 'https://old.example' }
       }
     ]
@@ -109,7 +109,9 @@ test('updateApplicationSettings preserves indexed node auth and sanitizes only p
     );
 
     assert.equal(responseStatus, 201);
-    assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0, 2, 5]);
+    // Node index 5 is unknown to the server, so it is dropped rather than provisioned;
+    // only the known indexes survive in the runtime config and the file.
+    assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0, 2]);
 
     const runtimeClnNode = Common.appConfig.nodes[1];
     assert.equal(runtimeClnNode.authentication.runePath, '/cln/rune');
@@ -121,7 +123,7 @@ test('updateApplicationSettings preserves indexed node auth and sanitizes only p
     assert.equal(runtimeClnNode.settings.blockExplorerUrl, 'https://old.example');
 
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
-    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 2, 5]);
+    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 2]);
     assert.equal(fileConfig.rtlPass, undefined);
     assert.equal(fileConfig.rtlConfFilePath, undefined);
     assert.equal(fileConfig.selectedNodeIndex, undefined);
@@ -516,7 +518,7 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
         index: 0,
         lnNode: 'lnd-main',
         lnImplementation: 'LND',
-        authentication: { macaroonPath: '/server/lnd/admin', configPath: '' },
+        authentication: { macaroonPath: '/server/lnd/admin', configPath: '', swapMacaroonPath: '/server/loop', boltzMacaroonPath: '/server/boltz' },
         settings: { userPersona: 'OPERATOR', themeMode: 'DAY', lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' }
       }
     ]
@@ -555,8 +557,8 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
         lnNode: 'lnd-main',
         lnImplementation: 'LND',
         macaroonPath: '/etc/shadow',
-        authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', runeValue: 'evil-rune', macaroonValue: 'evil-macaroon', options: { headers: { 'Grpc-Metadata-macaroon': 'evil' } } },
-        settings: { themeMode: 'NIGHT', lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', evilSetting: 'smuggled' }
+        authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', runeValue: 'evil-rune', macaroonValue: 'evil-macaroon', options: { headers: { 'Grpc-Metadata-macaroon': 'evil' } }, swapMacaroonPath: '/evil/loop', boltzMacaroonPath: '/evil/boltz' },
+        settings: { themeMode: 'NIGHT', logFile: '/tmp/evil.log', lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', evilSetting: 'smuggled' }
       },
       {
         index: 5,
@@ -601,6 +603,10 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
     assert.equal(existingNode.authentication.runeValue, undefined);
     assert.equal(existingNode.authentication.macaroonValue, undefined);
     assert.equal(existingNode.macaroonPath, undefined);
+    // The swap/boltz macaroon paths are read from disk and sent as auth headers, so the
+    // attacker-supplied ones are pinned back to the server-held values.
+    assert.equal(existingNode.authentication.swapMacaroonPath, '/server/loop');
+    assert.equal(existingNode.authentication.boltzMacaroonPath, '/server/boltz');
     // Runtime-only auth state carried by the pre-existing node survives the save.
     assert.deepEqual(existingNode.authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
     assert.equal(existingNode.settings.lnServerUrl, 'https://server:8080');
@@ -610,28 +616,22 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
     assert.equal(existingNode.settings.channelBackupPath, '/server/backups');
     assert.equal(existingNode.settings.themeMode, 'NIGHT');
     assert.equal(existingNode.settings.evilSetting, undefined);
-    const newNode = Common.appConfig.nodes[1];
-    assert.equal(newNode.index, 5);
-    assert.equal(newNode.authentication.macaroonPath, undefined);
-    assert.equal(newNode.authentication.runePath, undefined);
-    assert.equal(newNode.authentication.lnApiPassword, undefined);
-    assert.equal(newNode.authentication.configPath, undefined);
-    assert.equal(newNode.macaroonPath, undefined);
-    assert.equal(newNode.settings.lnServerUrl, 'https://new.example');
-    assert.equal(newNode.settings.themeMode, 'DAY');
+    // logFile is not accepted: config.ts rewrites it unconditionally at boot.
+    assert.equal(existingNode.settings.logFile, undefined);
+    // The unknown-index node is dropped rather than provisioned; nothing about it
+    // survives anywhere.
+    assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0]);
 
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
-    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 5]);
+    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0]);
     assert.equal(fileConfig.nodes[0].authentication.macaroonPath, '/server/lnd/admin');
     assert.equal(fileConfig.nodes[0].authentication.options, undefined);
     assert.equal(fileConfig.nodes[0].authentication.runeValue, undefined);
+    assert.equal(fileConfig.nodes[0].authentication.swapMacaroonPath, '/server/loop');
     assert.equal(fileConfig.nodes[0].settings.lnServerUrl, 'https://server:8080');
     assert.equal(fileConfig.nodes[0].settings.themeMode, 'NIGHT');
     assert.equal(fileConfig.nodes[0].settings.evilSetting, undefined);
     assert.equal(fileConfig.nodes[0].macaroonPath, undefined);
-    assert.equal(fileConfig.nodes[1].authentication.macaroonPath, undefined);
-    assert.equal(fileConfig.nodes[1].macaroonPath, undefined);
-    assert.equal(fileConfig.nodes[1].settings.lnServerUrl, 'https://new.example');
     assert.equal(responseBody.nodes[0].authentication.macaroonPath, undefined);
     assert.equal(responseBody.nodes[0].macaroonPath, undefined);
     assert.equal(responseBody.nodes[0].settings.lnServerUrl, 'https://server:8080');
@@ -725,7 +725,7 @@ test('updateApplicationSettings normalizes string node indexes when merging', ()
   }
 });
 
-test('updateApplicationSettings rejects an invalid lnServerUrl on a new node without persisting', () => {
+test('updateApplicationSettings drops unknown-index nodes instead of provisioning them', () => {
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-url-'));
   const oldConfig = {
     defaultNodeIndex: 0,
@@ -757,8 +757,15 @@ test('updateApplicationSettings rejects an invalid lnServerUrl on a new node wit
     allowPasswordUpdate: true,
     SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
     nodes: [
-      { index: 0, lnNode: 'lnd-main', lnImplementation: 'LND', authentication: {}, settings: {} },
-      { index: 9, lnNode: 'rogue-node', lnImplementation: 'LND', authentication: {}, settings: { lnServerUrl: 'not-a-valid-url' } }
+      { index: 0, lnNode: 'lnd-main', lnImplementation: 'LND', authentication: {}, settings: { themeMode: 'DAY' } },
+      {
+        index: 9,
+        lnNode: 'rogue-node',
+        lnImplementation: 'LND',
+        macaroonPath: '/etc/shadow',
+        authentication: { macaroonPath: '/evil/lnd', swapMacaroonPath: '/evil/loop', configPath: '/etc/passwd' },
+        settings: { lnServerUrl: 'https://evil.example', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', logFile: '/tmp/evil.log', themeMode: 'DAY' }
+      }
     ]
   };
 
@@ -785,11 +792,16 @@ test('updateApplicationSettings rejects an invalid lnServerUrl on a new node wit
       null
     );
 
-    assert.equal(responseStatus, 400);
-    assert.equal(JSON.stringify(responseBody).includes('Invalid lnServerUrl'), true);
-    // The failed validation must not have touched the runtime config or the file.
+    // The unknown node is dropped rather than provisioned — a caller-chosen credential
+    // path or server URL would otherwise be persisted and loaded back into the runtime
+    // nodes at the next restart — and the save itself still succeeds.
+    assert.equal(responseStatus, 201);
     assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0]);
-    assert.equal(JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes.length, 1);
+    assert.deepEqual(responseBody.nodes.map((node) => node.index), [0]);
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0]);
+    assert.equal(fileConfig.nodes.some((node) => JSON.stringify(node).includes('evil')), false);
+    assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -541,7 +541,8 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
   });
   // An attacker with an authenticated session attempts to re-point credential paths and
   // server URLs on the existing node, inject runtime-only auth state, smuggle an unknown
-  // setting, and provision a brand-new node carrying its own credential paths.
+  // setting, stash a root-level macaroonPath, and provision a brand-new node carrying its
+  // own credential paths.
   const requestBody = {
     ...clone(oldConfig),
     selectedNodeIndex: 0,
@@ -553,6 +554,7 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
         index: 0,
         lnNode: 'lnd-main',
         lnImplementation: 'LND',
+        macaroonPath: '/etc/shadow',
         authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', runeValue: 'evil-rune', macaroonValue: 'evil-macaroon', options: { headers: { 'Grpc-Metadata-macaroon': 'evil' } } },
         settings: { themeMode: 'NIGHT', lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', evilSetting: 'smuggled' }
       },
@@ -560,6 +562,7 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
         index: 5,
         lnNode: 'new-lnd',
         lnImplementation: 'LND',
+        macaroonPath: '/etc/passwd',
         authentication: { macaroonPath: '/evil/new', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd' },
         settings: { themeMode: 'DAY', lnServerUrl: 'https://new.example' }
       }
@@ -597,6 +600,7 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
     assert.equal(existingNode.authentication.lnApiPassword, undefined);
     assert.equal(existingNode.authentication.runeValue, undefined);
     assert.equal(existingNode.authentication.macaroonValue, undefined);
+    assert.equal(existingNode.macaroonPath, undefined);
     // Runtime-only auth state carried by the pre-existing node survives the save.
     assert.deepEqual(existingNode.authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
     assert.equal(existingNode.settings.lnServerUrl, 'https://server:8080');
@@ -612,6 +616,7 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
     assert.equal(newNode.authentication.runePath, undefined);
     assert.equal(newNode.authentication.lnApiPassword, undefined);
     assert.equal(newNode.authentication.configPath, undefined);
+    assert.equal(newNode.macaroonPath, undefined);
     assert.equal(newNode.settings.lnServerUrl, 'https://new.example');
     assert.equal(newNode.settings.themeMode, 'DAY');
 
@@ -623,9 +628,12 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
     assert.equal(fileConfig.nodes[0].settings.lnServerUrl, 'https://server:8080');
     assert.equal(fileConfig.nodes[0].settings.themeMode, 'NIGHT');
     assert.equal(fileConfig.nodes[0].settings.evilSetting, undefined);
+    assert.equal(fileConfig.nodes[0].macaroonPath, undefined);
     assert.equal(fileConfig.nodes[1].authentication.macaroonPath, undefined);
+    assert.equal(fileConfig.nodes[1].macaroonPath, undefined);
     assert.equal(fileConfig.nodes[1].settings.lnServerUrl, 'https://new.example');
     assert.equal(responseBody.nodes[0].authentication.macaroonPath, undefined);
+    assert.equal(responseBody.nodes[0].macaroonPath, undefined);
     assert.equal(responseBody.nodes[0].settings.lnServerUrl, 'https://server:8080');
   } finally {
     clearInterval(WSServer.pingInterval);

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -859,6 +859,297 @@ test('updateNodeSettings pins channelBackupPath to the server-held value', () =>
   }
 });
 
+test('updateNodeSettings strips sensitive settings fields via allowlist', () => {
+  // lnServerUrl, swapServerUrl, boltzServerUrl, bitcoindConfigPath and channelBackupPath
+  // are not in NODE_SETTINGS_ALLOWLIST; they must be silently dropped from the request.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nodesettings-allowlist-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({ ...oldConfig, rtlConfFilePath: tempDir });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateNodeSettings(
+      {
+        body: { settings: { themeMode: 'NIGHT', lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil' } },
+        session: { selectedNode: Common.nodes[0] }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    const fileNode = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
+    assert.equal(fileNode.settings.themeMode, 'NIGHT');
+    assert.equal(fileNode.settings.lnServerUrl, 'https://server:8080');
+    assert.equal(fileNode.settings.swapServerUrl, 'https://swap:8081');
+    assert.equal(fileNode.settings.boltzServerUrl, 'https://boltz:9003');
+    assert.equal(fileNode.settings.bitcoindConfigPath, '/server/bitcoin.conf');
+    assert.equal(fileNode.settings.channelBackupPath, '/server/backups');
+    assert.equal(Common.nodes[0].settings.themeMode, 'NIGHT');
+    assert.equal(Common.nodes[0].settings.lnServerUrl, 'https://server:8080');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings filters unknown top-level payload keys', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-toplevel-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), evilTopLevel: 'injected', dbDirectoryPath: '/etc/shadow', selectedNodeIndex: 0 },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.evilTopLevel, undefined);
+    assert.equal(Common.appConfig.dbDirectoryPath, '/db');
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.equal(fileConfig.evilTopLevel, undefined);
+    assert.equal(fileConfig.dbDirectoryPath, '/db');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings preserves runtime-only auth state when all payload nodes are dropped', () => {
+  // When every payload node has an unknown index, config.nodes is empty and the rebuild
+  // block must still use the server-held node list — not the stale on-disk copy — so
+  // runtime-only fields (options, runeValue) survive.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-empty-nodes-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' },
+    nodes: [
+      {
+        ...oldConfig.nodes[0],
+        authentication: {
+          ...oldConfig.nodes[0].authentication,
+          options: { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } }
+        }
+      }
+    ]
+  });
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), selectedNodeIndex: 0, nodes: [{ index: 9, lnNode: 'rogue', lnImplementation: 'LND', settings: { themeMode: 'NIGHT' } }] },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    // The unknown node was dropped; the existing node's runtime-only auth state survives.
+    assert.deepEqual(Common.appConfig.nodes.map((n) => n.index), [0]);
+    assert.deepEqual(Common.appConfig.nodes[0].authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings treats non-numeric indexes as unknown and drops them', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nan-index-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), selectedNodeIndex: 0, nodes: [{ index: null, lnNode: 'null-index', settings: { themeMode: 'NIGHT' } }, { index: 'abc', lnNode: 'non-numeric-index', settings: { themeMode: 'NIGHT' } }] },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    // null coerces to 0 via +null, which IS a known index — the node merges with node 0.
+    // 'abc' coerces to NaN, which is not finite, so it is dropped as unknown.
+    // Neither crashes the endpoint.
+    assert.equal(Common.appConfig.nodes.length, 1);
+    assert.equal(Common.appConfig.nodes[0].index, 0);
+    assert.equal(Common.appConfig.nodes[0].lnNode, 'lnd-main');
+    assert.deepEqual(Common.appConfig.nodes.map((n) => n.index), [0]);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateNodeSettings strips sensitive authentication fields via addSecureData', () => {
+  // boltzMacaroonPath and swapMacaroonPath are not in NODE_AUTH_ALLOWLIST; the node
+  // settings endpoint should not allow changing them.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nodesettings-auth-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin', swapMacaroonPath: '/server/loop', boltzMacaroonPath: '/server/boltz' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({ ...oldConfig, rtlConfFilePath: tempDir });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateNodeSettings(
+      {
+        body: { settings: { themeMode: 'NIGHT' }, authentication: { swapMacaroonPath: '/evil/loop', boltzMacaroonPath: '/evil/boltz' } },
+        session: { selectedNode: Common.nodes[0] }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    const fileNode = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
+    assert.equal(fileNode.settings.themeMode, 'NIGHT');
+    // The auth fields should not have been modified by the request body authentication.
+    assert.equal(fileNode.authentication.swapMacaroonPath, '/server/loop');
+    assert.equal(fileNode.authentication.boltzMacaroonPath, '/server/boltz');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test('getFile contains caller paths to the channel backup directory', async () => {
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-getfile-'));
   const backupDir = join(tempDir, 'backups');

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -1314,6 +1314,126 @@ test('updateApplicationSettings rebuilds and filters against the runtime node li
   }
 });
 
+test('updateApplicationSettings drops invalid defaultNodeIndex and selectedNodeIndex values', () => {
+  // Both scalars pass TOP_LEVEL_ALLOWLIST, but they must carry the same known-index
+  // discipline as nodes[]: defaultNodeIndex is persisted (unlike selectedNodeIndex it is
+  // not stripped from the file config), so a body value that is unknown (999) or
+  // unparseable ('abc') would survive a restart. They are dropped and the server-held
+  // values win.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-index-scalars-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), defaultNodeIndex: 999, selectedNodeIndex: 'abc' },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.defaultNodeIndex, 0);
+    assert.equal(Common.appConfig.selectedNodeIndex, 0);
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.equal(fileConfig.defaultNodeIndex, 0);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings does not silently discard the payload when the runtime node list is empty', () => {
+  // The node rebuild is guarded on common.nodes being non-empty. If it is empty (cannot
+  // happen after a normal boot — common.nodes is built from the file at boot — but the
+  // guard must not be silent), the allowlisted-and-pinned payload must become the saved
+  // nodes instead of the unmodified on-disk copy pretending a save happened.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-empty-runtime-'));
+  const staleFile = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...staleFile,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = [];
+    Common.selectedNode = null;
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(staleFile, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(staleFile), selectedNodeIndex: 0, nodes: [{ index: 9, lnNode: 'rogue', lnImplementation: 'LND', settings: { themeMode: 'NIGHT' } }] },
+        session: { selectedNode: null }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    // With no known runtime nodes, nothing is known; the payload node (index 9) is dropped
+    // and the save records exactly that instead of keeping the stale on-disk node.
+    assert.deepEqual(Common.appConfig.nodes, []);
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.deepEqual(fileConfig.nodes, []);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test('updateApplicationSettings treats empty, null, boolean and array indexes as unknown and drops them', () => {
   // indexKey rejects anything that is not a number or a non-blank numeric string. Under a
   // naive +val coercion ''/false/[]/null would all become 0 — a real node — and would

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -859,9 +859,12 @@ test('updateNodeSettings pins channelBackupPath to the server-held value', () =>
   }
 });
 
-test('updateNodeSettings strips sensitive settings fields via allowlist', () => {
-  // lnServerUrl, swapServerUrl, boltzServerUrl, bitcoindConfigPath and channelBackupPath
-  // are not in NODE_SETTINGS_ALLOWLIST; they must be silently dropped from the request.
+test('updateNodeSettings allowlists settings, applies valid service URLs and pins LN credential anchors', () => {
+  // lnServerUrl, bitcoindConfigPath and channelBackupPath are not in the node-settings
+  // allowlist — they must be silently dropped from the request. swapServerUrl and
+  // boltzServerUrl are legitimately edited here (the node-config Services page sends
+  // them), so valid http(s) values are applied; malformed or non-HTTP values are dropped
+  // by the same format validation the application-settings endpoint uses.
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nodesettings-allowlist-'));
   const oldConfig = {
     defaultNodeIndex: 0,
@@ -903,12 +906,32 @@ test('updateNodeSettings strips sensitive settings fields via allowlist', () => 
     const fileNode = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
     assert.equal(fileNode.settings.themeMode, 'NIGHT');
     assert.equal(fileNode.settings.lnServerUrl, 'https://server:8080');
-    assert.equal(fileNode.settings.swapServerUrl, 'https://swap:8081');
-    assert.equal(fileNode.settings.boltzServerUrl, 'https://boltz:9003');
+    // Valid service URLs are applied.
+    assert.equal(fileNode.settings.swapServerUrl, 'https://evil.swap');
+    assert.equal(fileNode.settings.boltzServerUrl, 'https://evil.boltz');
     assert.equal(fileNode.settings.bitcoindConfigPath, '/server/bitcoin.conf');
     assert.equal(fileNode.settings.channelBackupPath, '/server/backups');
     assert.equal(Common.nodes[0].settings.themeMode, 'NIGHT');
     assert.equal(Common.nodes[0].settings.lnServerUrl, 'https://server:8080');
+
+    // Malformed or non-HTTP service URLs are dropped, keeping the previously applied value.
+    updateNodeSettings(
+      {
+        body: { settings: { swapServerUrl: 'not-a-url', boltzServerUrl: 'file:///etc/passwd' } },
+        session: { selectedNode: Common.nodes[0] }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+    assert.equal(responseStatus, 201);
+    const fileNodeAfterInvalid = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
+    assert.equal(fileNodeAfterInvalid.settings.swapServerUrl, 'https://evil.swap');
+    assert.equal(fileNodeAfterInvalid.settings.boltzServerUrl, 'https://evil.boltz');
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
@@ -927,7 +950,7 @@ test('updateApplicationSettings validates blockExplorerUrl format and rejects ma
         lnNode: 'lnd-main',
         lnImplementation: 'LND',
         authentication: { macaroonPath: '/lnd/admin' },
-        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', blockExplorerUrl: 'https://mempool.space' }
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', blockExplorerUrl: 'https://mempool.space', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003' }
       }
     ]
   };
@@ -993,6 +1016,44 @@ test('updateApplicationSettings validates blockExplorerUrl format and rejects ma
 
     assert.equal(responseStatus, 201);
     assert.equal(Common.appConfig.nodes[0].settings.blockExplorerUrl, 'https://mempool.example');
+    // Service URLs are not accepted on the application-settings endpoint; they are pinned
+    // back to the server-held values.
+    assert.equal(Common.appConfig.nodes[0].settings.swapServerUrl, 'https://swap:8081');
+    assert.equal(Common.appConfig.nodes[0].settings.boltzServerUrl, 'https://boltz:9003');
+
+    // A parseable but non-HTTP scheme (file:///etc/passwd) is rejected too — it would
+    // otherwise be persisted and re-loaded into the runtime config, or copied into the
+    // outbound request built from the live node's settings.
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), selectedNodeIndex: 0, nodes: [{ index: 0, settings: { blockExplorerUrl: 'file:///etc/passwd', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', themeMode: 'DAY' } }] },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.nodes[0].settings.blockExplorerUrl, 'https://mempool.space');
+    assert.equal(Common.appConfig.nodes[0].settings.swapServerUrl, 'https://swap:8081');
+    assert.equal(Common.appConfig.nodes[0].settings.boltzServerUrl, 'https://boltz:9003');
+    assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
@@ -1124,7 +1185,140 @@ test('updateApplicationSettings preserves runtime-only auth state when all paylo
   }
 });
 
-test('updateApplicationSettings treats non-numeric indexes as unknown and drops them', () => {
+test('updateApplicationSettings drops a caller-supplied multiPass', () => {
+  // The plaintext password is hashed into multiPassHashed at boot and never sent back to
+  // the client (getApplicationSettings serves the file masked), so a multiPass arriving in
+  // the request body can only be attacker-supplied. It is rejected at the allowlist and
+  // must not be persisted to RTL-Config.json.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-multipass-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), selectedNodeIndex: 0, multiPass: 'attacker-password' },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.multiPass, undefined);
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.equal(fileConfig.multiPass, undefined);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings rebuilds and filters against the runtime node list (common.nodes), not the stale on-disk copy', () => {
+  // F12: both known-vs-unknown and the node rebuild — the two sides of the same decision —
+  // resolve against common.nodes, the single authoritative runtime list (addSecureData
+  // pins from it; updateNodeSettings mutates it in place). If the controller resolved
+  // against common.appConfig.nodes — a fresh clone at every save that can go stale — a
+  // settings edit made through the node-settings endpoint (swapServerUrl below) would be
+  // silently reverted to the stale on-disk value, and a runtime node could be dropped as
+  // unknown. Here the on-disk file (and the stale appConfig copy) predate the runtime
+  // state; the edit must survive the application-settings save.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-runtime-nodes-'));
+  const staleFile = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY' }
+      }
+    ]
+  };
+  const runtimeNodes = clone(staleFile.nodes);
+  runtimeNodes[0].settings.swapServerUrl = 'https://swap:8081';
+  runtimeNodes[0].settings.themeMode = 'NIGHT';
+  runtimeNodes[0].authentication.options = { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } };
+
+  try {
+    Common.appConfig = clone({
+      ...staleFile,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(runtimeNodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(staleFile, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: { ...clone(staleFile), selectedNodeIndex: 0, nodes: [{ index: 0, settings: { themeMode: 'DAY' } }, { index: 9, lnNode: 'rogue', lnImplementation: 'LND', settings: { themeMode: 'NIGHT' } }] },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    // The unknown node is dropped and only node 0 remains.
+    assert.deepEqual(Common.appConfig.nodes.map((n) => n.index), [0]);
+    // The runtime-only service URL edit made via updateNodeSettings survives the rebuild.
+    assert.equal(Common.appConfig.nodes[0].settings.swapServerUrl, 'https://swap:8081');
+    // Runtime-only auth state survives too.
+    assert.deepEqual(Common.appConfig.nodes[0].authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
+    // The payload edit is applied.
+    assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings treats empty, null, boolean and array indexes as unknown and drops them', () => {
+  // indexKey rejects anything that is not a number or a non-blank numeric string. Under a
+  // naive +val coercion ''/false/[]/null would all become 0 — a real node — and would
+  // merge into (and REWRITE) the operator's node as 'empty-index'/'bool-index'/etc.; they
+  // must instead be dropped as unknown. 'abc' → NaN → not finite → dropped too.
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nan-index-'));
   const oldConfig = {
     defaultNodeIndex: 0,
@@ -1156,7 +1350,17 @@ test('updateApplicationSettings treats non-numeric indexes as unknown and drops 
     let responseStatus = null;
     updateApplicationSettings(
       {
-        body: { ...clone(oldConfig), selectedNodeIndex: 0, nodes: [{ index: null, lnNode: 'null-index', settings: { themeMode: 'NIGHT' } }, { index: 'abc', lnNode: 'non-numeric-index', settings: { themeMode: 'NIGHT' } }] },
+        body: {
+          ...clone(oldConfig),
+          selectedNodeIndex: 0,
+          nodes: [
+            { index: null, lnNode: 'null-index', settings: { themeMode: 'NIGHT' } },
+            { index: '', lnNode: 'empty-index', settings: { themeMode: 'NIGHT' } },
+            { index: false, lnNode: 'bool-index', settings: { themeMode: 'NIGHT' } },
+            { index: [], lnNode: 'array-index', settings: { themeMode: 'NIGHT' } },
+            { index: 'abc', lnNode: 'non-numeric-index', settings: { themeMode: 'NIGHT' } }
+          ]
+        },
         session: { selectedNode: Common.selectedNode }
       },
       {
@@ -1169,9 +1373,7 @@ test('updateApplicationSettings treats non-numeric indexes as unknown and drops 
     );
 
     assert.equal(responseStatus, 201);
-    // null coerces to 0 via +null, which IS a known index — the node merges with node 0.
-    // 'abc' coerces to NaN, which is not finite, so it is dropped as unknown.
-    // Neither crashes the endpoint.
+    // None of the coerced-to-0 candidates may merge with the real node 0.
     assert.equal(Common.appConfig.nodes.length, 1);
     assert.equal(Common.appConfig.nodes[0].index, 0);
     assert.equal(Common.appConfig.nodes[0].lnNode, 'lnd-main');
@@ -1182,9 +1384,12 @@ test('updateApplicationSettings treats non-numeric indexes as unknown and drops 
   }
 });
 
-test('updateNodeSettings strips sensitive authentication fields via addSecureData', () => {
-  // boltzMacaroonPath and swapMacaroonPath are not in NODE_AUTH_ALLOWLIST; the node
-  // settings endpoint should not allow changing them.
+test('updateNodeSettings applies Loop/Boltz service macaroon paths but never the LN credential paths', () => {
+  // The node-config Services page edits the swap and Boltz macaroon paths through this
+  // endpoint (the client holds them — removeSecureData keeps them), so they are applied;
+  // an empty value clears the field. The LN credential anchors (macaroonPath, runePath,
+  // lnApiPassword, configPath) have no writable path through any endpoint and must stay
+  // pinned to the server value.
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-nodesettings-auth-'));
   const oldConfig = {
     defaultNodeIndex: 0,
@@ -1210,7 +1415,7 @@ test('updateNodeSettings strips sensitive authentication fields via addSecureDat
     let responseStatus = null;
     updateNodeSettings(
       {
-        body: { settings: { themeMode: 'NIGHT' }, authentication: { swapMacaroonPath: '/evil/loop', boltzMacaroonPath: '/evil/boltz' } },
+        body: { settings: { themeMode: 'NIGHT' }, authentication: { swapMacaroonPath: '/evil/loop', boltzMacaroonPath: '/evil/boltz', macaroonPath: '/evil/lnd', configPath: '/etc/passwd' } },
         session: { selectedNode: Common.nodes[0] }
       },
       {
@@ -1225,9 +1430,32 @@ test('updateNodeSettings strips sensitive authentication fields via addSecureDat
     assert.equal(responseStatus, 201);
     const fileNode = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
     assert.equal(fileNode.settings.themeMode, 'NIGHT');
-    // The auth fields should not have been modified by the request body authentication.
-    assert.equal(fileNode.authentication.swapMacaroonPath, '/server/loop');
-    assert.equal(fileNode.authentication.boltzMacaroonPath, '/server/boltz');
+    // The service macaroon paths are applied from the request body.
+    assert.equal(fileNode.authentication.swapMacaroonPath, '/evil/loop');
+    assert.equal(fileNode.authentication.boltzMacaroonPath, '/evil/boltz');
+    // The LN credential paths are untouched.
+    assert.equal(fileNode.authentication.macaroonPath, '/lnd/admin');
+    assert.equal(fileNode.authentication.configPath, undefined);
+
+    // An empty service path clears the field.
+    updateNodeSettings(
+      {
+        body: { authentication: { swapMacaroonPath: '', boltzMacaroonPath: '' } },
+        session: { selectedNode: Common.nodes[0] }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+    assert.equal(responseStatus, 201);
+    const clearedNode = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes[0];
+    assert.equal(clearedNode.authentication.swapMacaroonPath, undefined);
+    assert.equal(clearedNode.authentication.boltzMacaroonPath, undefined);
+    assert.equal(clearedNode.authentication.macaroonPath, '/lnd/admin');
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
@@ -1273,6 +1501,27 @@ test('getFile contains caller paths to the channel backup directory', async () =
     });
     assert.equal(missing.statusCode, 500);
     assert.equal(JSON.stringify(missing.body).includes(backupDir), false);
+
+    // The channel branch derives the backup file name from the channel value.
+    const channelServed = mockRes();
+    await new Promise((resolve) => {
+      const res = { status: (code) => { channelServed.statusCode = code; return { json: (body) => { channelServed.body = body; resolve(); } }; } };
+      getFile({ query: { channel: '1x2x3' }, session }, res, null);
+    });
+    assert.equal(channelServed.statusCode, 200);
+    assert.equal(channelServed.body, 'backup-data');
+
+    // A channel carrying path separators would otherwise concatenate into an escaping file
+    // name (secret.bak lives outside the backup dir); the sanitizer neutralizes them, so
+    // the read stays contained and fails on the missing file rather than serving the
+    // out-of-tree contents.
+    const channelTraversal = mockRes();
+    await new Promise((resolve) => {
+      const res = { status: (code) => { channelTraversal.statusCode = code; return { json: (body) => { channelTraversal.body = body; resolve(); } }; } };
+      getFile({ query: { channel: '../secret' }, session }, res, null);
+    });
+    assert.equal(channelTraversal.statusCode, 500);
+    assert.equal(JSON.stringify(channelTraversal.body).includes('top-secret'), false);
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -505,6 +505,289 @@ test('updateApplicationSettings falls back to an in-place write when the rename 
   }
 });
 
+test('updateApplicationSettings strips untrusted credential paths and un-allowlisted payload fields', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-allowlist-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/server/lnd/admin', configPath: '' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', lnServerUrl: 'https://server:8080', swapServerUrl: 'https://swap:8081', boltzServerUrl: 'https://boltz:9003', bitcoindConfigPath: '/server/bitcoin.conf', channelBackupPath: '/server/backups' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '', cookieValue: 'live-sso-cookie' },
+    nodes: [
+      {
+        ...oldConfig.nodes[0],
+        authentication: {
+          ...oldConfig.nodes[0].authentication,
+          options: { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } }
+        }
+      }
+    ]
+  });
+  // An attacker with an authenticated session attempts to re-point credential paths and
+  // server URLs on the existing node, inject runtime-only auth state, smuggle an unknown
+  // setting, and provision a brand-new node carrying its own credential paths.
+  const requestBody = {
+    ...clone(oldConfig),
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/evil/lnd', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd', runeValue: 'evil-rune', macaroonValue: 'evil-macaroon', options: { headers: { 'Grpc-Metadata-macaroon': 'evil' } } },
+        settings: { themeMode: 'NIGHT', lnServerUrl: 'https://evil.example', swapServerUrl: 'https://evil.swap', boltzServerUrl: 'https://evil.boltz', bitcoindConfigPath: '/etc/shadow', channelBackupPath: '/tmp/evil', evilSetting: 'smuggled' }
+      },
+      {
+        index: 5,
+        lnNode: 'new-lnd',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/evil/new', runePath: '/evil/rune', lnApiPassword: 'evil-pass', configPath: '/etc/passwd' },
+        settings: { themeMode: 'DAY', lnServerUrl: 'https://new.example' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    let responseBody;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return {
+            json: (body) => {
+              responseBody = body;
+            }
+          };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    const existingNode = Common.appConfig.nodes[0];
+    assert.equal(existingNode.authentication.macaroonPath, '/server/lnd/admin');
+    assert.equal(existingNode.authentication.configPath, '');
+    assert.equal(existingNode.authentication.runePath, undefined);
+    assert.equal(existingNode.authentication.lnApiPassword, undefined);
+    assert.equal(existingNode.authentication.runeValue, undefined);
+    assert.equal(existingNode.authentication.macaroonValue, undefined);
+    // Runtime-only auth state carried by the pre-existing node survives the save.
+    assert.deepEqual(existingNode.authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
+    assert.equal(existingNode.settings.lnServerUrl, 'https://server:8080');
+    assert.equal(existingNode.settings.swapServerUrl, 'https://swap:8081');
+    assert.equal(existingNode.settings.boltzServerUrl, 'https://boltz:9003');
+    assert.equal(existingNode.settings.bitcoindConfigPath, '/server/bitcoin.conf');
+    assert.equal(existingNode.settings.channelBackupPath, '/server/backups');
+    assert.equal(existingNode.settings.themeMode, 'NIGHT');
+    assert.equal(existingNode.settings.evilSetting, undefined);
+    const newNode = Common.appConfig.nodes[1];
+    assert.equal(newNode.index, 5);
+    assert.equal(newNode.authentication.macaroonPath, undefined);
+    assert.equal(newNode.authentication.runePath, undefined);
+    assert.equal(newNode.authentication.lnApiPassword, undefined);
+    assert.equal(newNode.authentication.configPath, undefined);
+    assert.equal(newNode.settings.lnServerUrl, 'https://new.example');
+    assert.equal(newNode.settings.themeMode, 'DAY');
+
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 5]);
+    assert.equal(fileConfig.nodes[0].authentication.macaroonPath, '/server/lnd/admin');
+    assert.equal(fileConfig.nodes[0].authentication.options, undefined);
+    assert.equal(fileConfig.nodes[0].authentication.runeValue, undefined);
+    assert.equal(fileConfig.nodes[0].settings.lnServerUrl, 'https://server:8080');
+    assert.equal(fileConfig.nodes[0].settings.themeMode, 'NIGHT');
+    assert.equal(fileConfig.nodes[0].settings.evilSetting, undefined);
+    assert.equal(fileConfig.nodes[1].authentication.macaroonPath, undefined);
+    assert.equal(fileConfig.nodes[1].settings.lnServerUrl, 'https://new.example');
+    assert.equal(responseBody.nodes[0].authentication.macaroonPath, undefined);
+    assert.equal(responseBody.nodes[0].settings.lnServerUrl, 'https://server:8080');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings normalizes string node indexes when merging', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-index-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/server/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', lnServerUrl: 'https://server:8080' }
+      },
+      {
+        index: 2,
+        lnNode: 'cln-secondary',
+        lnImplementation: 'CLN',
+        authentication: { runePath: '/cln/rune' },
+        settings: { userPersona: 'MERCHANT', themeMode: 'NIGHT', lnServerUrl: 'https://cln:8080' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '', cookieValue: 'live-sso-cookie' }
+  });
+  // JSON payloads carry indexes as strings; "2" must merge into the existing node 2, not
+  // be appended as a brand-new node.
+  const requestBody = {
+    ...clone(oldConfig),
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: '2',
+        lnNode: 'cln-secondary',
+        lnImplementation: 'CLN',
+        authentication: {},
+        settings: { themeMode: 'DAY' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0, 2]);
+    const clnNode = Common.appConfig.nodes[1];
+    assert.equal(clnNode.index, 2);
+    assert.equal(clnNode.settings.themeMode, 'DAY');
+    assert.equal(clnNode.settings.lnServerUrl, 'https://cln:8080');
+    assert.equal(clnNode.authentication.runePath, '/cln/rune');
+    const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 2]);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings rejects an invalid lnServerUrl on a new node without persisting', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-url-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/server/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', lnServerUrl: 'https://server:8080' }
+      }
+    ]
+  };
+  const runtimeConfig = clone({
+    ...oldConfig,
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    rtlConfFilePath: tempDir,
+    rtlPass: 'hashed-password',
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '', cookieValue: 'live-sso-cookie' }
+  });
+  const requestBody = {
+    ...clone(oldConfig),
+    selectedNodeIndex: 0,
+    enable2FA: false,
+    allowPasswordUpdate: true,
+    SSO: { rtlSSO: 0, rtlCookiePath: '/cookie-path', logoutRedirectLink: '' },
+    nodes: [
+      { index: 0, lnNode: 'lnd-main', lnImplementation: 'LND', authentication: {}, settings: {} },
+      { index: 9, lnNode: 'rogue-node', lnImplementation: 'LND', authentication: {}, settings: { lnServerUrl: 'not-a-valid-url' } }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone(runtimeConfig);
+    Common.nodes = clone(runtimeConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    let responseBody;
+    updateApplicationSettings(
+      { body: clone(requestBody), session: { selectedNode: Common.selectedNode } },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return {
+            json: (body) => {
+              responseBody = body;
+            }
+          };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 400);
+    assert.equal(JSON.stringify(responseBody).includes('Invalid lnServerUrl'), true);
+    // The failed validation must not have touched the runtime config or the file.
+    assert.deepEqual(Common.appConfig.nodes.map((node) => node.index), [0]);
+    assert.equal(JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8')).nodes.length, 1);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test('updateNodeSettings pins channelBackupPath to the server-held value', () => {
   // channelBackupPath anchors getFile's containment root; accepting it from the request
   // would let the caller being contained choose the containment base.

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -915,6 +915,90 @@ test('updateNodeSettings strips sensitive settings fields via allowlist', () => 
   }
 });
 
+test('updateApplicationSettings validates blockExplorerUrl format and rejects malformed values', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-blockexplorer-'));
+  const oldConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', blockExplorerUrl: 'https://mempool.space' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+
+    let responseStatus;
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), selectedNodeIndex: 0, nodes: [{ index: 0, settings: { blockExplorerUrl: 'not-a-url', themeMode: 'NIGHT' } }] },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    // The malformed URL is rejected; the server-held value is preserved.
+    assert.equal(Common.appConfig.nodes[0].settings.blockExplorerUrl, 'https://mempool.space');
+    // Other settings still merge.
+    assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'NIGHT');
+
+    // Now test a valid URL is accepted.
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(oldConfig, null, 2), 'utf-8');
+    Common.appConfig = clone({
+      ...oldConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(oldConfig.nodes);
+    Common.selectedNode = Common.nodes[0];
+
+    updateApplicationSettings(
+      {
+        body: { ...clone(oldConfig), selectedNodeIndex: 0, nodes: [{ index: 0, settings: { blockExplorerUrl: 'https://mempool.example', themeMode: 'DAY' } }] },
+        session: { selectedNode: Common.selectedNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    assert.equal(Common.appConfig.nodes[0].settings.blockExplorerUrl, 'https://mempool.example');
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test('updateApplicationSettings filters unknown top-level payload keys', () => {
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-toplevel-'));
   const oldConfig = {

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import test from 'node:test';
 
-import { updateApplicationSettings, updateNodeSettings, getFile } from '../../backend/controllers/shared/RTLConf.js';
+import { updateApplicationSettings, updateNodeSettings, getFile, getExplorerTransaction } from '../../backend/controllers/shared/RTLConf.js';
 import { Common } from '../../backend/utils/common.js';
 import { WSServer } from '../../backend/utils/webSocketServer.js';
 
@@ -1374,11 +1375,12 @@ test('updateApplicationSettings drops invalid defaultNodeIndex and selectedNodeI
   }
 });
 
-test('updateApplicationSettings does not silently discard the payload when the runtime node list is empty', () => {
+test('updateApplicationSettings keeps the on-disk node list when the runtime node list is empty', () => {
   // The node rebuild is guarded on common.nodes being non-empty. If it is empty (cannot
-  // happen after a normal boot — common.nodes is built from the file at boot — but the
-  // guard must not be silent), the allowlisted-and-pinned payload must become the saved
-  // nodes instead of the unmodified on-disk copy pretending a save happened.
+  // happen after a normal boot — common.nodes is built from the file at boot and only
+  // mutated in place afterwards), knownIndexes is empty too, so every payload node is
+  // dropped as unknown. There is then nothing to merge, and the on-disk node list must
+  // survive untouched rather than being overwritten with an empty array.
   const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-empty-runtime-'));
   const staleFile = {
     defaultNodeIndex: 0,
@@ -1423,11 +1425,91 @@ test('updateApplicationSettings does not silently discard the payload when the r
     );
 
     assert.equal(responseStatus, 201);
-    // With no known runtime nodes, nothing is known; the payload node (index 9) is dropped
-    // and the save records exactly that instead of keeping the stale on-disk node.
-    assert.deepEqual(Common.appConfig.nodes, []);
+    // With no known runtime nodes the payload node (index 9) is dropped; the on-disk node
+    // list is neither replaced by it nor wiped.
+    assert.deepEqual(Common.appConfig.nodes, staleFile.nodes);
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
-    assert.deepEqual(fileConfig.nodes, []);
+    assert.deepEqual(fileConfig.nodes, staleFile.nodes);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('updateApplicationSettings publishes allowlisted node edits to the live runtime node list', () => {
+  // common.appConfig is reassigned on every save, but common.nodes is the list the
+  // session, the explorer requests and the next save read from. A saved setting must land
+  // there too, or it takes effect only after a restart and the next save reverts it.
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-live-nodes-'));
+  const fileConfig = {
+    defaultNodeIndex: 0,
+    dbDirectoryPath: '/db',
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [
+      {
+        index: 0,
+        lnNode: 'lnd-main',
+        lnImplementation: 'LND',
+        authentication: { macaroonPath: '/lnd/admin' },
+        settings: { userPersona: 'OPERATOR', themeMode: 'DAY', lnServerUrl: 'https://lnd.internal:8080', blockExplorerUrl: 'https://old.example' }
+      }
+    ]
+  };
+
+  try {
+    Common.appConfig = clone({
+      ...fileConfig,
+      selectedNodeIndex: 0,
+      rtlConfFilePath: tempDir,
+      rtlPass: 'hashed-password',
+      SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '', cookieValue: '' }
+    });
+    Common.nodes = clone(fileConfig.nodes);
+    Common.nodes[0].authentication.options = { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } };
+    const liveNode = Common.nodes[0];
+    Common.selectedNode = liveNode;
+    writeFileSync(join(tempDir, 'RTL-Config.json'), JSON.stringify(fileConfig, null, 2), 'utf-8');
+
+    let responseStatus = null;
+    updateApplicationSettings(
+      {
+        body: {
+          ...clone(fileConfig),
+          selectedNodeIndex: 0,
+          nodes: [{ index: 0, lnNode: 'lnd-renamed', lnImplementation: 'LND', settings: { themeMode: 'NIGHT', blockExplorerUrl: 'https://new.example', lnServerUrl: 'https://attacker.example' } }]
+        },
+        session: { selectedNode: liveNode }
+      },
+      {
+        status: (status) => {
+          responseStatus = status;
+          return { json: () => {} };
+        }
+      },
+      null
+    );
+
+    assert.equal(responseStatus, 201);
+    // The live node object (still the same one the session holds) carries the edit.
+    assert.equal(Common.nodes[0], liveNode);
+    assert.equal(liveNode.settings.themeMode, 'NIGHT');
+    assert.equal(liveNode.settings.blockExplorerUrl, 'https://new.example');
+    assert.equal(liveNode.lnNode, 'lnd-renamed');
+    // Pinned anchors and runtime-only auth state are untouched.
+    assert.equal(liveNode.settings.lnServerUrl, 'https://lnd.internal:8080');
+    assert.equal(liveNode.authentication.macaroonPath, '/lnd/admin');
+    assert.deepEqual(liveNode.authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
+    // A second save that omits the setting must not revert it.
+    updateApplicationSettings(
+      { body: { ...clone(fileConfig), selectedNodeIndex: 0, nodes: [{ index: 0, settings: { userPersona: 'MERCHANT' } }] }, session: { selectedNode: liveNode } },
+      { status: () => ({ json: () => {} }) },
+      null
+    );
+    assert.equal(liveNode.settings.themeMode, 'NIGHT');
+    assert.equal(liveNode.settings.userPersona, 'MERCHANT');
+    const persisted = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.equal(persisted.nodes[0].settings.themeMode, 'NIGHT');
+    assert.equal(persisted.nodes[0].settings.userPersona, 'MERCHANT');
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
@@ -1645,5 +1727,71 @@ test('getFile contains caller paths to the channel backup directory', async () =
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getFile refuses an empty backup root and a non-string channel instead of widening the read', async () => {
+  const mockRes = () => {
+    const res = { statusCode: null, body: null };
+    res.status = (code) => {
+      res.statusCode = code;
+      return { json: (body) => { res.body = body; } };
+    };
+    return res;
+  };
+  const tempDir = mkdtempSync(join(tmpdir(), 'rtlconf-getfile-guard-'));
+  const backupDir = join(tempDir, 'backups');
+  mkdirSync(backupDir);
+  writeFileSync(join(backupDir, 'channel-1x2x3.bak'), 'backup-data', 'utf-8');
+
+  try {
+    // resolve('') is the working directory, so an unset backup path would silently make
+    // the whole install tree the containment root. Refuse before any read.
+    for (const emptyRoot of ['', undefined]) {
+      const session = { selectedNode: { lnImplementation: 'LND', settings: { channelBackupPath: emptyRoot } } };
+      const rejected = mockRes();
+      getFile({ query: { path: join(process.cwd(), 'package.json') }, session }, rejected, null);
+      assert.equal(rejected.statusCode, 500);
+      assert.equal(JSON.stringify(rejected.body).includes('"name"'), false);
+      const rejectedChannel = mockRes();
+      getFile({ query: { channel: '1x2x3' }, session }, rejectedChannel, null);
+      assert.equal(rejectedChannel.statusCode, 500);
+    }
+
+    // Express parses ?channel=a&channel=b into an array and ?channel[x]=y into an object;
+    // neither has .replace, and the handler has no try/catch, so this used to throw.
+    const session = { selectedNode: { lnImplementation: 'LND', settings: { channelBackupPath: backupDir } } };
+    for (const badChannel of [['1x2x3', '4x5x6'], { x: '1x2x3' }]) {
+      const rejected = mockRes();
+      assert.doesNotThrow(() => getFile({ query: { channel: badChannel }, session }, rejected, null));
+      assert.equal(rejected.statusCode, 400);
+    }
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getExplorerTransaction URL-encodes the txid path segment', async () => {
+  const seen = [];
+  const server = createServer((req, res) => {
+    seen.push(req.url);
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const explorer = 'http://127.0.0.1:' + server.address().port;
+  const session = { selectedNode: { index: 7, lnImplementation: 'LND', settings: { blockExplorerUrl: explorer } } };
+
+  try {
+    const body = await new Promise((resolve) => {
+      const res = { status: () => ({ json: (payload) => resolve(payload) }) };
+      getExplorerTransaction({ params: { txid: 'abc/../../api/v1/fees?x=1#f' }, session }, res, null);
+    });
+    assert.deepEqual(body, { ok: true });
+    assert.deepEqual(seen, ['/api/tx/' + encodeURIComponent('abc/../../api/v1/fees?x=1#f')]);
+  } finally {
+    clearInterval(WSServer.pingInterval);
+    await new Promise((resolve) => server.close(resolve));
   }
 });

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -1369,6 +1369,19 @@ test('updateApplicationSettings drops invalid defaultNodeIndex and selectedNodeI
     assert.equal(Common.appConfig.selectedNodeIndex, 0);
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
     assert.equal(fileConfig.defaultNodeIndex, 0);
+
+    // A valid index arriving as a JSON string is normalized to a number, like the node
+    // entries are: every consumer compares strictly (findNode, getApplicationSettings),
+    // so a persisted "0" would match no node after a restart.
+    updateApplicationSettings(
+      { body: { ...clone(oldConfig), defaultNodeIndex: '0', selectedNodeIndex: '0' }, session: { selectedNode: Common.selectedNode } },
+      { status: () => ({ json: () => {} }) },
+      null
+    );
+    assert.strictEqual(Common.appConfig.defaultNodeIndex, 0);
+    assert.strictEqual(Common.appConfig.selectedNodeIndex, 0);
+    const normalized = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
+    assert.strictEqual(normalized.defaultNodeIndex, 0);
   } finally {
     clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });


### PR DESCRIPTION
## Here is a full breakdown

Fixes #1660


## Context & Problem Statement

Prior to this fix, the `/api/rtlconf/updateApplicationSettings` endpoint merged the
request body's per-node `authentication` and `settings` into the server's runtime config
(`Common.appConfig`) without allowlisting. An authenticated caller could supply a
`macaroonPath`, `runePath`, `lnApiPassword`, `configPath` or `lnServerUrl` and re-point
credential reads (`getConfig`, `getFile`) or credentialed outbound requests at
attacker-controlled values — a confused-deputy vector into host file reads and internal
HTTP targets.

## Solution Overview

The endpoint now allowlists the node fields it accepts from the body and re-pins server
URLs and credential paths to the server-held values for existing nodes:

* **Payload allowlisting:** per-node `settings` keys are restricted to the same set the
  Node Settings endpoint uses, and `authentication` is stripped wholesale from the
  request body (addSecureData re-pins every credential anchor from the server-held node).
  Unknown top-level keys, unknown node indexes (there is no add-node flow through this
  endpoint), a caller-invented node top-level key, and a plaintext `multiPass` are
  dropped with a warning instead of being persisted.
* **Credential & path pinning:** `macaroonPath`, `runePath`, `lnApiPassword`,
  `configPath`, `bitcoindConfigPath`, `channelBackupPath`, `logFile` and the server URLs
  (`lnServerUrl`, `swapServerUrl`, `boltzServerUrl`) are pinned to the server-held values
  for existing nodes and stripped from unknown nodes. Known-vs-unknown and the rebuild
  both resolve against the single authoritative runtime node list (`common.nodes`), so
  the two layers can never disagree about which node is which.
* **URL format validation:** user-editable URL settings — `blockExplorerUrl` here, plus
  `swapServerUrl`/`boltzServerUrl` on the Node Settings endpoint — are validated by the
  shared `filterNodeSettings`/`isValidHttpUrl` helpers; malformed or non-http(s) values
  (e.g. `file://`) are silently dropped and the previous server-held value is kept. This
  is format validation only and does not stop a caller from pointing at an internal host:
  self-hosted block explorers and Loop/Boltz servers are intended features, so the fields
  are deliberately not pinned.
* **Loop/Boltz service settings stay editable:** the Node Settings endpoint (the
  node-config Services page) still accepts `swapServerUrl`, `boltzServerUrl` and
  `swapMacaroonPath`/`boltzMacaroonPath`, now with the same format validation; an empty
  macaroon path clears the field. The LN credential paths have no writable path through
  any endpoint.
* **Index & path hardening:** node indexes are normalized to numbers, and values that a
  naive coercion would turn into `0` (`''`, `false`, `[]`, `null`) are treated as unknown
  instead of merging into a real node; the `defaultNodeIndex`/`selectedNodeIndex` scalars
  are held to the same known-index standard as the node entries, so an out-of-range or
  unparseable value is dropped rather than persisted across a restart; CLN's live rune
  (`authentication.runeValue`) is pinned for known nodes and stripped for unknown nodes
  like every other credential; the `getFile` channel-branch file name sanitizes
  the channel value so it cannot walk out of the backup directory; a live 2FA seed cannot
  be overwritten by a request-supplied seed.

## Key Technical Changes

* `server/controllers/shared/RTLConf.ts` — allowlists, shared
  `filterNodeSettings`/`isValidHttpUrl` helpers, `common.nodes`-based known-vs-unknown
  filtering and rebuild, channel-backup file-name sanitization in `getFile`.
* `server/utils/common.ts` — `addSecureData` pins anchors from the single authoritative
  runtime node list, never keeps a caller-supplied `multiPass`, and normalizes indexes
  without coercing empty/falsy values to `0`.

## Design Rationale

* **Defense in depth:** allowlisting plus pinning means even future settings keys cannot
  be persisted into the config file and re-parsed at the next boot/save.
* **Non-disruptive UX:** legitimate dashboard customization (themes, block explorer,
  currency, Loop/Boltz service config) keeps working; only credential paths and server
  URLs are restricted.
* **Containment:** the `getConfig` and `getFile` file reads stay confined to their
  configured roots, and the channel-branch file name can no longer escape the backup
  directory.
* **No silent no-op:** when the live runtime node list is empty the allowlisted-and-pinned
  payload is still written to the file — the save the caller is told about is the save
  that happened.

## Testing & Verification

* Backend regression tests (`test/backend/rtlconf.test.mjs`, `test/backend/common.test.mjs`)
  cover the allowlists, node-settings service edits, URL format validation (including a
  parseable `file://` URL), unknown-node drop, index normalization (`''`/`false`/`[]`/
  `null`) and the index scalars, `multiPass` rejection, `runeValue` pinning/stripping,
  runtime-node-list pinning, the empty-runtime-list path and the channel-branch
  traversal — 80 backend tests pass.
* Frontend Karma suite passes (229/229) and `npm run lint` is green.
* **Note:** invalid URL values are silently dropped rather than rejected with `400`; the
  settings-save response carries no per-field error and the UI reflects the server-held
  values on the next load.