### PR TITLE
Report a failed Eclair channel open instead of success and Unknown Error

### DIFF
--- a/backend/controllers/eclair/channels.js
+++ b/backend/controllers/eclair/channels.js
@@ -12,13 +12,17 @@ export const simplifyAllChannels = (selNode, channels) => {
     const simplifiedChannels = [];
     channels.forEach((channel) => {
         channelNodeIds = channelNodeIds + ',' + channel.nodeId;
+        // A channel that is still being opened, or that failed before funding and is on its way out, has no
+        // commitments yet. Eclair lists it anyway, so read its balances as zero instead of throwing on the
+        // missing object and turning the whole channel list into an error.
+        const spec = channel.data?.commitments?.active?.[0]?.localCommit?.spec;
         simplifiedChannels.push({
             nodeId: channel.nodeId ? channel.nodeId : '',
             channelId: channel.channelId ? channel.channelId : '',
             state: channel.state ? channel.state : '',
             announceChannel: channel.data && channel.data.commitments && channel.data.commitments.params && channel.data.commitments.params.channelFlags && channel.data.commitments.params.channelFlags.announceChannel ? channel.data.commitments.params.channelFlags.announceChannel : false,
-            toLocal: (channel.data.commitments.active[0].localCommit.spec.toLocal) ? Math.round(+channel.data.commitments.active[0].localCommit.spec.toLocal / 1000) : 0,
-            toRemote: (channel.data.commitments.active[0].localCommit.spec.toRemote) ? Math.round(+channel.data.commitments.active[0].localCommit.spec.toRemote / 1000) : 0,
+            toLocal: (spec && spec.toLocal) ? Math.round(+spec.toLocal / 1000) : 0,
+            toRemote: (spec && spec.toRemote) ? Math.round(+spec.toRemote / 1000) : 0,
             shortChannelId: channel.data && channel.data.channelUpdate && channel.data.channelUpdate.shortChannelId ? channel.data.channelUpdate.shortChannelId : '',
             isInitiator: channel.data && channel.data.commitments && channel.data.commitments.params && channel.data.commitments.params.localParams && channel.data.commitments.params.localParams.isInitiator ? channel.data.commitments.params.localParams.isInitiator : false,
             feeBaseMsat: channel.data && channel.data.channelUpdate && channel.data.channelUpdate.feeBaseMsat ? channel.data.channelUpdate.feeBaseMsat : 0,
@@ -112,6 +116,14 @@ export const openChannel = (req, res, next) => {
     options.form = req.body;
     logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Channels', msg: 'Open Channel Params', data: options.form });
     request.post(options).then((body) => {
+        // Eclair answers /open with HTTP 200 whatever happened. Only 'created channel <id> ...' means a channel
+        // was opened; anything else is the reason it was not ('wallet error: Insufficient funds (code: -4)',
+        // 'peer aborted the channel funding flow: ...', 'disconnected', 'open channel cancelled, took too long').
+        if (typeof body !== 'string' || !body.startsWith('created channel')) {
+            const reason = typeof body === 'string' ? body : JSON.stringify(body);
+            const err = common.handleError({ statusCode: 500, message: reason, error: reason }, 'Channels', 'Open Channel Error', req.session.selectedNode);
+            return res.status(err.statusCode).json({ message: err.message, error: err.error });
+        }
         logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Channels', msg: 'Channel Opened', data: body });
         res.status(201).json(body);
     }).catch((errRes) => {

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -118,6 +118,24 @@ this release should add its entry under the appropriate section below.
   still builds `?payment_hash=` by concatenation, as do `newAddress.ts`, `channels.ts` and
   `wallet.ts`.
 
+- **Eclair: a failed channel open is reported as a failure**
+  ([#1695](https://github.com/Ride-The-Lightning/RTL/pull/1695)).
+  Eclair answers `/open` with HTTP 200 whatever happened: `created channel …` when a channel was
+  opened, and otherwise the reason it was not — `wallet error: Insufficient funds (code: -4)`,
+  `peer aborted the channel funding flow: …`, `disconnected`. RTL took every 200 as a success, so a
+  failed open showed "Channel Added Successfully!" and refreshed the channel list. That refresh then
+  hit the channel that had just failed, which Eclair keeps listing for about a minute with no
+  `commitments` object, and the channel mapper read `data.commitments.active[0]` without checking;
+  the TypeError serialised to `{}` and reached the page as "Unknown Error". The reason for the
+  failure appeared nowhere but Eclair's own log. The backend now treats any `/open` reply that does
+  not start with `created channel` as an error carrying Eclair's text, so the open dialog shows
+  "wallet error: Insufficient funds (code: -4)" or "wallet error: requirement failed: mining fee is
+  higher than budget (167 sat > 25 sat)" where it used to show success, and the mapper reads the
+  balances of a channel that has no commitments yet as zero — which also covers a channel that is
+  simply still being opened, and dual-funded opens that sit in that state for longer. Seen on an
+  Eclair 0.14.2 node opening to Core Lightning, where three different failures in one session all
+  looked identical from RTL.
+
 ## Enhancements
 
 - **Loop and Boltz connection settings are configured in the config file or environment only**

--- a/server/controllers/eclair/channels.ts
+++ b/server/controllers/eclair/channels.ts
@@ -15,13 +15,17 @@ export const simplifyAllChannels = (selNode: SelectedNode, channels) => {
   const simplifiedChannels = [];
   channels.forEach((channel) => {
     channelNodeIds = channelNodeIds + ',' + channel.nodeId;
+    // A channel that is still being opened, or that failed before funding and is on its way out, has no
+    // commitments yet. Eclair lists it anyway, so read its balances as zero instead of throwing on the
+    // missing object and turning the whole channel list into an error.
+    const spec = channel.data?.commitments?.active?.[0]?.localCommit?.spec;
     simplifiedChannels.push({
       nodeId: channel.nodeId ? channel.nodeId : '',
       channelId: channel.channelId ? channel.channelId : '',
       state: channel.state ? channel.state : '',
       announceChannel: channel.data && channel.data.commitments && channel.data.commitments.params && channel.data.commitments.params.channelFlags && channel.data.commitments.params.channelFlags.announceChannel ? channel.data.commitments.params.channelFlags.announceChannel : false,
-      toLocal: (channel.data.commitments.active[0].localCommit.spec.toLocal) ? Math.round(+channel.data.commitments.active[0].localCommit.spec.toLocal / 1000) : 0,
-      toRemote: (channel.data.commitments.active[0].localCommit.spec.toRemote) ? Math.round(+channel.data.commitments.active[0].localCommit.spec.toRemote / 1000) : 0,
+      toLocal: (spec && spec.toLocal) ? Math.round(+spec.toLocal / 1000) : 0,
+      toRemote: (spec && spec.toRemote) ? Math.round(+spec.toRemote / 1000) : 0,
       shortChannelId: channel.data && channel.data.channelUpdate && channel.data.channelUpdate.shortChannelId ? channel.data.channelUpdate.shortChannelId : '',
       isInitiator: channel.data && channel.data.commitments && channel.data.commitments.params && channel.data.commitments.params.localParams && channel.data.commitments.params.localParams.isInitiator ? channel.data.commitments.params.localParams.isInitiator : false,
       feeBaseMsat: channel.data && channel.data.channelUpdate && channel.data.channelUpdate.feeBaseMsat ? channel.data.channelUpdate.feeBaseMsat : 0,
@@ -110,6 +114,14 @@ export const openChannel = (req, res, next) => {
   options.form = req.body;
   logger.log({ selectedNode: req.session.selectedNode, level: 'DEBUG', fileName: 'Channels', msg: 'Open Channel Params', data: options.form });
   request.post(options).then((body) => {
+    // Eclair answers /open with HTTP 200 whatever happened. Only 'created channel <id> ...' means a channel
+    // was opened; anything else is the reason it was not ('wallet error: Insufficient funds (code: -4)',
+    // 'peer aborted the channel funding flow: ...', 'disconnected', 'open channel cancelled, took too long').
+    if (typeof body !== 'string' || !body.startsWith('created channel')) {
+      const reason = typeof body === 'string' ? body : JSON.stringify(body);
+      const err = common.handleError({ statusCode: 500, message: reason, error: reason }, 'Channels', 'Open Channel Error', req.session.selectedNode);
+      return res.status(err.statusCode).json({ message: err.message, error: err.error });
+    }
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Channels', msg: 'Channel Opened', data: body });
     res.status(201).json(body);
   }).catch((errRes) => {

--- a/test/backend/eclair-open-channel.test.mjs
+++ b/test/backend/eclair-open-channel.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+
+import { getChannels, openChannel } from '../../backend/controllers/eclair/channels.js';
+
+// Eclair answers /open with HTTP 200 whether or not a channel was opened: the body is the string
+// 'created channel <id> ...' when it was, and the reason when it was not. It also lists a channel in
+// /channels from the moment the open starts, before the channel has any commitments. RTL used to
+// take every /open reply as a success and then crash on the commitment-less entry, so a failed open
+// reached the user as "Channel Added Successfully!" followed by "Unknown Error". These tests pin both.
+
+const PEER_ID = '03' + 'cd'.repeat(32);
+
+const normalChannel = {
+  nodeId: PEER_ID,
+  channelId: '11'.repeat(32),
+  state: 'NORMAL',
+  data: {
+    commitments: {
+      params: { channelFlags: { announceChannel: true }, localParams: { isInitiator: true } },
+      active: [{ localCommit: { spec: { toLocal: 24000000, toRemote: 1000000 } } }]
+    },
+    channelUpdate: { shortChannelId: '900000x1x0', feeBaseMsat: 1000, feeProportionalMillionths: 100 }
+  }
+};
+
+// The shape eclair returns for a channel whose funding transaction does not exist yet
+// (WAIT_FOR_FUNDING_INTERNAL, and CLOSED for a minute afterwards when the funding failed):
+// channel parameters, no commitments.
+const openingChannel = {
+  nodeId: PEER_ID,
+  channelId: '22'.repeat(32),
+  state: 'WAIT_FOR_FUNDING_INTERNAL',
+  data: {
+    channelParams: { localParams: { isChannelOpener: true } },
+    channelType: 'anchor_outputs_zero_fee_htlc_tx',
+    localCommitParams: { dustLimit: 546 },
+    remoteCommitParams: { dustLimit: 546 }
+  }
+};
+
+const startFakeEclair = async ({ openReply, channels }) => {
+  const seen = [];
+  const server = createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      seen.push({ path: req.url, form: Object.fromEntries(new URLSearchParams(raw)) });
+      res.setHeader('Content-Type', 'application/json');
+      if (req.url === '/open') {
+        res.end(JSON.stringify(openReply));
+      } else if (req.url === '/channels') {
+        res.end(JSON.stringify(channels));
+      } else if (req.url === '/nodes') {
+        res.end(JSON.stringify([{ nodeId: PEER_ID, alias: 'cln' }]));
+      } else {
+        res.statusCode = 404;
+        res.end('{}');
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  return { url: 'http://127.0.0.1:' + port, seen, close: () => new Promise((resolve) => server.close(resolve)) };
+};
+
+const buildRequest = (node, body) => ({
+  session: {
+    selectedNode: {
+      index: 1,
+      lnNode: 'eclair-node',
+      lnImplementation: 'ECL',
+      authentication: {
+        options: {
+          url: '',
+          rejectUnauthorized: false,
+          json: true,
+          headers: { authorization: 'Basic ' + Buffer.from(':pw').toString('base64') }
+        }
+      },
+      settings: { lnServerUrl: node.url, logLevel: 'ERROR' }
+    }
+  },
+  body,
+  query: {}
+});
+
+const invoke = (handler, node, body) => new Promise((resolve) => {
+  const out = { statusCode: null, body: null };
+  const res = {
+    status: (code) => { out.statusCode = code; return res; },
+    json: (payload) => { out.body = payload; resolve(out); return res; }
+  };
+  handler(buildRequest(node, body), res, () => { });
+});
+
+const openBody = { nodeId: PEER_ID, fundingSatoshis: 25000, announceChannel: true };
+
+test('openChannel reports a created channel as a success', async () => {
+  const reply = 'created channel ' + '11'.repeat(32) + ' with fundingTxId=' + '33'.repeat(32) + ' and fees=167 sat';
+  const node = await startFakeEclair({ openReply: reply, channels: [] });
+  try {
+    const res = await invoke(openChannel, node, openBody);
+    assert.equal(res.statusCode, 201, JSON.stringify(res.body));
+    assert.equal(res.body, reply);
+    const open = node.seen.find((call) => call.path === '/open');
+    assert.equal(open.form.nodeId, PEER_ID);
+    assert.equal(open.form.fundingSatoshis, '25000');
+  } finally {
+    await node.close();
+  }
+});
+
+test('openChannel reports a rejected open as an error carrying eclair\'s reason', async () => {
+  const reason = 'wallet error: Insufficient funds (code: -4)';
+  const node = await startFakeEclair({ openReply: reason, channels: [] });
+  try {
+    const res = await invoke(openChannel, node, openBody);
+    assert.equal(res.statusCode, 500, JSON.stringify(res.body));
+    assert.equal(res.body.error, reason);
+    assert.equal(res.body.message, reason);
+  } finally {
+    await node.close();
+  }
+});
+
+test('openChannel treats every reply other than "created channel" as a failure', async () => {
+  const replies = [
+    'wallet error: requirement failed: mining fee is higher than budget (167 sat > 25 sat)',
+    'peer aborted the channel funding flow: \'dustLimit=546 sat is above our channelReserve=250 sat\'',
+    'disconnected',
+    'open channel cancelled, took too long',
+    'channel creation cancelled'
+  ];
+  for (const reply of replies) {
+    const node = await startFakeEclair({ openReply: reply, channels: [] });
+    try {
+      const res = await invoke(openChannel, node, openBody);
+      assert.equal(res.statusCode, 500, reply + ' must not be reported as a success');
+      assert.equal(res.body.error, reply);
+    } finally {
+      await node.close();
+    }
+  }
+});
+
+test('getChannels lists a channel that has no commitments yet, with zero balances', async () => {
+  const node = await startFakeEclair({ openReply: '', channels: [normalChannel, openingChannel] });
+  try {
+    const res = await invoke(getChannels, node, {});
+    assert.equal(res.statusCode, 200, JSON.stringify(res.body));
+    assert.equal(res.body.length, 2);
+    const [normal, opening] = res.body;
+    assert.equal(normal.state, 'NORMAL');
+    assert.equal(normal.toLocal, 24000);
+    assert.equal(normal.toRemote, 1000);
+    assert.equal(normal.announceChannel, true);
+    assert.equal(normal.alias, 'cln');
+    assert.equal(opening.state, 'WAIT_FOR_FUNDING_INTERNAL');
+    assert.equal(opening.toLocal, 0);
+    assert.equal(opening.toRemote, 0);
+    assert.equal(opening.channelId, '22'.repeat(32));
+    assert.equal(opening.alias, 'cln');
+  } finally {
+    await node.close();
+  }
+});


### PR DESCRIPTION
Eclair answers /open with HTTP 200 whatever the outcome; only a body starting with 'created channel' means a channel was opened. Treat everything else as the error it is, carrying Eclair's reason. Guard the channel mapper against a channel that has no commitments yet, which Eclair lists while an open is in flight and for a minute after one fails, so the list no longer collapses into Unknown Error.