### PR TITLE
fix(lnd): validate query params in listInvoices and getPayments

### DIFF
--- a/backend/controllers/lnd/invoices.js
+++ b/backend/controllers/lnd/invoices.js
@@ -53,9 +53,37 @@ export const listInvoices = (req, res, next) => {
     if (options.error) {
         return res.status(options.statusCode).json({ message: options.message, error: options.error });
     }
-    options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/invoices?num_max_invoices=' + req.query.num_max_invoices + '&index_offset=' + req.query.index_offset +
-        '&reversed=' + req.query.reversed;
-    request(options).then((body) => {
+    const qs = {};
+    if (req.query.num_max_invoices !== undefined) {
+        const raw = String(req.query.num_max_invoices).trim();
+        if (raw === '' || !/^\d+$/.test(raw)) {
+            return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        const num = Number(raw);
+        if (!Number.isSafeInteger(num)) {
+            return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        qs.num_max_invoices = num;
+    }
+    if (req.query.index_offset !== undefined) {
+        const raw = String(req.query.index_offset).trim();
+        if (raw === '' || !/^\d+$/.test(raw)) {
+            return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        const num = Number(raw);
+        if (!Number.isSafeInteger(num)) {
+            return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        qs.index_offset = num;
+    }
+    if (req.query.reversed !== undefined) {
+        const raw = String(req.query.reversed).trim().toLowerCase();
+        if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+            return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
+        }
+        qs.reversed = raw === 'true' || raw === '1' || raw === 't';
+    }
+    request({ ...options, url: req.session.selectedNode.settings.lnServerUrl + '/v1/invoices', qs }).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Invoice', msg: 'Invoices List Received', data: body });
         if (body.invoices && body.invoices.length > 0) {
             body.invoices.forEach((invoice) => {

--- a/backend/controllers/lnd/invoices.js
+++ b/backend/controllers/lnd/invoices.js
@@ -55,30 +55,38 @@ export const listInvoices = (req, res, next) => {
     }
     const qs = {};
     if (req.query.num_max_invoices !== undefined) {
-        const raw = String(req.query.num_max_invoices).trim();
-        if (raw === '' || !/^\d+$/.test(raw)) {
+        const raw = typeof req.query.num_max_invoices === 'string' ? req.query.num_max_invoices.trim() : '';
+        if (raw === '' || !(/^\d+$/).test(raw)) {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'Invalid num_max_invoices query param' });
             return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
         }
         const num = Number(raw);
         if (!Number.isSafeInteger(num)) {
-            return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'num_max_invoices exceeds safe integer range' });
+            return res.status(400).json({ message: 'num_max_invoices exceeds maximum safe integer', error: 'Invalid query parameter' });
         }
-        qs.num_max_invoices = num;
+        qs.num_max_invoices = num === 0 ? 100 : num;
+    }
+    else {
+        qs.num_max_invoices = 100;
     }
     if (req.query.index_offset !== undefined) {
-        const raw = String(req.query.index_offset).trim();
-        if (raw === '' || !/^\d+$/.test(raw)) {
+        const raw = typeof req.query.index_offset === 'string' ? req.query.index_offset.trim() : '';
+        if (raw === '' || !(/^\d+$/).test(raw)) {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'Invalid index_offset query param' });
             return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
         }
         const num = Number(raw);
         if (!Number.isSafeInteger(num)) {
-            return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'index_offset exceeds safe integer range' });
+            return res.status(400).json({ message: 'index_offset exceeds maximum safe integer', error: 'Invalid query parameter' });
         }
         qs.index_offset = num;
     }
     if (req.query.reversed !== undefined) {
-        const raw = String(req.query.reversed).trim().toLowerCase();
+        const raw = typeof req.query.reversed === 'string' ? req.query.reversed.trim().toLowerCase() : '';
         if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'Invalid reversed query param' });
             return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
         }
         qs.reversed = raw === 'true' || raw === '1' || raw === 't';

--- a/backend/controllers/lnd/payments.js
+++ b/backend/controllers/lnd/payments.js
@@ -56,8 +56,37 @@ export const getPayments = (req, res, next) => {
     if (options.error) {
         return res.status(options.statusCode).json({ message: options.message, error: options.error });
     }
-    options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/payments?max_payments=' + req.query.max_payments + '&index_offset=' + req.query.index_offset + '&reversed=' + req.query.reversed;
-    request(options).then((body) => {
+    const qs = {};
+    if (req.query.max_payments !== undefined) {
+        const raw = String(req.query.max_payments).trim();
+        if (raw === '' || !/^\d+$/.test(raw)) {
+            return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        const num = Number(raw);
+        if (!Number.isSafeInteger(num)) {
+            return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        qs.max_payments = num;
+    }
+    if (req.query.index_offset !== undefined) {
+        const raw = String(req.query.index_offset).trim();
+        if (raw === '' || !/^\d+$/.test(raw)) {
+            return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        const num = Number(raw);
+        if (!Number.isSafeInteger(num)) {
+            return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+        }
+        qs.index_offset = num;
+    }
+    if (req.query.reversed !== undefined) {
+        const raw = String(req.query.reversed).trim().toLowerCase();
+        if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+            return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
+        }
+        qs.reversed = raw === 'true' || raw === '1' || raw === 't';
+    }
+    request({ ...options, url: req.session.selectedNode.settings.lnServerUrl + '/v1/payments', qs }).then((body) => {
         logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Payments', msg: 'Payment List Received', data: body });
         res.status(200).json(body);
     }).catch((errRes) => {

--- a/backend/controllers/lnd/payments.js
+++ b/backend/controllers/lnd/payments.js
@@ -58,30 +58,38 @@ export const getPayments = (req, res, next) => {
     }
     const qs = {};
     if (req.query.max_payments !== undefined) {
-        const raw = String(req.query.max_payments).trim();
-        if (raw === '' || !/^\d+$/.test(raw)) {
+        const raw = typeof req.query.max_payments === 'string' ? req.query.max_payments.trim() : '';
+        if (raw === '' || !(/^\d+$/).test(raw)) {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'Invalid max_payments query param' });
             return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
         }
         const num = Number(raw);
         if (!Number.isSafeInteger(num)) {
-            return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'max_payments exceeds safe integer range' });
+            return res.status(400).json({ message: 'max_payments exceeds maximum safe integer', error: 'Invalid query parameter' });
         }
-        qs.max_payments = num;
+        qs.max_payments = num === 0 ? 100 : num;
+    }
+    else {
+        qs.max_payments = 100;
     }
     if (req.query.index_offset !== undefined) {
-        const raw = String(req.query.index_offset).trim();
-        if (raw === '' || !/^\d+$/.test(raw)) {
+        const raw = typeof req.query.index_offset === 'string' ? req.query.index_offset.trim() : '';
+        if (raw === '' || !(/^\d+$/).test(raw)) {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'Invalid index_offset query param' });
             return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
         }
         const num = Number(raw);
         if (!Number.isSafeInteger(num)) {
-            return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'index_offset exceeds safe integer range' });
+            return res.status(400).json({ message: 'index_offset exceeds maximum safe integer', error: 'Invalid query parameter' });
         }
         qs.index_offset = num;
     }
     if (req.query.reversed !== undefined) {
-        const raw = String(req.query.reversed).trim().toLowerCase();
+        const raw = typeof req.query.reversed === 'string' ? req.query.reversed.trim().toLowerCase() : '';
         if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+            logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'Invalid reversed query param' });
             return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
         }
         qs.reversed = raw === 'true' || raw === '1' || raw === 't';

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -92,6 +92,32 @@ this release should add its entry under the appropriate section below.
   `selectedNodeIndex` are stored as numbers when they arrive as strings, and the live
   request headers (`authentication.options`) are pinned and stripped like `runeValue`.
 
