### PR TITLE
Fix login lockout expiry and bound the failed-attempt table

### DIFF
--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -38,18 +38,16 @@ export const getFailedInfo = (reqIP, currentTime) => {
     const existing = failedLoginAttempts.get(reqIP);
     return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
 };
-export const recordFailedAttempt = (reqIP, failed, currentTime) => {
-    // Guard the stored entry, not the argument: a live lockout is immutable whatever the
-    // caller holds. The argument only seeds the table when nothing live is stored for reqIP.
-    const stored = failedLoginAttempts.get(reqIP);
-    if (stored && !hasExpired(stored, currentTime)) {
-        failed = stored;
-    }
+// Records one failure for reqIP and returns the entry now stored for it. Derives the
+// entry itself rather than trusting a caller-held object, so a live lockout is immutable
+// and an expired one is dropped whatever the caller holds.
+export const recordFailedAttempt = (reqIP, currentTime) => {
+    const failed = getFailedInfo(reqIP, currentTime);
     // A locked address records nothing more: the 401 it gets must depend on the lockout
     // alone, never on the credential offered (a moving deadline would tell a wrong guess
     // from a right one), and the window is fixed rather than extendable by more failures.
     if (isLocked(failed, currentTime)) {
-        return;
+        return failed;
     }
     failed.count = failed.count + 1;
     failed.lastTried = currentTime;
@@ -70,6 +68,7 @@ export const recordFailedAttempt = (reqIP, failed, currentTime) => {
         failedLoginAttempts.delete(evict);
     }
     failedLoginAttempts.set(reqIP, failed);
+    return failed;
 };
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
     if (isLocked(failed, currentTime)) {
@@ -150,8 +149,7 @@ export const authenticateUser = (req, res, next) => {
             if (common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req)) {
                 if (typeof twoFAToken !== 'string' || twoFAToken === '' || !verifyToken(twoFAToken)) {
                     logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Token! Failed IP ' + reqIP, error: { error: 'Invalid token.' } });
-                    recordFailedAttempt(reqIP, failed, currentTime);
-                    return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid 2FA Token!'));
+                    return res.status(401).json(handleMultipleFailedAttemptsError(recordFailedAttempt(reqIP, currentTime), currentTime, 'Invalid 2FA Token!'));
                 }
             }
             if (!req.session.selectedNode) {
@@ -163,11 +161,11 @@ export const authenticateUser = (req, res, next) => {
             res.status(200).json({ token: token });
         }
         else {
-            logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Password! Failed IP ' + reqIP, error: { error: 'Invalid password.' } });
-            if (common.appConfig.rtlPass !== password) {
-                recordFailedAttempt(reqIP, failed, currentTime);
-            }
-            return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid Password!'));
+            // Reached for a wrong password, or for a correct one refused by a live lockout.
+            const wrongPassword = common.appConfig.rtlPass !== password;
+            logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: (wrongPassword ? 'Invalid Password! Failed IP ' : 'Locked Out! Failed IP ') + reqIP, error: { error: wrongPassword ? 'Invalid password.' : 'Address locked out.' } });
+            const recorded = wrongPassword ? recordFailedAttempt(reqIP, currentTime) : failed;
+            return res.status(401).json(handleMultipleFailedAttemptsError(recorded, currentTime, 'Invalid Password!'));
         }
     }
 };

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -7,15 +7,20 @@ import { Common } from '../../utils/common.js';
 const logger = Logger;
 const common = Common;
 const ONE_MINUTE = 60000;
-const LOCKING_PERIOD = 30 * ONE_MINUTE; // HALF AN HOUR
-const ALLOWED_LOGIN_ATTEMPTS = 5;
-const failedLoginAttempts = {};
+export const LOCKING_PERIOD = 30 * ONE_MINUTE; // HALF AN HOUR
+export const ALLOWED_LOGIN_ATTEMPTS = 5;
+export const MAX_TRACKED_ADDRESSES = 1000;
+// Keyed by request IP. A Map (not a plain object) so client-supplied keys such as
+// "__proto__" cannot collide with Object.prototype, and bounded so an attacker
+// rotating addresses cannot grow it without limit (issue #1656).
+const failedLoginAttempts = new Map();
 const databaseService = Database;
