### PR TITLE
Run the fixture's LND nodes on two versions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,11 +55,27 @@ routing screens something to show. Two nodes would leave them empty. The `cln`
 clnrest with rune auth. The `eclair` node does the same for RTL's Eclair screens —
 RTL talks to its HTTP API with basic auth.
 
-LND, bitcoind and Eclair images come from [Polar](https://lightningpolar.com); the Core
-Lightning image is the official [`elementsproject/lightningd`](https://hub.docker.com/r/elementsproject/lightningd).
+bitcoind and Eclair images come from [Polar](https://lightningpolar.com); the Core Lightning
+image is the official [`elementsproject/lightningd`](https://hub.docker.com/r/elementsproject/lightningd)
+and the LND nodes use the official [`lightninglabs/lnd`](https://hub.docker.com/r/lightninglabs/lnd).
 All are multi-arch (amd64 + arm64) and nothing is built locally, so this works on
 Apple Silicon. (The official `acinq/eclair` image is amd64-only and its versioned tags
 are years stale, which is why Polar's build of the same source is used instead.)
+
+**The three LND nodes deliberately run two different versions**, so that version-gated UI can be
+checked against a node on either side of a gate without editing the fixture:
+
+| Node    | LND version    |
+|---------|----------------|
+| `alice` | `v0.21.2-beta` |
+| `bob`   | `v0.20.3-beta` |
+| `carol` | `v0.21.2-beta` |
+
+`bob` is the one held back because it is the routing middle node, so every forwarded payment in
+the fixture crosses a version boundary. LND comes from `lightninglabs/lnd` rather than Polar
+because Polar publishes nothing newer than `0.20.0-beta`; that image's entrypoint is already
+`lnd`, so the `command:` lists start at the first flag, and its datadir is `/root/.lnd` rather
+than Polar's `/home/lnd/.lnd` — which is why `bin/ln-cli` and `scripts/seed.sh` pass `--lnddir`.
 
 ## Requirements
 

--- a/docker/bin/ln-cli
+++ b/docker/bin/ln-cli
@@ -7,9 +7,9 @@
 #   bin/ln-cli bob listchannels
 #   bin/ln-cli carol addinvoice --amt=1000
 #
-# --lnddir is passed explicitly: 'docker compose exec' lands as root, whose HOME
-# is /root, but lnd's datadir is /home/lnd/.lnd. Without it lncli looks for the
-# TLS cert in the wrong place and fails.
+# --lnddir is passed explicitly so this keeps working whatever the image's default
+# is: lightninglabs/lnd stores data in /root/.lnd, Polar used /home/lnd/.lnd, and
+# without it lncli looks for the TLS cert in the wrong place and fails.
 
 set -euo pipefail
 
@@ -28,5 +28,5 @@ esac
 
 exec docker compose exec -T "$node" lncli \
   --network=regtest \
-  --lnddir=/home/lnd/.lnd \
+  --lnddir=/root/.lnd \
   "$@"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,8 +21,11 @@ volumes:
   rtl_sso_config:
   rtl_sso_cookie:
 
+# No image here: the nodes deliberately run different LND versions, so each pins its own.
+# lightninglabs/lnd rather than Polar because Polar publishes nothing newer than 0.20.0-beta.
+# Its entrypoint is already `lnd`, so the command lists below start at the first flag, and its
+# datadir is /root/.lnd (Polar used /home/lnd/.lnd) -- bin/ln-cli and scripts/seed.sh pass it.
 x-lnd: &lnd
-  image: polarlightning/lnd:0.20.0-beta
   restart: unless-stopped
   depends_on:
     - bitcoind
@@ -63,9 +66,9 @@ services:
   # (https://alice:8080) or TLS validation fails.
   alice:
     <<: *lnd
+    image: lightninglabs/lnd:v0.21.2-beta
     container_name: ${COMPOSE_PROJECT_NAME}_alice
     command:
-      - lnd
       - --noseedbackup
       - --trickledelay=5000
       - --alias=alice
@@ -89,13 +92,13 @@ services:
     ports:
       - "${ALICE_REST_PORT}:${LIGHTNING_REST_PORT}"
     volumes:
-      - alice_data:/home/lnd/.lnd
+      - alice_data:/root/.lnd
 
   bob:
     <<: *lnd
+    image: lightninglabs/lnd:v0.20.3-beta
     container_name: ${COMPOSE_PROJECT_NAME}_bob
     command:
-      - lnd
       - --noseedbackup
       - --trickledelay=5000
       - --alias=bob
@@ -119,13 +122,13 @@ services:
     ports:
       - "${BOB_REST_PORT}:${LIGHTNING_REST_PORT}"
     volumes:
-      - bob_data:/home/lnd/.lnd
+      - bob_data:/root/.lnd
 
   carol:
     <<: *lnd
+    image: lightninglabs/lnd:v0.21.2-beta
     container_name: ${COMPOSE_PROJECT_NAME}_carol
     command:
-      - lnd
       - --noseedbackup
       - --trickledelay=5000
       - --alias=carol
@@ -149,7 +152,7 @@ services:
     ports:
       - "${CAROL_REST_PORT}:${LIGHTNING_REST_PORT}"
     volumes:
-      - carol_data:/home/lnd/.lnd
+      - carol_data:/root/.lnd
 
   # Core Lightning node. Unlike the LND nodes it talks to RTL over clnrest (the
   # built-in REST plugin) using rune auth, so it needs --clnrest-* options and a

--- a/docker/scripts/seed.sh
+++ b/docker/scripts/seed.sh
@@ -56,11 +56,12 @@ bcli() {
     -rpcuser="$BITCOIN_RPC_USER" -rpcpassword="$BITCOIN_RPC_PASSWORD" "$@"
 }
 
-# 'docker compose exec' lands as root, whose HOME is /root, but lnd's datadir is
-# /home/lnd/.lnd -- so lncli must be told where to find the cert and macaroon.
+# --lnddir is passed explicitly rather than relying on lncli's ~/.lnd default, so this
+# keeps working if the image's datadir moves again -- Polar used /home/lnd/.lnd, and
+# without the flag lncli looks for the TLS cert and macaroon in the wrong place.
 lncli() {
   local node=$1; shift
-  docker compose exec -T "$node" lncli --network=regtest --lnddir=/home/lnd/.lnd "$@"
+  docker compose exec -T "$node" lncli --network=regtest --lnddir=/root/.lnd "$@"
 }
 
 # Core Lightning cli. Runs inside the cln container against the regtest node.


### PR DESCRIPTION
All three LND nodes in the fixture ran the same image, so there was no way to exercise a version-gated screen against a node on either side of the gate without editing the fixture. The `fund_max` work in #1682 needed exactly that (the toggle is gated on LND 0.16.0), and the next such gate will need it again.

### What changed

| Node    | LND version    |
|---------|----------------|
| `alice` | `v0.21.2-beta` |
| `bob`   | `v0.20.3-beta` |
| `carol` | `v0.21.2-beta` |

`bob` is the one held back because it is the routing middle node, so every forwarded payment in the fixture crosses a version boundary as well.

### Why this leaves Polar for LND

Polar publishes nothing newer than `0.20.0-beta`, so the LND nodes now use the official [`lightninglabs/lnd`](https://hub.docker.com/r/lightninglabs/lnd). Both tags are multi-arch (amd64 + arm64), so Apple Silicon is unaffected and nothing is built locally. bitcoind and Eclair still come from Polar, and Core Lightning from `elementsproject/lightningd`.

That image differs from Polar's in two ways, both handled here:

- **Its entrypoint is already `lnd`**, so the `command:` lists drop their leading `lnd` argument. Left in place it would have run `lnd lnd --noseedbackup`.
- **Its datadir is `/root/.lnd`**, not `/home/lnd/.lnd`. That moves the three volume mounts and the `--lnddir` that `bin/ln-cli` and `scripts/seed.sh` pass. The volume *contents* keep the same shape, so RTL's own read-only mounts (`alice_data:/lnd/alice:ro`) and the `macaroonPath` entries in `RTL-Config.regtest.json` are untouched.

### Verification

Clean bring-up (`docker compose up -d` on empty volumes, then `./scripts/seed.sh`):

- `seed.sh` runs to completion — channels, routed and direct payments, and unpaid invoices all as before.
- All three nodes report the intended version through RTL's own API, with the expected channel counts and balances:
  ```
  alice  | version 0.21.2-beta commit=v0.21.2-beta | channels 2 | onchain 4995882
  bob    | version 0.20.3-beta commit=v0.20.3-beta | channels 3 | onchain 6995882
  carol  | version 0.21.2-beta commit=v0.21.2-beta | channels 1 | onchain 10000000
  ```
- `bob forwarded 4 payment(s)` — routing works across the version boundary on both legs.
- `./scripts/verify-sso.sh` passes 11/11, including reaching alice through the proxy.

One caveat: this was verified with **fresh volumes**. Existing volumes should carry over — the content shape is unchanged, and the new image runs as root so the old uid-1000 file ownership is readable — but that path is untested. The `down -v` reset in the readme covers it either way.

No release note: `docker/` is dev-only and ships in no release, matching how the previous fixture change landed on `master`.