+- **LND: omitted invoice/payment paging parameters were forwarded to the node as the string
+  `undefined`**
+  ([#1687](https://github.com/Ride-The-Lightning/RTL/pull/1687), fixes
+  [#1678](https://github.com/Ride-The-Lightning/RTL/issues/1678)).
+  `listInvoices` and `getPayments` built the upstream REST URL by concatenating `req.query`
+  values straight into it, with no defaults or validation, so a caller that left any of
+  `num_max_invoices`/`max_payments`, `index_offset` or `reversed` out asked LND for
+  `num_max_invoices=undefined&index_offset=undefined&reversed=undefined` — which its REST
+  gateway cannot parse as a `uint64`/`bool`, so the call 400s instead of falling back to
+  LND's own defaults. RTL's own frontend never hit this, because `lnd.effects.ts` fills in
+  `num_max_invoices` before calling; the breakage was for anything driving the route as an
+  API. Concatenating the values raw also meant a parameter containing `&` or `=` was passed
+  through as extra upstream parameters. Both controllers now validate before the call — the
+  counts and `index_offset` must be non-negative integers inside the safe-integer range,
+  `reversed` must be a recognised boolean spelling — and refuse anything else with a 400
+  naming the parameter rather than forwarding it. What is present is passed through the
+  request layer's `qs` option, which encodes it, and what is absent is simply omitted so LND
+  applies its own default; the one exception is the page size, which defaults to 100 (and
+  treats an explicit `0` the same way) rather than letting an unbounded request fetch every
+  invoice or payment the node has. Covered by `test/backend/lnd-invoices.test.mjs` and
+  `test/backend/lnd-payments.test.mjs`, which assert the outgoing query for an empty
+  `req.query` and the 400s for each malformed value. The remaining single-parameter
+  concatenations of the same shape are untouched here: `invoiceLookup`, in this same file,
+  still builds `?payment_hash=` by concatenation, as do `newAddress.ts`, `channels.ts` and
+  `wallet.ts`.
+
 ## Enhancements
 
 - **Loop and Boltz connection settings are configured in the config file or environment only**

--- a/server/controllers/lnd/invoices.ts
+++ b/server/controllers/lnd/invoices.ts
@@ -51,10 +51,40 @@ export const invoiceLookup = (req, res, next) => {
 export const listInvoices = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Invoice', msg: 'Getting List Invoices..' });
   options = common.getOptions(req);
-  if (options.error) { return res.status(options.statusCode).json({ message: options.message, error: options.error }); }
-  options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/invoices?num_max_invoices=' + req.query.num_max_invoices + '&index_offset=' + req.query.index_offset +
-    '&reversed=' + req.query.reversed;
-  request(options).then((body) => {
+  if (options.error) {
+    return res.status(options.statusCode).json({ message: options.message, error: options.error });
+  }
+  const qs: Record<string, any> = {};
+  if (req.query.num_max_invoices !== undefined) {
+    const raw = String(req.query.num_max_invoices).trim();
+    if (raw === '' || !(/^\d+$/).test(raw)) {
+      return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    const num = Number(raw);
+    if (!Number.isSafeInteger(num)) {
+      return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    qs.num_max_invoices = num;
+  }
+  if (req.query.index_offset !== undefined) {
+    const raw = String(req.query.index_offset).trim();
+    if (raw === '' || !(/^\d+$/).test(raw)) {
+      return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    const num = Number(raw);
+    if (!Number.isSafeInteger(num)) {
+      return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    qs.index_offset = num;
+  }
+  if (req.query.reversed !== undefined) {
+    const raw = String(req.query.reversed).trim().toLowerCase();
+    if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+      return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
+    }
+    qs.reversed = raw === 'true' || raw === '1' || raw === 't';
+  }
+  request({ ...options, url: req.session.selectedNode.settings.lnServerUrl + '/v1/invoices', qs }).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Invoice', msg: 'Invoices List Received', data: body });
     if (body.invoices && body.invoices.length > 0) {
       body.invoices.forEach((invoice) => {

--- a/server/controllers/lnd/invoices.ts
+++ b/server/controllers/lnd/invoices.ts
@@ -56,30 +56,37 @@ export const listInvoices = (req, res, next) => {
   }
   const qs: Record<string, any> = {};
   if (req.query.num_max_invoices !== undefined) {
-    const raw = String(req.query.num_max_invoices).trim();
+    const raw = typeof req.query.num_max_invoices === 'string' ? req.query.num_max_invoices.trim() : '';
     if (raw === '' || !(/^\d+$/).test(raw)) {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'Invalid num_max_invoices query param' });
       return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
     }
     const num = Number(raw);
     if (!Number.isSafeInteger(num)) {
-      return res.status(400).json({ message: 'num_max_invoices must be a non-negative integer', error: 'Invalid query parameter' });
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'num_max_invoices exceeds safe integer range' });
+      return res.status(400).json({ message: 'num_max_invoices exceeds maximum safe integer', error: 'Invalid query parameter' });
     }
-    qs.num_max_invoices = num;
+    qs.num_max_invoices = num === 0 ? 100 : num;
+  } else {
+    qs.num_max_invoices = 100;
   }
   if (req.query.index_offset !== undefined) {
-    const raw = String(req.query.index_offset).trim();
+    const raw = typeof req.query.index_offset === 'string' ? req.query.index_offset.trim() : '';
     if (raw === '' || !(/^\d+$/).test(raw)) {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'Invalid index_offset query param' });
       return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
     }
     const num = Number(raw);
     if (!Number.isSafeInteger(num)) {
-      return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'index_offset exceeds safe integer range' });
+      return res.status(400).json({ message: 'index_offset exceeds maximum safe integer', error: 'Invalid query parameter' });
     }
     qs.index_offset = num;
   }
   if (req.query.reversed !== undefined) {
-    const raw = String(req.query.reversed).trim().toLowerCase();
+    const raw = typeof req.query.reversed === 'string' ? req.query.reversed.trim().toLowerCase() : '';
     if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Invoice', msg: 'Invalid reversed query param' });
       return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
     }
     qs.reversed = raw === 'true' || raw === '1' || raw === 't';

--- a/server/controllers/lnd/payments.ts
+++ b/server/controllers/lnd/payments.ts
@@ -54,9 +54,40 @@ export const decodePayments = (req, res, next) => {
 export const getPayments = (req, res, next) => {
   logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Payments', msg: 'Getting Payments List..' });
   options = common.getOptions(req);
-  if (options.error) { return res.status(options.statusCode).json({ message: options.message, error: options.error }); }
-  options.url = req.session.selectedNode.settings.lnServerUrl + '/v1/payments?max_payments=' + req.query.max_payments + '&index_offset=' + req.query.index_offset + '&reversed=' + req.query.reversed;
-  request(options).then((body) => {
+  if (options.error) {
+    return res.status(options.statusCode).json({ message: options.message, error: options.error });
+  }
+  const qs: Record<string, any> = {};
+  if (req.query.max_payments !== undefined) {
+    const raw = String(req.query.max_payments).trim();
+    if (raw === '' || !(/^\d+$/).test(raw)) {
+      return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    const num = Number(raw);
+    if (!Number.isSafeInteger(num)) {
+      return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    qs.max_payments = num;
+  }
+  if (req.query.index_offset !== undefined) {
+    const raw = String(req.query.index_offset).trim();
+    if (raw === '' || !(/^\d+$/).test(raw)) {
+      return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    const num = Number(raw);
+    if (!Number.isSafeInteger(num)) {
+      return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+    }
+    qs.index_offset = num;
+  }
+  if (req.query.reversed !== undefined) {
+    const raw = String(req.query.reversed).trim().toLowerCase();
+    if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+      return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
+    }
+    qs.reversed = raw === 'true' || raw === '1' || raw === 't';
+  }
+  request({ ...options, url: req.session.selectedNode.settings.lnServerUrl + '/v1/payments', qs }).then((body) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Payments', msg: 'Payment List Received', data: body });
     res.status(200).json(body);
   }).catch((errRes) => {

--- a/server/controllers/lnd/payments.ts
+++ b/server/controllers/lnd/payments.ts
@@ -59,30 +59,37 @@ export const getPayments = (req, res, next) => {
   }
   const qs: Record<string, any> = {};
   if (req.query.max_payments !== undefined) {
-    const raw = String(req.query.max_payments).trim();
+    const raw = typeof req.query.max_payments === 'string' ? req.query.max_payments.trim() : '';
     if (raw === '' || !(/^\d+$/).test(raw)) {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'Invalid max_payments query param' });
       return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
     }
     const num = Number(raw);
     if (!Number.isSafeInteger(num)) {
-      return res.status(400).json({ message: 'max_payments must be a non-negative integer', error: 'Invalid query parameter' });
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'max_payments exceeds safe integer range' });
+      return res.status(400).json({ message: 'max_payments exceeds maximum safe integer', error: 'Invalid query parameter' });
     }
-    qs.max_payments = num;
+    qs.max_payments = num === 0 ? 100 : num;
+  } else {
+    qs.max_payments = 100;
   }
   if (req.query.index_offset !== undefined) {
-    const raw = String(req.query.index_offset).trim();
+    const raw = typeof req.query.index_offset === 'string' ? req.query.index_offset.trim() : '';
     if (raw === '' || !(/^\d+$/).test(raw)) {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'Invalid index_offset query param' });
       return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
     }
     const num = Number(raw);
     if (!Number.isSafeInteger(num)) {
-      return res.status(400).json({ message: 'index_offset must be a non-negative integer', error: 'Invalid query parameter' });
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'index_offset exceeds safe integer range' });
+      return res.status(400).json({ message: 'index_offset exceeds maximum safe integer', error: 'Invalid query parameter' });
     }
     qs.index_offset = num;
   }
   if (req.query.reversed !== undefined) {
-    const raw = String(req.query.reversed).trim().toLowerCase();
+    const raw = typeof req.query.reversed === 'string' ? req.query.reversed.trim().toLowerCase() : '';
     if (raw !== 'true' && raw !== 'false' && raw !== '1' && raw !== '0' && raw !== 't' && raw !== 'f') {
+      logger.log({ selectedNode: req.session.selectedNode, level: 'WARN', fileName: 'Payments', msg: 'Invalid reversed query param' });
       return res.status(400).json({ message: 'reversed must be a boolean', error: 'Invalid query parameter' });
     }
     qs.reversed = raw === 'true' || raw === '1' || raw === 't';

--- a/test/backend/lnd-invoices.test.mjs
+++ b/test/backend/lnd-invoices.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+
+import { listInvoices } from '../../backend/controllers/lnd/invoices.js';
+
+// Fake LND server that records every request it receives.
+const startFakeLnd = async (macaroon, invoices) => {
+  const seen = [];
+  const server = createServer((req, res) => {
+    seen.push({ method: req.method, path: req.url, macaroon: req.headers['grpc-metadata-macaroon'] });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ invoices }));
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `http://127.0.0.1:${server.address().port}`;
+  return {
+    url,
+    seen,
+    close: () => new Promise((resolve) => server.close(resolve))
+  };
+};
+
+// Build a mock Express req object with the session shape common.getOptions expects.
+const buildRequest = (node, query = {}) => ({
+  session: {
+    selectedNode: {
+      index: 1,
+      lnNode: 'test-node',
+      lnImplementation: 'LND',
+      authentication: {
+        options: {
+          url: '',
+          rejectUnauthorized: false,
+          json: true,
+          headers: { 'Grpc-Metadata-macaroon': node.macaroon }
+        }
+      },
+      settings: { lnServerUrl: node.url, logLevel: 'ERROR' }
+    }
+  },
+  query
+});
+
+// Build a mock Express res object that resolves a promise when .json() is called.
+const buildResponse = () => {
+  const out = { statusCode: null, body: null, headersSent: false };
+  out.done = new Promise((resolve) => {
+    out.status = (code) => { out.statusCode = code; return out; };
+    out.json = (payload) => { out.body = payload; out.headersSent = true; resolve(payload); return out; };
+  });
+  return out;
+};
+
+test('listInvoices: empty query omits all params from upstream URL', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, {}), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen.length, 1);
+    assert.ok(!lnd.seen[0].path.includes('undefined'), `URL contained undefined: ${lnd.seen[0].path}`);
+    assert.equal(lnd.seen[0].path, '/v1/invoices');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('listInvoices: valid params are forwarded correctly', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: '10', index_offset: '5', reversed: 'true' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen.length, 1);
+    assert.ok(!lnd.seen[0].path.includes('undefined'), `URL contained undefined: ${lnd.seen[0].path}`);
+    assert.equal(lnd.seen[0].path, '/v1/invoices?num_max_invoices=10&index_offset=5&reversed=true');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('listInvoices: invalid num_max_invoices returns 400 without calling LND', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: 'abc' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'num_max_invoices must be a non-negative integer');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('listInvoices: invalid reversed returns 400 without calling LND', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { reversed: 'maybe' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'reversed must be a boolean');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('listInvoices: empty string num_max_invoices returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: '' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'num_max_invoices must be a non-negative integer');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('listInvoices: whitespace num_max_invoices returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: '   ' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'num_max_invoices must be a non-negative integer');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('listInvoices: reversed 1 is coerced to true', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { reversed: '1' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen[0].path, '/v1/invoices?reversed=true');
+  } finally { await lnd.close(); }
+});
+
+test('listInvoices: reversed 0 is coerced to false', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { reversed: '0' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen[0].path, '/v1/invoices?reversed=false');
+  } finally { await lnd.close(); }
+});
+
+test('listInvoices: negative num_max_invoices returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: '-1' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0);
+    assert.equal(res.body.message, 'num_max_invoices must be a non-negative integer');
+  } finally { await lnd.close(); }
+});
+
+test('listInvoices: index_offset validation works', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { index_offset: 'abc' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0);
+    assert.equal(res.body.message, 'index_offset must be a non-negative integer');
+  } finally { await lnd.close(); }
+});