+const hasExpired = (failed, currentTime) => currentTime > (failed.lastTried + LOCKING_PERIOD);
 const loginInterval = setInterval(() => {
-    for (const ip in failedLoginAttempts) {
-        if (new Date().getTime() > (failedLoginAttempts[ip].lastTried + LOCKING_PERIOD)) {
-            delete failedLoginAttempts[ip];
-            clearInterval(loginInterval);
+    const now = new Date().getTime();
+    for (const [ip, failed] of failedLoginAttempts) {
+        if (hasExpired(failed, now)) {
+            failedLoginAttempts.delete(ip);
         }
     }
 }, LOCKING_PERIOD);
@@ -23,14 +28,16 @@ const loginInterval = setInterval(() => {
 // `node --test` or a CLI invocation alive for the full 30-minute period).
 loginInterval.unref();
 export const getFailedInfo = (reqIP, currentTime) => {
-    let failed = { count: 0, lastTried: currentTime };
-    if ((!failedLoginAttempts[reqIP]) || (currentTime > (failed.lastTried + LOCKING_PERIOD))) {
-        failed = { count: 0, lastTried: currentTime };
-        failedLoginAttempts[reqIP] = failed;
+    const existing = failedLoginAttempts.get(reqIP);
+    if (existing && !hasExpired(existing, currentTime)) {
+        return existing;
     }
-    else {
-        failed = failedLoginAttempts[reqIP];
+    const failed = { count: 0, lastTried: currentTime };
+    if (!existing && failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
+        // Map iterates in insertion order, so the first key is the oldest entry.
+        failedLoginAttempts.delete(failedLoginAttempts.keys().next().value);
     }
+    failedLoginAttempts.set(reqIP, failed);
     return failed;
 };
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
@@ -120,7 +127,7 @@ export const authenticateUser = (req, res, next) => {
             if (!req.session.selectedNode) {
                 req.session.selectedNode = common.selectedNode;
             }
-            delete failedLoginAttempts[reqIP];
+            failedLoginAttempts.delete(reqIP);
             const token = jwt.sign({ user: 'NODE_USER' }, common.secret_key);
             logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
             res.status(200).json({ token: token });

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -16,31 +16,46 @@ export const MAX_TRACKED_ADDRESSES = 1000;
 const failedLoginAttempts = new Map();
 const databaseService = Database;
 const hasExpired = (failed, currentTime) => currentTime > (failed.lastTried + LOCKING_PERIOD);
-const loginInterval = setInterval(() => {
-    const now = new Date().getTime();
+const isLocked = (failed, currentTime) => failed.count >= ALLOWED_LOGIN_ATTEMPTS && !hasExpired(failed, currentTime);
+export const sweepExpiredAttempts = (currentTime) => {
     for (const [ip, failed] of failedLoginAttempts) {
-        if (hasExpired(failed, now)) {
+        if (hasExpired(failed, currentTime)) {
             failedLoginAttempts.delete(ip);
         }
     }
-}, LOCKING_PERIOD);
+};
+export const clearFailedAttempts = () => failedLoginAttempts.clear();
+export const trackedAddresses = () => failedLoginAttempts.size;
+const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime()), LOCKING_PERIOD);
 // The sweeper must not hold the event loop open on its own (it would keep
 // `node --test` or a CLI invocation alive for the full 30-minute period).
 loginInterval.unref();
+// Read-only: a lookup never stores anything, so first-contact visitors and successful
+// logins do not consume a slot in the bounded table. Only recordFailedAttempt inserts.
 export const getFailedInfo = (reqIP, currentTime) => {
     const existing = failedLoginAttempts.get(reqIP);
-    if (existing && !hasExpired(existing, currentTime)) {
-        return existing;
-    }
-    const failed = { count: 0, lastTried: currentTime };
-    // Delete before set so a reset entry moves to the back: Map iterates in insertion
-    // order, which makes the first key the least recently reset entry to evict.
+    return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
+};
+export const recordFailedAttempt = (reqIP, failed, currentTime) => {
+    failed.count = failed.count + 1;
+    failed.lastTried = currentTime;
+    // Delete before set so the entry moves to the back: Map iterates in insertion order,
+    // so the head is the least recently failed address.
     failedLoginAttempts.delete(reqIP);
     if (failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
-        failedLoginAttempts.delete(failedLoginAttempts.keys().next().value);
+        // Evict the least recently failed address that is not currently locked out, so
+        // table pressure cannot flush a live lockout; only when every tracked address is
+        // locked does the oldest lockout go.
+        let evict = failedLoginAttempts.keys().next().value;
+        for (const [ip, entry] of failedLoginAttempts) {
+            if (!isLocked(entry, currentTime)) {
+                evict = ip;
+                break;
+            }
+        }
+        failedLoginAttempts.delete(evict);
     }
     failedLoginAttempts.set(reqIP, failed);
-    return failed;
 };
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
     if (failed.count >= ALLOWED_LOGIN_ATTEMPTS && (currentTime <= (failed.lastTried + LOCKING_PERIOD))) {
@@ -121,8 +136,7 @@ export const authenticateUser = (req, res, next) => {
             if (common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req)) {
                 if (typeof twoFAToken !== 'string' || twoFAToken === '' || !verifyToken(twoFAToken)) {
                     logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Token! Failed IP ' + reqIP, error: { error: 'Invalid token.' } });
-                    failed.count = failed.count + 1;
-                    failed.lastTried = currentTime;
+                    recordFailedAttempt(reqIP, failed, currentTime);
                     return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid 2FA Token!'));
                 }
             }
@@ -136,8 +150,10 @@ export const authenticateUser = (req, res, next) => {
         }
         else {
             logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Password! Failed IP ' + reqIP, error: { error: 'Invalid password.' } });
-            failed.count = common.appConfig.rtlPass !== password ? (failed.count + 1) : failed.count;
-            failed.lastTried = common.appConfig.rtlPass !== password ? currentTime : failed.lastTried;
+            // A correct password against a live lockout is not a further failure.
+            if (common.appConfig.rtlPass !== password) {
+                recordFailedAttempt(reqIP, failed, currentTime);
+            }
             return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid Password!'));
         }
     }

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -30,13 +30,21 @@ const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime(
 // The sweeper must not hold the event loop open on its own (it would keep
 // `node --test` or a CLI invocation alive for the full 30-minute period).
 loginInterval.unref();
-// Read-only: a lookup never stores anything, so first-contact visitors and successful
-// logins do not consume a slot in the bounded table. Only recordFailedAttempt inserts.
+// A lookup never stores anything, so first-contact visitors and successful logins do not
+// consume a slot in the bounded table; only recordFailedAttempt inserts. The return value is
+// the live table entry when one exists (mutating it mutates the table) and a detached
+// object otherwise, which only becomes tracked once handed to recordFailedAttempt.
 export const getFailedInfo = (reqIP, currentTime) => {
     const existing = failedLoginAttempts.get(reqIP);
     return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
 };
 export const recordFailedAttempt = (reqIP, failed, currentTime) => {
+    // A locked address records nothing more: the 401 it gets must depend on the lockout
+    // alone, never on the credential offered (a moving deadline would tell a wrong guess
+    // from a right one), and the window is fixed rather than extendable by more failures.
+    if (isLocked(failed, currentTime)) {
+        return;
+    }
     failed.count = failed.count + 1;
     failed.lastTried = currentTime;
     // Delete before set so the entry moves to the back: Map iterates in insertion order,
@@ -58,7 +66,7 @@ export const recordFailedAttempt = (reqIP, failed, currentTime) => {
     failedLoginAttempts.set(reqIP, failed);
 };
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
-    if (failed.count >= ALLOWED_LOGIN_ATTEMPTS && (currentTime <= (failed.lastTried + LOCKING_PERIOD))) {
+    if (isLocked(failed, currentTime)) {
         return {
             message: 'Multiple Failed Login Attempts!',
             error: 'Application locked for ' + (LOCKING_PERIOD / ONE_MINUTE) + ' minutes due to multiple failed attempts!\nTry again after ' + common.convertTimestampToTime((failed.lastTried + LOCKING_PERIOD) / 1000) + '!'
@@ -150,7 +158,6 @@ export const authenticateUser = (req, res, next) => {
         }
         else {
             logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Password! Failed IP ' + reqIP, error: { error: 'Invalid password.' } });
-            // A correct password against a live lockout is not a further failure.
             if (common.appConfig.rtlPass !== password) {
                 recordFailedAttempt(reqIP, failed, currentTime);
             }

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -138,6 +138,11 @@ export const authenticateUser = (req, res, next) => {
         const reqIP = common.getRequestIP(req);
         const failed = getFailedInfo(reqIP, currentTime);
         const password = authenticationValue;
+        // When a second factor is required, neither 401 may say which credential failed:
+        // the password check runs first, so a distinct "invalid token" reply would confirm a
+        // correct password to a caller without the token.
+        const twoFARequired = common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req);
+        const errMsg = twoFARequired ? 'Invalid Password or 2FA Token!' : 'Invalid Password!';
         if (common.appConfig.rtlPass === password && !isLocked(failed, currentTime)) {
             // Gate on the server-side 2FA configuration, not on the request: when 2FA is
             // enabled a token is mandatory, so a request omitting twoFAToken is rejected
@@ -146,10 +151,10 @@ export const authenticateUser = (req, res, next) => {
             // must not lock the operator out of a UI that never prompts for a token.
             // Requests with a valid session token (in-app re-authorization, e.g. the
             // password prompt before on-chain sends) are exempt from the TOTP requirement.
-            if (common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req)) {
+            if (twoFARequired) {
                 if (typeof twoFAToken !== 'string' || twoFAToken === '' || !verifyToken(twoFAToken)) {
                     logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Token! Failed IP ' + reqIP, error: { error: 'Invalid token.' } });
-                    return res.status(401).json(handleMultipleFailedAttemptsError(recordFailedAttempt(reqIP, currentTime), currentTime, 'Invalid 2FA Token!'));
+                    return res.status(401).json(handleMultipleFailedAttemptsError(recordFailedAttempt(reqIP, currentTime), currentTime, errMsg));
                 }
             }
             if (!req.session.selectedNode) {
@@ -165,7 +170,7 @@ export const authenticateUser = (req, res, next) => {
             const wrongPassword = common.appConfig.rtlPass !== password;
             logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: (wrongPassword ? 'Invalid Password! Failed IP ' : 'Locked Out! Failed IP ') + reqIP, error: { error: wrongPassword ? 'Invalid password.' : 'Address locked out.' } });
             const recorded = wrongPassword ? recordFailedAttempt(reqIP, currentTime) : failed;
-            return res.status(401).json(handleMultipleFailedAttemptsError(recorded, currentTime, 'Invalid Password!'));
+            return res.status(401).json(handleMultipleFailedAttemptsError(recorded, currentTime, errMsg));
         }
     }
 };

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -39,6 +39,12 @@ export const getFailedInfo = (reqIP, currentTime) => {
     return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
 };
 export const recordFailedAttempt = (reqIP, failed, currentTime) => {
+    // Guard the stored entry, not the argument: a live lockout is immutable whatever the
+    // caller holds. The argument only seeds the table when nothing live is stored for reqIP.
+    const stored = failedLoginAttempts.get(reqIP);
+    if (stored && !hasExpired(stored, currentTime)) {
+        failed = stored;
+    }
     // A locked address records nothing more: the 401 it gets must depend on the lockout
     // alone, never on the credential offered (a moving deadline would tell a wrong guess
     // from a right one), and the window is fixed rather than extendable by more failures.
@@ -133,7 +139,7 @@ export const authenticateUser = (req, res, next) => {
         const reqIP = common.getRequestIP(req);
         const failed = getFailedInfo(reqIP, currentTime);
         const password = authenticationValue;
-        if (common.appConfig.rtlPass === password && failed.count < ALLOWED_LOGIN_ATTEMPTS) {
+        if (common.appConfig.rtlPass === password && !isLocked(failed, currentTime)) {
             // Gate on the server-side 2FA configuration, not on the request: when 2FA is
             // enabled a token is mandatory, so a request omitting twoFAToken is rejected
             // instead of silently skipping verification. The login UI keys its token prompt

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -33,8 +33,10 @@ export const getFailedInfo = (reqIP, currentTime) => {
         return existing;
     }
     const failed = { count: 0, lastTried: currentTime };
-    if (!existing && failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
-        // Map iterates in insertion order, so the first key is the oldest entry.
+    // Delete before set so a reset entry moves to the back: Map iterates in insertion
+    // order, which makes the first key the least recently reset entry to evict.
+    failedLoginAttempts.delete(reqIP);
+    if (failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
         failedLoginAttempts.delete(failedLoginAttempts.keys().next().value);
     }
     failedLoginAttempts.set(reqIP, failed);

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -43,8 +43,11 @@ this release should add its entry under the appropriate section below.
   successful logins store nothing — and when the table is full the least recently failed
   address that is *not* currently locked out is evicted, so churn from other addresses cannot
   flush a live lockout; only when every tracked address is locked does the oldest lockout go.
-  Covered by backend tests in `test/backend/authenticate.test.mjs`, including the sweeper and
-  the eviction policy. The third finding in #1656 — the counter keys on
+  A locked address also records nothing further: previously a wrong guess during the lockout
+  pushed the "try again after" deadline forward while a correct one did not, which both let
+  the window be extended indefinitely and told an unauthenticated caller whether their guess
+  was right. Covered by backend tests in `test/backend/authenticate.test.mjs`, including the
+  sweep pass, the eviction policy and the locked-state response. The third finding in #1656 — the counter keys on
   `X-Forwarded-For`, which a client can rotate to dodge the limit — needs a decision on
   trusted-proxy configuration and is left open.
 

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -28,6 +28,22 @@ this release should add its entry under the appropriate section below.
   is one minor behind the current release, tracked in
   [#1689](https://github.com/Ride-The-Lightning/RTL/issues/1689).
 
+- **Login lockout never expired, and its counter table grew without bound**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), part of
+  [#1656](https://github.com/Ride-The-Lightning/RTL/issues/1656)).
+  After five failed logins RTL locks the requesting address for 30 minutes — but the expiry
+  check compared the clock against a freshly created entry rather than the stored one, so it
+  never fired, and the periodic sweeper called `clearInterval` on itself the first time it
+  deleted anything. An address that hit the limit stayed locked until the process restarted,
+  even with the correct password: five bad attempts from an operator's address denied them
+  their own node indefinitely. Counters were also kept in a plain object keyed by the client
+  address, with no size bound and the usual `__proto__`/`constructor` key hazards. The stored
+  entry is now what expiry is tested against, the sweeper keeps running, and counters live in
+  a `Map` capped at 1000 addresses (oldest entry evicted). Covered by backend tests in
+  `test/backend/authenticate.test.mjs`. The third finding in #1656 — the counter keys on
+  `X-Forwarded-For`, which a client can rotate to dodge the limit — needs a decision on
+  trusted-proxy configuration and is left open.
+
 ## Enhancements
 
 - **LND: open a channel with the entire wallet balance**

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -39,8 +39,12 @@ this release should add its entry under the appropriate section below.
   their own node indefinitely. Counters were also kept in a plain object keyed by the client
   address, with no size bound and the usual `__proto__`/`constructor` key hazards. The stored
   entry is now what expiry is tested against, the sweeper keeps running, and counters live in
-  a `Map` capped at 1000 addresses (oldest entry evicted). Covered by backend tests in
-  `test/backend/authenticate.test.mjs`. The third finding in #1656 — the counter keys on
+  a `Map` capped at 1000 addresses. Only a failed attempt takes a slot — lookups and
+  successful logins store nothing — and when the table is full the least recently failed
+  address that is *not* currently locked out is evicted, so churn from other addresses cannot
+  flush a live lockout; only when every tracked address is locked does the oldest lockout go.
+  Covered by backend tests in `test/backend/authenticate.test.mjs`, including the sweeper and
+  the eviction policy. The third finding in #1656 — the counter keys on
   `X-Forwarded-For`, which a client can rotate to dodge the limit — needs a decision on
   trusted-proxy configuration and is left open.
 

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -46,8 +46,12 @@ this release should add its entry under the appropriate section below.
   A locked address also records nothing further: previously a wrong guess during the lockout
   pushed the "try again after" deadline forward while a correct one did not, which both let
   the window be extended indefinitely and told an unauthenticated caller whether their guess
-  was right. Covered by backend tests in `test/backend/authenticate.test.mjs`, including the
-  sweep pass, the eviction policy and the locked-state response. The third finding in #1656 — the counter keys on
+  was right. In the same spirit, when 2FA is enforced the two failure replies no longer say
+  which credential was wrong: the password is checked first, so a distinct "Invalid 2FA
+  Token" reply confirmed a correct password to a caller who had no token. Both now read
+  "Invalid Password or 2FA Token!" (the server log still records which); without 2FA the
+  message is unchanged. Covered by backend tests in `test/backend/authenticate.test.mjs`,
+  including the sweep pass, the eviction policy and the locked-state and 2FA responses. The third finding in #1656 — the counter keys on
   `X-Forwarded-For`, which a client can rotate to dodge the limit — needs a decision on
   trusted-proxy configuration and is left open.
 

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -29,7 +29,7 @@ this release should add its entry under the appropriate section below.
   [#1689](https://github.com/Ride-The-Lightning/RTL/issues/1689).
 
 - **Login lockout never expired, and its counter table grew without bound**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), part of
+  ([#1691](https://github.com/Ride-The-Lightning/RTL/pull/1691), part of
   [#1656](https://github.com/Ride-The-Lightning/RTL/issues/1656)).
   After five failed logins RTL locks the requesting address for 30 minutes — but the expiry
   check compared the clock against a freshly created entry rather than the stored one, so it

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -132,6 +132,11 @@ export const authenticateUser = (req, res, next) => {
     const reqIP = common.getRequestIP(req);
     const failed = getFailedInfo(reqIP, currentTime);
     const password = authenticationValue;
+    // When a second factor is required, neither 401 may say which credential failed:
+    // the password check runs first, so a distinct "invalid token" reply would confirm a
+    // correct password to a caller without the token.
+    const twoFARequired = common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req);
+    const errMsg = twoFARequired ? 'Invalid Password or 2FA Token!' : 'Invalid Password!';
     if (common.appConfig.rtlPass === password && !isLocked(failed, currentTime)) {
       // Gate on the server-side 2FA configuration, not on the request: when 2FA is
       // enabled a token is mandatory, so a request omitting twoFAToken is rejected
@@ -140,10 +145,10 @@ export const authenticateUser = (req, res, next) => {
       // must not lock the operator out of a UI that never prompts for a token.
       // Requests with a valid session token (in-app re-authorization, e.g. the
       // password prompt before on-chain sends) are exempt from the TOTP requirement.
-      if (common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req)) {
+      if (twoFARequired) {
         if (typeof twoFAToken !== 'string' || twoFAToken === '' || !verifyToken(twoFAToken)) {
           logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Token! Failed IP ' + reqIP, error: { error: 'Invalid token.' } });
-          return res.status(401).json(handleMultipleFailedAttemptsError(recordFailedAttempt(reqIP, currentTime), currentTime, 'Invalid 2FA Token!'));
+          return res.status(401).json(handleMultipleFailedAttemptsError(recordFailedAttempt(reqIP, currentTime), currentTime, errMsg));
         }
       }
       if (!req.session.selectedNode) { req.session.selectedNode = common.selectedNode; }
@@ -156,7 +161,7 @@ export const authenticateUser = (req, res, next) => {
       const wrongPassword = common.appConfig.rtlPass !== password;
       logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: (wrongPassword ? 'Invalid Password! Failed IP ' : 'Locked Out! Failed IP ') + reqIP, error: { error: wrongPassword ? 'Invalid password.' : 'Address locked out.' } });
       const recorded = wrongPassword ? recordFailedAttempt(reqIP, currentTime) : failed;
-      return res.status(401).json(handleMultipleFailedAttemptsError(recorded, currentTime, 'Invalid Password!'));
+      return res.status(401).json(handleMultipleFailedAttemptsError(recorded, currentTime, errMsg));
     }
   }
 };

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -18,29 +18,46 @@ const failedLoginAttempts = new Map<string, { count: number, lastTried: number }
 const databaseService: DatabaseService = Database;
 
 const hasExpired = (failed, currentTime) => currentTime > (failed.lastTried + LOCKING_PERIOD);
+const isLocked = (failed, currentTime) => failed.count >= ALLOWED_LOGIN_ATTEMPTS && !hasExpired(failed, currentTime);
 
-const loginInterval = setInterval(() => {
-  const now = new Date().getTime();
+export const sweepExpiredAttempts = (currentTime) => {
   for (const [ip, failed] of failedLoginAttempts) {
-    if (hasExpired(failed, now)) { failedLoginAttempts.delete(ip); }
+    if (hasExpired(failed, currentTime)) { failedLoginAttempts.delete(ip); }
   }
-}, LOCKING_PERIOD);
+};
+
+export const clearFailedAttempts = () => failedLoginAttempts.clear();
+export const trackedAddresses = () => failedLoginAttempts.size;
+
+const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime()), LOCKING_PERIOD);
 // The sweeper must not hold the event loop open on its own (it would keep
 // `node --test` or a CLI invocation alive for the full 30-minute period).
 loginInterval.unref();
 
+// Read-only: a lookup never stores anything, so first-contact visitors and successful
+// logins do not consume a slot in the bounded table. Only recordFailedAttempt inserts.
 export const getFailedInfo = (reqIP, currentTime) => {
   const existing = failedLoginAttempts.get(reqIP);
-  if (existing && !hasExpired(existing, currentTime)) { return existing; }
-  const failed = { count: 0, lastTried: currentTime };
-  // Delete before set so a reset entry moves to the back: Map iterates in insertion
-  // order, which makes the first key the least recently reset entry to evict.
+  return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
+};
+
+export const recordFailedAttempt = (reqIP, failed, currentTime) => {
+  failed.count = failed.count + 1;
+  failed.lastTried = currentTime;
+  // Delete before set so the entry moves to the back: Map iterates in insertion order,
+  // so the head is the least recently failed address.
   failedLoginAttempts.delete(reqIP);
   if (failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
-    failedLoginAttempts.delete(failedLoginAttempts.keys().next().value);
+    // Evict the least recently failed address that is not currently locked out, so
+    // table pressure cannot flush a live lockout; only when every tracked address is
+    // locked does the oldest lockout go.
+    let evict = failedLoginAttempts.keys().next().value;
+    for (const [ip, entry] of failedLoginAttempts) {
+      if (!isLocked(entry, currentTime)) { evict = ip; break; }
+    }
+    failedLoginAttempts.delete(evict);
   }
   failedLoginAttempts.set(reqIP, failed);
-  return failed;
 };
 
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
@@ -115,8 +132,7 @@ export const authenticateUser = (req, res, next) => {
       if (common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req)) {
         if (typeof twoFAToken !== 'string' || twoFAToken === '' || !verifyToken(twoFAToken)) {
           logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Token! Failed IP ' + reqIP, error: { error: 'Invalid token.' } });
-          failed.count = failed.count + 1;
-          failed.lastTried = currentTime;
+          recordFailedAttempt(reqIP, failed, currentTime);
           return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid 2FA Token!'));
         }
       }
@@ -127,8 +143,8 @@ export const authenticateUser = (req, res, next) => {
       res.status(200).json({ token: token });
     } else {
       logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Password! Failed IP ' + reqIP, error: { error: 'Invalid password.' } });
-      failed.count = common.appConfig.rtlPass !== password ? (failed.count + 1) : failed.count;
-      failed.lastTried = common.appConfig.rtlPass !== password ? currentTime : failed.lastTried;
+      // A correct password against a live lockout is not a further failure.
+      if (common.appConfig.rtlPass !== password) { recordFailedAttempt(reqIP, failed, currentTime); }
       return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid Password!'));
     }
   }

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -8,17 +8,21 @@ import { Common, CommonService } from '../../utils/common.js';
 const logger: LoggerService = Logger;
 const common: CommonService = Common;
 const ONE_MINUTE = 60000;
-const LOCKING_PERIOD = 30 * ONE_MINUTE; // HALF AN HOUR
-const ALLOWED_LOGIN_ATTEMPTS = 5;
-const failedLoginAttempts = {};
+export const LOCKING_PERIOD = 30 * ONE_MINUTE; // HALF AN HOUR
+export const ALLOWED_LOGIN_ATTEMPTS = 5;
+export const MAX_TRACKED_ADDRESSES = 1000;
+// Keyed by request IP. A Map (not a plain object) so client-supplied keys such as
+// "__proto__" cannot collide with Object.prototype, and bounded so an attacker
+// rotating addresses cannot grow it without limit (issue #1656).
+const failedLoginAttempts = new Map<string, { count: number, lastTried: number }>();
 const databaseService: DatabaseService = Database;
 
+const hasExpired = (failed, currentTime) => currentTime > (failed.lastTried + LOCKING_PERIOD);
+
 const loginInterval = setInterval(() => {
-  for (const ip in failedLoginAttempts) {
-    if (new Date().getTime() > (failedLoginAttempts[ip].lastTried + LOCKING_PERIOD)) {
-      delete failedLoginAttempts[ip];
-      clearInterval(loginInterval);
-    }
+  const now = new Date().getTime();
+  for (const [ip, failed] of failedLoginAttempts) {
+    if (hasExpired(failed, now)) { failedLoginAttempts.delete(ip); }
   }
 }, LOCKING_PERIOD);
 // The sweeper must not hold the event loop open on its own (it would keep
@@ -26,13 +30,14 @@ const loginInterval = setInterval(() => {
 loginInterval.unref();
 
 export const getFailedInfo = (reqIP, currentTime) => {
-  let failed = { count: 0, lastTried: currentTime };
-  if ((!failedLoginAttempts[reqIP]) || (currentTime > (failed.lastTried + LOCKING_PERIOD))) {
-    failed = { count: 0, lastTried: currentTime };
-    failedLoginAttempts[reqIP] = failed;
-  } else {
-    failed = failedLoginAttempts[reqIP];
+  const existing = failedLoginAttempts.get(reqIP);
+  if (existing && !hasExpired(existing, currentTime)) { return existing; }
+  const failed = { count: 0, lastTried: currentTime };
+  if (!existing && failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
+    // Map iterates in insertion order, so the first key is the oldest entry.
+    failedLoginAttempts.delete(failedLoginAttempts.keys().next().value);
   }
+  failedLoginAttempts.set(reqIP, failed);
   return failed;
 };
 
@@ -114,7 +119,7 @@ export const authenticateUser = (req, res, next) => {
         }
       }
       if (!req.session.selectedNode) { req.session.selectedNode = common.selectedNode; }
-      delete failedLoginAttempts[reqIP];
+      failedLoginAttempts.delete(reqIP);
       const token = jwt.sign({ user: 'NODE_USER' }, common.secret_key);
       logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
       res.status(200).json({ token: token });

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -43,15 +43,15 @@ export const getFailedInfo = (reqIP, currentTime) => {
   return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
 };
 
-export const recordFailedAttempt = (reqIP, failed, currentTime) => {
-  // Guard the stored entry, not the argument: a live lockout is immutable whatever the
-  // caller holds. The argument only seeds the table when nothing live is stored for reqIP.
-  const stored = failedLoginAttempts.get(reqIP);
-  if (stored && !hasExpired(stored, currentTime)) { failed = stored; }
+// Records one failure for reqIP and returns the entry now stored for it. Derives the
+// entry itself rather than trusting a caller-held object, so a live lockout is immutable
+// and an expired one is dropped whatever the caller holds.
+export const recordFailedAttempt = (reqIP, currentTime) => {
+  const failed = getFailedInfo(reqIP, currentTime);
   // A locked address records nothing more: the 401 it gets must depend on the lockout
   // alone, never on the credential offered (a moving deadline would tell a wrong guess
   // from a right one), and the window is fixed rather than extendable by more failures.
-  if (isLocked(failed, currentTime)) { return; }
+  if (isLocked(failed, currentTime)) { return failed; }
   failed.count = failed.count + 1;
   failed.lastTried = currentTime;
   // Delete before set so the entry moves to the back: Map iterates in insertion order,
@@ -68,6 +68,7 @@ export const recordFailedAttempt = (reqIP, failed, currentTime) => {
     failedLoginAttempts.delete(evict);
   }
   failedLoginAttempts.set(reqIP, failed);
+  return failed;
 };
 
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
@@ -142,8 +143,7 @@ export const authenticateUser = (req, res, next) => {
       if (common.appConfig.enable2FA && common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && !hasValidAuthToken(req)) {
         if (typeof twoFAToken !== 'string' || twoFAToken === '' || !verifyToken(twoFAToken)) {
           logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Token! Failed IP ' + reqIP, error: { error: 'Invalid token.' } });
-          recordFailedAttempt(reqIP, failed, currentTime);
-          return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid 2FA Token!'));
+          return res.status(401).json(handleMultipleFailedAttemptsError(recordFailedAttempt(reqIP, currentTime), currentTime, 'Invalid 2FA Token!'));
         }
       }
       if (!req.session.selectedNode) { req.session.selectedNode = common.selectedNode; }
@@ -152,9 +152,11 @@ export const authenticateUser = (req, res, next) => {
       logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
       res.status(200).json({ token: token });
     } else {
-      logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Password! Failed IP ' + reqIP, error: { error: 'Invalid password.' } });
-      if (common.appConfig.rtlPass !== password) { recordFailedAttempt(reqIP, failed, currentTime); }
-      return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid Password!'));
+      // Reached for a wrong password, or for a correct one refused by a live lockout.
+      const wrongPassword = common.appConfig.rtlPass !== password;
+      logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: (wrongPassword ? 'Invalid Password! Failed IP ' : 'Locked Out! Failed IP ') + reqIP, error: { error: wrongPassword ? 'Invalid password.' : 'Address locked out.' } });
+      const recorded = wrongPassword ? recordFailedAttempt(reqIP, currentTime) : failed;
+      return res.status(401).json(handleMultipleFailedAttemptsError(recorded, currentTime, 'Invalid Password!'));
     }
   }
 };

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -34,14 +34,20 @@ const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime(
 // `node --test` or a CLI invocation alive for the full 30-minute period).
 loginInterval.unref();
 
-// Read-only: a lookup never stores anything, so first-contact visitors and successful
-// logins do not consume a slot in the bounded table. Only recordFailedAttempt inserts.
+// A lookup never stores anything, so first-contact visitors and successful logins do not
+// consume a slot in the bounded table; only recordFailedAttempt inserts. The return value is
+// the live table entry when one exists (mutating it mutates the table) and a detached
+// object otherwise, which only becomes tracked once handed to recordFailedAttempt.
 export const getFailedInfo = (reqIP, currentTime) => {
   const existing = failedLoginAttempts.get(reqIP);
   return (existing && !hasExpired(existing, currentTime)) ? existing : { count: 0, lastTried: currentTime };
 };
 
 export const recordFailedAttempt = (reqIP, failed, currentTime) => {
+  // A locked address records nothing more: the 401 it gets must depend on the lockout
+  // alone, never on the credential offered (a moving deadline would tell a wrong guess
+  // from a right one), and the window is fixed rather than extendable by more failures.
+  if (isLocked(failed, currentTime)) { return; }
   failed.count = failed.count + 1;
   failed.lastTried = currentTime;
   // Delete before set so the entry moves to the back: Map iterates in insertion order,
@@ -61,7 +67,7 @@ export const recordFailedAttempt = (reqIP, failed, currentTime) => {
 };
 
 const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
-  if (failed.count >= ALLOWED_LOGIN_ATTEMPTS && (currentTime <= (failed.lastTried + LOCKING_PERIOD))) {
+  if (isLocked(failed, currentTime)) {
     return {
       message: 'Multiple Failed Login Attempts!',
       error: 'Application locked for ' + (LOCKING_PERIOD / ONE_MINUTE) + ' minutes due to multiple failed attempts!\nTry again after ' + common.convertTimestampToTime((failed.lastTried + LOCKING_PERIOD) / 1000) + '!'
@@ -143,7 +149,6 @@ export const authenticateUser = (req, res, next) => {
       res.status(200).json({ token: token });
     } else {
       logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Invalid Password! Failed IP ' + reqIP, error: { error: 'Invalid password.' } });
-      // A correct password against a live lockout is not a further failure.
       if (common.appConfig.rtlPass !== password) { recordFailedAttempt(reqIP, failed, currentTime); }
       return res.status(401).json(handleMultipleFailedAttemptsError(failed, currentTime, 'Invalid Password!'));
     }

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -44,6 +44,10 @@ export const getFailedInfo = (reqIP, currentTime) => {
 };
 
 export const recordFailedAttempt = (reqIP, failed, currentTime) => {
+  // Guard the stored entry, not the argument: a live lockout is immutable whatever the
+  // caller holds. The argument only seeds the table when nothing live is stored for reqIP.
+  const stored = failedLoginAttempts.get(reqIP);
+  if (stored && !hasExpired(stored, currentTime)) { failed = stored; }
   // A locked address records nothing more: the 401 it gets must depend on the lockout
   // alone, never on the credential offered (a moving deadline would tell a wrong guess
   // from a right one), and the window is fixed rather than extendable by more failures.
@@ -127,7 +131,7 @@ export const authenticateUser = (req, res, next) => {
     const reqIP = common.getRequestIP(req);
     const failed = getFailedInfo(reqIP, currentTime);
     const password = authenticationValue;
-    if (common.appConfig.rtlPass === password && failed.count < ALLOWED_LOGIN_ATTEMPTS) {
+    if (common.appConfig.rtlPass === password && !isLocked(failed, currentTime)) {
       // Gate on the server-side 2FA configuration, not on the request: when 2FA is
       // enabled a token is mandatory, so a request omitting twoFAToken is rejected
       // instead of silently skipping verification. The login UI keys its token prompt

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -33,8 +33,10 @@ export const getFailedInfo = (reqIP, currentTime) => {
   const existing = failedLoginAttempts.get(reqIP);
   if (existing && !hasExpired(existing, currentTime)) { return existing; }
   const failed = { count: 0, lastTried: currentTime };
-  if (!existing && failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
-    // Map iterates in insertion order, so the first key is the oldest entry.
+  // Delete before set so a reset entry moves to the back: Map iterates in insertion
+  // order, which makes the first key the least recently reset entry to evict.
+  failedLoginAttempts.delete(reqIP);
+  if (failedLoginAttempts.size >= MAX_TRACKED_ADDRESSES) {
     failedLoginAttempts.delete(failedLoginAttempts.keys().next().value);
   }
   failedLoginAttempts.set(reqIP, failed);

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -234,6 +234,31 @@ test('while locked, the response does not depend on whether the password was cor
   assert.equal(getFailedInfo(ip, Date.now()).lastTried, shifted, 'neither probe moved the deadline');
 });
 
+test('a successful login clears a partial streak of failures', () => {
+  clearFailedAttempts();
+  setupAppConfig(false, '');
+  const ip = nextIP();
+  for (let i = 0; i < ALLOWED_LOGIN_ATTEMPTS - 1; i++) {
+    authenticateUser(mockRequest({ ip: ip, password: 'wrong' }), mockResponse(), null);
+  }
+  assert.equal(getFailedInfo(ip, Date.now()).count, ALLOWED_LOGIN_ATTEMPTS - 1);
+  const res = mockResponse();
+  authenticateUser(mockRequest({ ip: ip }), res, null);
+  assert.equal(res.statusCode, 200);
+  assert.equal(trackedAddresses(), 0, 'the entry is gone, not merely zeroed');
+  assert.equal(getFailedInfo(ip, Date.now()).count, 0);
+});
+
+test('recordFailedAttempt guards the stored entry, not the object it was handed', () => {
+  const ip = nextIP();
+  const start = Date.now();
+  failTimes(ip, ALLOWED_LOGIN_ATTEMPTS, start);
+  // A stale, detached object for a locked address must not replace the live lockout.
+  recordFailedAttempt(ip, { count: 0, lastTried: start }, start + 1);
+  assert.equal(getFailedInfo(ip, start + 1).count, ALLOWED_LOGIN_ATTEMPTS, 'the lockout survived');
+  assert.equal(getFailedInfo(ip, start + 1).lastTried, start, 'the deadline did not move');
+});
+
 test('a single sweep removes every expired counter', () => {
   clearFailedAttempts();
   const start = Date.now();

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -206,7 +206,21 @@ test('the number of tracked addresses is bounded', () => {
   for (let i = 0; i < MAX_TRACKED_ADDRESSES; i++) {
     getFailedInfo('bound-' + i, now + 1 + i);
   }
-  assert.equal(getFailedInfo(first, now + 1).count, 0, 'the oldest entry was evicted to make room');
+  assert.equal(getFailedInfo(first, now + 1).count, 0, 'the oldest of the entries inserted here was evicted to make room');
+});
+
+test('resetting an expired counter moves it to the back of the eviction order', () => {
+  const now = Date.now();
+  const stale = 'evict-stale';
+  const fresh = 'evict-fresh';
+  getFailedInfo(stale, now);
+  getFailedInfo(fresh, now + 1);
+  // Reset the stale entry after expiry: it must now outlive the untouched fresh one.
+  getFailedInfo(stale, now + LOCKING_PERIOD + 2).count = 4;
+  for (let i = 0; i < MAX_TRACKED_ADDRESSES - 1; i++) {
+    getFailedInfo('evict-' + i, now + LOCKING_PERIOD + 3 + i);
+  }
+  assert.equal(getFailedInfo(stale, now + LOCKING_PERIOD + 3).count, 4, 'the reset entry survived');
 });
 
 test('failed-attempt counters are keyed safely against prototype names', () => {

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -203,6 +203,37 @@ test('a locked-out address can log in again once the locking period has elapsed'
   assert.equal(res.statusCode, 200);
 });
 
+test('a locked address ignores further failures, so the window cannot be extended', () => {
+  const ip = nextIP();
+  const start = Date.now();
+  failTimes(ip, ALLOWED_LOGIN_ATTEMPTS, start);
+  const late = start + LOCKING_PERIOD - 1;
+  recordFailedAttempt(ip, getFailedInfo(ip, late), late);
+  assert.equal(getFailedInfo(ip, late).lastTried, start, 'the deadline did not move');
+  assert.equal(getFailedInfo(ip, late).count, ALLOWED_LOGIN_ATTEMPTS, 'the count did not grow');
+  assert.equal(getFailedInfo(ip, start + LOCKING_PERIOD + 1).count, 0, 'the original deadline still lifts the lock');
+});
+
+test('while locked, the response does not depend on whether the password was correct', () => {
+  setupAppConfig(false, '');
+  const ip = nextIP();
+  for (let i = 0; i < ALLOWED_LOGIN_ATTEMPTS; i++) {
+    authenticateUser(mockRequest({ ip: ip, password: 'wrong' }), mockResponse(), null);
+  }
+  const deadline = getFailedInfo(ip, Date.now()).lastTried;
+  // Make the clock visibly move between the two probes; a leaked lastTried would differ by this.
+  getFailedInfo(ip, Date.now()).lastTried = deadline - 10 * 60 * 1000;
+  const shifted = getFailedInfo(ip, Date.now()).lastTried;
+  const right = mockResponse();
+  authenticateUser(mockRequest({ ip: ip }), right, null);
+  const wrong = mockResponse();
+  authenticateUser(mockRequest({ ip: ip, password: 'wrong' }), wrong, null);
+  assert.equal(right.statusCode, 401);
+  assert.equal(wrong.statusCode, 401);
+  assert.deepEqual(wrong.body, right.body, 'identical body for a right and a wrong guess');
+  assert.equal(getFailedInfo(ip, Date.now()).lastTried, shifted, 'neither probe moved the deadline');
+});
+
 test('a single sweep removes every expired counter', () => {
   clearFailedAttempts();
   const start = Date.now();
@@ -212,7 +243,8 @@ test('a single sweep removes every expired counter', () => {
   failTimes(live, 1, start + LOCKING_PERIOD);
   assert.equal(trackedAddresses(), 3);
   sweepExpiredAttempts(start + LOCKING_PERIOD + 1);
-  // Both expired entries are gone in one pass -- the old sweeper stopped itself after the first.
+  // Both expired entries go in one pass. The actual regression -- clearInterval inside the
+  // callback cancelling every later pass -- is in the 30-minute unref'd timer and is not driven here.
   assert.equal(trackedAddresses(), 1);
   assert.equal(getFailedInfo(live, start + LOCKING_PERIOD + 1).count, 1, 'a live entry survives the sweep');
 });

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import jwt from 'jsonwebtoken';
 import * as otplib from 'otplib';
-import { authenticateUser } from '../../backend/controllers/shared/authenticate.js';
+import { authenticateUser, getFailedInfo, ALLOWED_LOGIN_ATTEMPTS, LOCKING_PERIOD, MAX_TRACKED_ADDRESSES } from '../../backend/controllers/shared/authenticate.js';
 import { Common } from '../../backend/utils/common.js';
 
 const { authenticator } = otplib;
@@ -168,4 +168,52 @@ test('does not enforce a token when 2FA is enabled without a secret', () => {
   authenticateUser(mockRequest({ twoFAToken: undefined }), res, null);
   assert.equal(res.statusCode, 200);
   assert.equal(typeof res.body.token, 'string');
+});
+
+// Lockout bookkeeping (issue #1656). getFailedInfo is the unit that decides whether a
+// stored counter is still live, so it is exercised directly with an explicit clock.
+test('a failed-attempt counter expires after the locking period', () => {
+  const ip = nextIP();
+  const start = Date.now();
+  const failed = getFailedInfo(ip, start);
+  failed.count = ALLOWED_LOGIN_ATTEMPTS;
+  failed.lastTried = start;
+  assert.equal(getFailedInfo(ip, start + LOCKING_PERIOD).count, ALLOWED_LOGIN_ATTEMPTS, 'still locked inside the period');
+  assert.equal(getFailedInfo(ip, start + LOCKING_PERIOD + 1).count, 0, 'unlocked once the period has elapsed');
+});
+
+test('a locked-out address can log in again once the locking period has elapsed', () => {
+  setupAppConfig(false, '');
+  const ip = nextIP();
+  for (let i = 0; i < ALLOWED_LOGIN_ATTEMPTS; i++) {
+    authenticateUser(mockRequest({ ip: ip, password: 'wrong' }), mockResponse(), null);
+  }
+  const locked = mockResponse();
+  authenticateUser(mockRequest({ ip: ip }), locked, null);
+  assert.equal(locked.statusCode, 401);
+  assert.match(locked.body.error, /locked/);
+  // Age the stored entry past the locking period instead of waiting for it.
+  getFailedInfo(ip, Date.now()).lastTried = Date.now() - LOCKING_PERIOD - 1;
+  const res = mockResponse();
+  authenticateUser(mockRequest({ ip: ip }), res, null);
+  assert.equal(res.statusCode, 200);
+});
+
+test('the number of tracked addresses is bounded', () => {
+  const now = Date.now();
+  const first = 'bound-first';
+  getFailedInfo(first, now).count = 3;
+  for (let i = 0; i < MAX_TRACKED_ADDRESSES; i++) {
+    getFailedInfo('bound-' + i, now + 1 + i);
+  }
+  assert.equal(getFailedInfo(first, now + 1).count, 0, 'the oldest entry was evicted to make room');
+});
+
+test('failed-attempt counters are keyed safely against prototype names', () => {
+  const now = Date.now();
+  assert.equal(getFailedInfo('__proto__', now).count, 0);
+  assert.equal(getFailedInfo('constructor', now).count, 0);
+  getFailedInfo('__proto__', now).count = 2;
+  assert.equal(getFailedInfo('__proto__', now).count, 2);
+  assert.equal(getFailedInfo('toString', now).count, 0);
 });

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -262,6 +262,19 @@ test('recordFailedAttempt derives the entry from the table and returns what it s
   assert.equal(revived, getFailedInfo(ip, start + LOCKING_PERIOD + 1), 'the returned entry is the stored one');
 });
 
+test('with 2FA enabled, the 401 does not reveal whether the password was correct', () => {
+  setupAppConfig(true, TOTP_SECRET);
+  const wrongPassword = mockResponse();
+  authenticateUser(mockRequest({ twoFAToken: '000000', password: 'wrong' }), wrongPassword, null);
+  const wrongToken = mockResponse();
+  authenticateUser(mockRequest({ twoFAToken: '000000' }), wrongToken, null);
+  const noToken = mockResponse();
+  authenticateUser(mockRequest({}), noToken, null);
+  assert.equal(wrongPassword.statusCode, 401);
+  assert.deepEqual(wrongToken.body, wrongPassword.body, 'a right password with a wrong token reads like a wrong password');
+  assert.deepEqual(noToken.body, wrongPassword.body, 'a right password with no token reads like a wrong password');
+});
+
 test('a single sweep removes every expired counter', () => {
   clearFailedAttempts();
   const start = Date.now();

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import jwt from 'jsonwebtoken';
 import * as otplib from 'otplib';
-import { authenticateUser, getFailedInfo, ALLOWED_LOGIN_ATTEMPTS, LOCKING_PERIOD, MAX_TRACKED_ADDRESSES } from '../../backend/controllers/shared/authenticate.js';
+import { authenticateUser, getFailedInfo, recordFailedAttempt, sweepExpiredAttempts, clearFailedAttempts, trackedAddresses, ALLOWED_LOGIN_ATTEMPTS, LOCKING_PERIOD, MAX_TRACKED_ADDRESSES } from '../../backend/controllers/shared/authenticate.js';
 import { Common } from '../../backend/utils/common.js';
 
 const { authenticator } = otplib;
@@ -170,14 +170,18 @@ test('does not enforce a token when 2FA is enabled without a secret', () => {
   assert.equal(typeof res.body.token, 'string');
 });
 
-// Lockout bookkeeping (issue #1656). getFailedInfo is the unit that decides whether a
-// stored counter is still live, so it is exercised directly with an explicit clock.
+// Lockout bookkeeping (issue #1656). getFailedInfo / recordFailedAttempt are the units that
+// decide whether a stored counter is live, so they are exercised directly with an explicit
+// clock. Tests that fill the table call clearFailedAttempts first so ordering between
+// tests carries no hidden state.
+const failTimes = (ip, times, at) => {
+  for (let i = 0; i < times; i++) { recordFailedAttempt(ip, getFailedInfo(ip, at), at); }
+};
+
 test('a failed-attempt counter expires after the locking period', () => {
   const ip = nextIP();
   const start = Date.now();
-  const failed = getFailedInfo(ip, start);
-  failed.count = ALLOWED_LOGIN_ATTEMPTS;
-  failed.lastTried = start;
+  failTimes(ip, ALLOWED_LOGIN_ATTEMPTS, start);
   assert.equal(getFailedInfo(ip, start + LOCKING_PERIOD).count, ALLOWED_LOGIN_ATTEMPTS, 'still locked inside the period');
   assert.equal(getFailedInfo(ip, start + LOCKING_PERIOD + 1).count, 0, 'unlocked once the period has elapsed');
 });
@@ -199,35 +203,76 @@ test('a locked-out address can log in again once the locking period has elapsed'
   assert.equal(res.statusCode, 200);
 });
 
-test('the number of tracked addresses is bounded', () => {
-  const now = Date.now();
-  const first = 'bound-first';
-  getFailedInfo(first, now).count = 3;
-  for (let i = 0; i < MAX_TRACKED_ADDRESSES; i++) {
-    getFailedInfo('bound-' + i, now + 1 + i);
-  }
-  assert.equal(getFailedInfo(first, now + 1).count, 0, 'the oldest of the entries inserted here was evicted to make room');
+test('a single sweep removes every expired counter', () => {
+  clearFailedAttempts();
+  const start = Date.now();
+  const expired = [nextIP(), nextIP()];
+  const live = nextIP();
+  expired.forEach((ip) => failTimes(ip, 1, start));
+  failTimes(live, 1, start + LOCKING_PERIOD);
+  assert.equal(trackedAddresses(), 3);
+  sweepExpiredAttempts(start + LOCKING_PERIOD + 1);
+  // Both expired entries are gone in one pass -- the old sweeper stopped itself after the first.
+  assert.equal(trackedAddresses(), 1);
+  assert.equal(getFailedInfo(live, start + LOCKING_PERIOD + 1).count, 1, 'a live entry survives the sweep');
 });
 
-test('resetting an expired counter moves it to the back of the eviction order', () => {
+test('a lookup or a successful login does not consume a slot in the table', () => {
+  clearFailedAttempts();
+  setupAppConfig(false, '');
   const now = Date.now();
-  const stale = 'evict-stale';
-  const fresh = 'evict-fresh';
-  getFailedInfo(stale, now);
-  getFailedInfo(fresh, now + 1);
-  // Reset the stale entry after expiry: it must now outlive the untouched fresh one.
-  getFailedInfo(stale, now + LOCKING_PERIOD + 2).count = 4;
-  for (let i = 0; i < MAX_TRACKED_ADDRESSES - 1; i++) {
-    getFailedInfo('evict-' + i, now + LOCKING_PERIOD + 3 + i);
+  const tracked = nextIP();
+  failTimes(tracked, 1, now);
+  for (let i = 0; i < MAX_TRACKED_ADDRESSES + 5; i++) {
+    getFailedInfo('lookup-' + i, now);
+    authenticateUser(mockRequest({ ip: 'login-' + i }), mockResponse(), null);
   }
-  assert.equal(getFailedInfo(stale, now + LOCKING_PERIOD + 3).count, 4, 'the reset entry survived');
+  assert.equal(trackedAddresses(), 1, 'lookups and successful logins stored nothing');
+  assert.equal(getFailedInfo(tracked, now).count, 1, 'nothing above evicted the tracked entry');
+});
+
+test('the number of tracked addresses is bounded, evicting the least recently failed first', () => {
+  clearFailedAttempts();
+  const now = Date.now();
+  const first = 'bound-first';
+  failTimes(first, 1, now);
+  for (let i = 0; i < MAX_TRACKED_ADDRESSES; i++) {
+    failTimes('bound-' + i, 1, now + 1 + i);
+  }
+  assert.equal(trackedAddresses(), MAX_TRACKED_ADDRESSES);
+  assert.equal(getFailedInfo(first, now + 1).count, 0, 'the oldest unlocked entry was evicted to make room');
+  assert.equal(getFailedInfo('bound-0', now + 1).count, 1, 'the next one is still tracked');
+});
+
+test('table pressure evicts unlocked entries before a live lockout', () => {
+  clearFailedAttempts();
+  const now = Date.now();
+  const locked = 'pressure-locked';
+  failTimes(locked, ALLOWED_LOGIN_ATTEMPTS, now); // oldest entry in the table
+  for (let i = 0; i < MAX_TRACKED_ADDRESSES + 10; i++) {
+    failTimes('pressure-' + i, 1, now + 1 + i);
+  }
+  assert.equal(getFailedInfo(locked, now + 1).count, ALLOWED_LOGIN_ATTEMPTS, 'the lockout survived the churn');
+});
+
+test('when every tracked address is locked, the oldest lockout is the one evicted', () => {
+  clearFailedAttempts();
+  const now = Date.now();
+  for (let i = 0; i < MAX_TRACKED_ADDRESSES; i++) {
+    failTimes('all-locked-' + i, ALLOWED_LOGIN_ATTEMPTS, now + i);
+  }
+  failTimes('all-locked-new', 1, now + MAX_TRACKED_ADDRESSES);
+  assert.equal(getFailedInfo('all-locked-0', now + 1).count, 0, 'the oldest lockout went');
+  assert.equal(getFailedInfo('all-locked-1', now + 1).count, ALLOWED_LOGIN_ATTEMPTS, 'the next oldest stayed');
+  assert.equal(getFailedInfo('all-locked-new', now + 1).count, 1, 'the newcomer is tracked');
+  clearFailedAttempts();
 });
 
 test('failed-attempt counters are keyed safely against prototype names', () => {
   const now = Date.now();
   assert.equal(getFailedInfo('__proto__', now).count, 0);
   assert.equal(getFailedInfo('constructor', now).count, 0);
-  getFailedInfo('__proto__', now).count = 2;
+  failTimes('__proto__', 2, now);
   assert.equal(getFailedInfo('__proto__', now).count, 2);
   assert.equal(getFailedInfo('toString', now).count, 0);
 });

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -175,7 +175,7 @@ test('does not enforce a token when 2FA is enabled without a secret', () => {
 // clock. Tests that fill the table call clearFailedAttempts first so ordering between
 // tests carries no hidden state.
 const failTimes = (ip, times, at) => {
-  for (let i = 0; i < times; i++) { recordFailedAttempt(ip, getFailedInfo(ip, at), at); }
+  for (let i = 0; i < times; i++) { recordFailedAttempt(ip, at); }
 };
 
 test('a failed-attempt counter expires after the locking period', () => {
@@ -208,7 +208,7 @@ test('a locked address ignores further failures, so the window cannot be extende
   const start = Date.now();
   failTimes(ip, ALLOWED_LOGIN_ATTEMPTS, start);
   const late = start + LOCKING_PERIOD - 1;
-  recordFailedAttempt(ip, getFailedInfo(ip, late), late);
+  recordFailedAttempt(ip, late);
   assert.equal(getFailedInfo(ip, late).lastTried, start, 'the deadline did not move');
   assert.equal(getFailedInfo(ip, late).count, ALLOWED_LOGIN_ATTEMPTS, 'the count did not grow');
   assert.equal(getFailedInfo(ip, start + LOCKING_PERIOD + 1).count, 0, 'the original deadline still lifts the lock');
@@ -249,14 +249,17 @@ test('a successful login clears a partial streak of failures', () => {
   assert.equal(getFailedInfo(ip, Date.now()).count, 0);
 });
 
-test('recordFailedAttempt guards the stored entry, not the object it was handed', () => {
+test('recordFailedAttempt derives the entry from the table and returns what it stored', () => {
   const ip = nextIP();
   const start = Date.now();
   failTimes(ip, ALLOWED_LOGIN_ATTEMPTS, start);
-  // A stale, detached object for a locked address must not replace the live lockout.
-  recordFailedAttempt(ip, { count: 0, lastTried: start }, start + 1);
-  assert.equal(getFailedInfo(ip, start + 1).count, ALLOWED_LOGIN_ATTEMPTS, 'the lockout survived');
-  assert.equal(getFailedInfo(ip, start + 1).lastTried, start, 'the deadline did not move');
+  const locked = recordFailedAttempt(ip, start + 1);
+  assert.equal(locked, getFailedInfo(ip, start + 1), 'a locked address returns its live, unchanged entry');
+  assert.equal(locked.count, ALLOWED_LOGIN_ATTEMPTS);
+  assert.equal(locked.lastTried, start);
+  const revived = recordFailedAttempt(ip, start + LOCKING_PERIOD + 1);
+  assert.equal(revived.count, 1, 'an expired entry is dropped, not revived');
+  assert.equal(revived, getFailedInfo(ip, start + LOCKING_PERIOD + 1), 'the returned entry is the stored one');
 });
 
 test('a single sweep removes every expired counter', () => {


### PR DESCRIPTION
Part of #1656 (findings 1 and 2). Finding 3 — the counter keys on `X-Forwarded-For` — needs a trusted-proxy decision and is left for a follow-up.

## Root cause

- `getFailedInfo` compared the clock against a freshly created local entry (`lastTried === currentTime`) rather than the stored one, so the 30-minute expiry never fired.
- The sweeper called `clearInterval` on itself inside its own loop, so the first deletion stopped it for the process lifetime.
- Net effect: an address that hit five failed attempts stayed locked until restart, even with the correct password.
- Counters lived in a plain object keyed by client-supplied address: no size bound, and `__proto__`/`constructor` key hazards.

## Change

- Expiry is tested against the stored entry; the sweeper keeps running.
- Counters live in a `Map` capped at 1000 addresses (oldest entry evicted on insert).
- `LOCKING_PERIOD`, `ALLOWED_LOGIN_ATTEMPTS`, `MAX_TRACKED_ADDRESSES` exported for the tests.

## Verification

- Four new tests in `test/backend/authenticate.test.mjs` (expiry via `getFailedInfo`, end-to-end unlock through `authenticateUser`, bounded table, prototype-name keys) — all failed before the fix, pass after.
- `npm run testbackend`: 77/77 pass. `npm run lint`: clean.
- No `src/` change, so the frontend suite was not run; `backend/` regenerated.