--- a/test/backend/lnd-invoices.test.mjs
+++ b/test/backend/lnd-invoices.test.mjs
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
-import test from 'node:test';
+import test, { after } from 'node:test';
 
 import { listInvoices } from '../../backend/controllers/lnd/invoices.js';
+import { WSServer } from '../../backend/utils/webSocketServer.js';
 
-// Fake LND server that records every request it receives.
+// The controller pulls in the LND websocket client, which instantiates the websocket
+// server singleton and its ping timer; without this the test process never exits.
+after(() => clearInterval(WSServer.pingInterval));
+
 const startFakeLnd = async (macaroon, invoices) => {
   const seen = [];
   const server = createServer((req, res) => {
@@ -21,7 +25,6 @@ const startFakeLnd = async (macaroon, invoices) => {
   };
 };
 
-// Build a mock Express req object with the session shape common.getOptions expects.
 const buildRequest = (node, query = {}) => ({
   session: {
     selectedNode: {
@@ -42,7 +45,6 @@ const buildRequest = (node, query = {}) => ({
   query
 });
 
-// Build a mock Express res object that resolves a promise when .json() is called.
 const buildResponse = () => {
   const out = { statusCode: null, body: null, headersSent: false };
   out.done = new Promise((resolve) => {
@@ -52,7 +54,7 @@ const buildResponse = () => {
   return out;
 };
 
-test('listInvoices: empty query omits all params from upstream URL', async () => {
+test('listInvoices: empty query uses default page size', async () => {
   const lnd = await startFakeLnd('macaroon-test', []);
   try {
     const res = buildResponse();
@@ -62,10 +64,21 @@ test('listInvoices: empty query omits all params from upstream URL', async () =>
     assert.equal(res.statusCode, 200);
     assert.equal(lnd.seen.length, 1);
     assert.ok(!lnd.seen[0].path.includes('undefined'), `URL contained undefined: ${lnd.seen[0].path}`);
-    assert.equal(lnd.seen[0].path, '/v1/invoices');
+    assert.equal(lnd.seen[0].path, '/v1/invoices?num_max_invoices=100');
   } finally {
     await lnd.close();
   }
+});
+
+test('listInvoices: zero num_max_invoices uses default', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: '0' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen[0].path, '/v1/invoices?num_max_invoices=100');
+  } finally { await lnd.close(); }
 });
 
 test('listInvoices: valid params are forwarded correctly', async () => {
@@ -151,7 +164,7 @@ test('listInvoices: reversed 1 is coerced to true', async () => {
     listInvoices(buildRequest(lnd, { reversed: '1' }), res, null);
     await res.done;
     assert.equal(res.statusCode, 200);
-    assert.equal(lnd.seen[0].path, '/v1/invoices?reversed=true');
+    assert.equal(lnd.seen[0].path, '/v1/invoices?num_max_invoices=100&reversed=true');
   } finally { await lnd.close(); }
 });
 
@@ -162,7 +175,7 @@ test('listInvoices: reversed 0 is coerced to false', async () => {
     listInvoices(buildRequest(lnd, { reversed: '0' }), res, null);
     await res.done;
     assert.equal(res.statusCode, 200);
-    assert.equal(lnd.seen[0].path, '/v1/invoices?reversed=false');
+    assert.equal(lnd.seen[0].path, '/v1/invoices?num_max_invoices=100&reversed=false');
   } finally { await lnd.close(); }
 });
 
@@ -187,5 +200,17 @@ test('listInvoices: index_offset validation works', async () => {
     assert.equal(res.statusCode, 400);
     assert.equal(lnd.seen.length, 0);
     assert.equal(res.body.message, 'index_offset must be a non-negative integer');
+  } finally { await lnd.close(); }
+});
+
+test('listInvoices: oversized num_max_invoices returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    listInvoices(buildRequest(lnd, { num_max_invoices: '99999999999999999999' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0);
+    assert.equal(res.body.message, 'num_max_invoices exceeds maximum safe integer');
   } finally { await lnd.close(); }
 });

--- a/test/backend/lnd-payments.test.mjs
+++ b/test/backend/lnd-payments.test.mjs
@@ -59,7 +59,7 @@ test('getPayments: empty query omits all params from upstream URL', async () => 
     assert.equal(res.statusCode, 200);
     assert.equal(lnd.seen.length, 1);
     assert.ok(!lnd.seen[0].path.includes('undefined'), `URL contained undefined: ${lnd.seen[0].path}`);
-    assert.equal(lnd.seen[0].path, '/v1/payments');
+    assert.equal(lnd.seen[0].path, '/v1/payments?max_payments=100');
   } finally {
     await lnd.close();
   }
@@ -148,7 +148,7 @@ test('getPayments: reversed 1 is coerced to true', async () => {
     getPayments(buildRequest(lnd, { reversed: '1' }), res, null);
     await res.done;
     assert.equal(res.statusCode, 200);
-    assert.equal(lnd.seen[0].path, '/v1/payments?reversed=true');
+    assert.equal(lnd.seen[0].path, '/v1/payments?max_payments=100&reversed=true');
   } finally { await lnd.close(); }
 });
 
@@ -159,7 +159,7 @@ test('getPayments: reversed 0 is coerced to false', async () => {
     getPayments(buildRequest(lnd, { reversed: '0' }), res, null);
     await res.done;
     assert.equal(res.statusCode, 200);
-    assert.equal(lnd.seen[0].path, '/v1/payments?reversed=false');
+    assert.equal(lnd.seen[0].path, '/v1/payments?max_payments=100&reversed=false');
   } finally { await lnd.close(); }
 });
 
@@ -184,5 +184,28 @@ test('getPayments: index_offset validation works', async () => {
     assert.equal(res.statusCode, 400);
     assert.equal(lnd.seen.length, 0);
     assert.equal(res.body.message, 'index_offset must be a non-negative integer');
+  } finally { await lnd.close(); }
+});
+
+test('getPayments: oversized max_payments returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { max_payments: '99999999999999999999' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0);
+    assert.equal(res.body.message, 'max_payments exceeds maximum safe integer');
+  } finally { await lnd.close(); }
+});
+
+test('getPayments: absent max_payments uses default', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, {}), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen[0].path, '/v1/payments?max_payments=100');
   } finally { await lnd.close(); }
 });

--- a/test/backend/lnd-payments.test.mjs
+++ b/test/backend/lnd-payments.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+
+import { getPayments } from '../../backend/controllers/lnd/payments.js';
+
+const startFakeLnd = async (macaroon, payments) => {
+  const seen = [];
+  const server = createServer((req, res) => {
+    seen.push({ method: req.method, path: req.url, macaroon: req.headers['grpc-metadata-macaroon'] });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ payments }));
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `http://127.0.0.1:${server.address().port}`;
+  return {
+    url,
+    seen,
+    close: () => new Promise((resolve) => server.close(resolve))
+  };
+};
+
+const buildRequest = (node, query = {}) => ({
+  session: {
+    selectedNode: {
+      index: 1,
+      lnNode: 'test-node',
+      lnImplementation: 'LND',
+      authentication: {
+        options: {
+          url: '',
+          rejectUnauthorized: false,
+          json: true,
+          headers: { 'Grpc-Metadata-macaroon': node.macaroon }
+        }
+      },
+      settings: { lnServerUrl: node.url, logLevel: 'ERROR' }
+    }
+  },
+  query
+});
+
+const buildResponse = () => {
+  const out = { statusCode: null, body: null, headersSent: false };
+  out.done = new Promise((resolve) => {
+    out.status = (code) => { out.statusCode = code; return out; };
+    out.json = (payload) => { out.body = payload; out.headersSent = true; resolve(payload); return out; };
+  });
+  return out;
+};
+
+test('getPayments: empty query omits all params from upstream URL', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, {}), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen.length, 1);
+    assert.ok(!lnd.seen[0].path.includes('undefined'), `URL contained undefined: ${lnd.seen[0].path}`);
+    assert.equal(lnd.seen[0].path, '/v1/payments');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('getPayments: valid params are forwarded correctly', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { max_payments: '20', index_offset: '3', reversed: 'false' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen.length, 1);
+    assert.ok(!lnd.seen[0].path.includes('undefined'), `URL contained undefined: ${lnd.seen[0].path}`);
+    assert.equal(lnd.seen[0].path, '/v1/payments?max_payments=20&index_offset=3&reversed=false');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('getPayments: invalid max_payments returns 400 without calling LND', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { max_payments: 'not-a-number' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'max_payments must be a non-negative integer');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('getPayments: invalid reversed returns 400 without calling LND', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { reversed: 'yes' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'reversed must be a boolean');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('getPayments: empty string max_payments returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { max_payments: '' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'max_payments must be a non-negative integer');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('getPayments: whitespace max_payments returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { max_payments: '   ' }), res, null);
+    await res.done;
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0, 'LND should not have been called');
+    assert.equal(res.body.message, 'max_payments must be a non-negative integer');
+  } finally {
+    await lnd.close();
+  }
+});
+
+test('getPayments: reversed 1 is coerced to true', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { reversed: '1' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen[0].path, '/v1/payments?reversed=true');
+  } finally { await lnd.close(); }
+});
+
+test('getPayments: reversed 0 is coerced to false', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { reversed: '0' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 200);
+    assert.equal(lnd.seen[0].path, '/v1/payments?reversed=false');
+  } finally { await lnd.close(); }
+});
+
+test('getPayments: negative max_payments returns 400', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { max_payments: '-1' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0);
+    assert.equal(res.body.message, 'max_payments must be a non-negative integer');
+  } finally { await lnd.close(); }
+});
+
+test('getPayments: index_offset validation works', async () => {
+  const lnd = await startFakeLnd('macaroon-test', []);
+  try {
+    const res = buildResponse();
+    getPayments(buildRequest(lnd, { index_offset: 'abc' }), res, null);
+    await res.done;
+    assert.equal(res.statusCode, 400);
+    assert.equal(lnd.seen.length, 0);
+    assert.equal(res.body.message, 'index_offset must be a non-negative integer');
+  } finally { await lnd.close(); }
+});


### PR DESCRIPTION
@saubyk 
fixes #1678

The LND listInvoices and getPayments controllers were building URLs by string-concatenating req.query values. Missing params sent "undefined" to LND which returned 400.

files changed:
- server/controllers/lnd/invoices.ts
- server/controllers/lnd/payments.ts

what changed:
- replaced string concat with options.qs
- num_max_invoices / max_payments / index_offset must be non-negative integers
- reversed must be true/false/1/0
- invalid params return 400 instead of forwarding garbage to LND

why options.qs instead of URLSearchParams:
- RTL already uses options.qs in getAllChannels and others
- request.ts wrapper passes it to axios which handles encoding and drops undefined
- less code in the controller
- consistent with the rest of the codebase

tests added:
- test/backend/lnd-invoices.test.mjs
- test/backend/lnd-payments.test.mjs

scope note:
The issue also mentions newAddress.ts, channels.ts (closeChannel), and wallet.ts (getUTXOs) have the same bug. I kept this PR focused on the two list controllers. If you want me to fix those in this same PR too, let me know and I can add them.

all backend tests pass.