### PR TITLE
Stop the websocket ping timer from holding the process open

### DIFF
--- a/backend/utils/webSocketServer.js
+++ b/backend/utils/webSocketServer.js
@@ -174,6 +174,12 @@ export class RTLWebSocketServer {
         };
         this.generateAcceptValue = (acceptKey) => crypto.createHash('sha1').update(acceptKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', 'binary').digest('base64');
         this.getClients = () => this.webSocketServer.clients;
+        // The ping timer must not hold the event loop open on its own. Creating this singleton is
+        // a side effect of importing the module, so without this any process that merely pulls in
+        // a controller on the websocket path stays alive for the full hour -- which is what hung
+        // `node --test`. The running server is held up by its own HTTP listener, where the timer
+        // still fires normally.
+        this.pingInterval.unref();
     }
 }
 export const WSServer = new RTLWebSocketServer();

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -182,7 +182,7 @@ this release should add its entry under the appropriate section below.
   Angular frontend reads is unchanged.
 
 - **The websocket ping timer no longer holds the process open**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), fixes
+  ([#1699](https://github.com/Ride-The-Lightning/RTL/pull/1699), fixes
   [#1697](https://github.com/Ride-The-Lightning/RTL/issues/1697)).
   `RTLWebSocketServer.pingInterval` is created in a class-field initializer, so the hourly
   timer starts as a side effect of *importing* `server/utils/webSocketServer.ts` — and it was

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -181,6 +181,23 @@ this release should add its entry under the appropriate section below.
   RTL-Quickpay jQuery client, which has since been archived — is gone; the cookie the
   Angular frontend reads is unchanged.
 
+- **The websocket ping timer no longer holds the process open**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), fixes
+  [#1697](https://github.com/Ride-The-Lightning/RTL/issues/1697)).
+  `RTLWebSocketServer.pingInterval` is created in a class-field initializer, so the hourly
+  timer starts as a side effect of *importing* `server/utils/webSocketServer.ts` — and it was
+  never `unref()`'d. Any process that merely pulled the module in stayed alive for the full
+  hour. That is not a problem for the running server, which its own HTTP listener keeps up,
+  but it hung `npm run testbackend`: `test/backend/lnd-invoices.test.mjs` imports the LND
+  invoice controller, which reaches the module through `webSocketClient.ts`, so a suite whose
+  tests had all passed simply never exited, with no failing assertion to point at. The timer is
+  now `unref()`'d in the constructor, matching what `authenticate.ts` already does for the
+  login-lockout sweeper; it still fires normally in the running server. The 28 manual
+  `clearInterval(WSServer.pingInterval)` calls that had accumulated in
+  `route-guards.test.mjs`, `rtlconf.test.mjs` and `lnd-invoices.test.mjs` to work around it are
+  gone, and `test/backend/websocket-server.test.mjs` asserts the timer is unreferenced so the
+  trap cannot come back.
+
 ## Developer Tooling
 
 - **Declare a minimum Node.js version**

--- a/server/utils/webSocketServer.ts
+++ b/server/utils/webSocketServer.ts
@@ -31,6 +31,15 @@ export class RTLWebSocketServer {
     }
   }, 1000 * 60 * 60); // Terminate broken connections every hour
 
+  constructor() {
+    // The ping timer must not hold the event loop open on its own. Creating this singleton is
+    // a side effect of importing the module, so without this any process that merely pulls in
+    // a controller on the websocket path stays alive for the full hour -- which is what hung
+    // `node --test`. The running server is held up by its own HTTP listener, where the timer
+    // still fires normally.
+    this.pingInterval.unref();
+  }
+
   public mount = (httpServer) => {
     this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'WebSocketServer', msg: 'Connecting Websocket Server..' });
     this.webSocketServer = new WebSocketServer({ noServer: true, path: this.common.baseHref + '/api/ws', verifyClient: (process.env.NODE_ENV === 'development') ? null : verifyWSUser });

--- a/test/backend/lnd-invoices.test.mjs
+++ b/test/backend/lnd-invoices.test.mjs
@@ -1,13 +1,8 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
-import test, { after } from 'node:test';
+import test from 'node:test';
 
 import { listInvoices } from '../../backend/controllers/lnd/invoices.js';
-import { WSServer } from '../../backend/utils/webSocketServer.js';
-
-// The controller pulls in the LND websocket client, which instantiates the websocket
-// server singleton and its ping timer; without this the test process never exits.
-after(() => clearInterval(WSServer.pingInterval));
 
 const startFakeLnd = async (macaroon, invoices) => {
   const seen = [];

--- a/test/backend/route-guards.test.mjs
+++ b/test/backend/route-guards.test.mjs
@@ -10,7 +10,6 @@ import express from 'express';
 import eclChannelsRoutes from '../../backend/routes/eclair/channels.js';
 import rtlConfRoutes from '../../backend/routes/shared/RTLConf.js';
 import { Common } from '../../backend/utils/common.js';
-import { WSServer } from '../../backend/utils/webSocketServer.js';
 
 // The guard's error path logs against the selected node; before login the session has
 // none and handleError falls back to the process-wide one, which app startup normally sets.
@@ -32,7 +31,6 @@ const withRouter = async (mountPath, router, fn) => {
   } finally {
     server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));
-    clearInterval(WSServer.pingInterval);
   }
 };
 
@@ -107,7 +105,6 @@ test('every route outside the login page set carries isAuthenticated first', asy
       assert.ok(!layer.route && leafRouters.has(layer.handle), tree + '/index.js mounts something other than a walked leaf router');
     }
   }
-  clearInterval(WSServer.pingInterval);
   for (const tree of Object.keys(seen)) { assert.ok(seen[tree] > 0, 'walked no routes under ' + tree); }
   assert.deepEqual(unguarded, []);
 });

--- a/test/backend/rtlconf.test.mjs
+++ b/test/backend/rtlconf.test.mjs
@@ -7,7 +7,6 @@ import test from 'node:test';
 
 import { updateApplicationSettings, updateNodeSettings, getFile, getExplorerTransaction } from '../../backend/controllers/shared/RTLConf.js';
 import { Common } from '../../backend/utils/common.js';
-import { WSServer } from '../../backend/utils/webSocketServer.js';
 
 const clone = (value) => JSON.parse(JSON.stringify(value));
 
@@ -136,7 +135,6 @@ test('updateApplicationSettings preserves indexed node auth and sanitizes only p
     assert.equal(fileConfig.nodes[1].authentication.options, undefined);
     assert.equal(responseBody.nodes[1].authentication.runePath, undefined);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -207,7 +205,6 @@ test('updateApplicationSettings keeps the SSO cookie server-side without exposin
     assert.equal(fileConfig.SSO.cookieValue, undefined);
     assert.equal(responseBody.SSO.cookieValue, undefined);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -277,7 +274,6 @@ test('updateApplicationSettings restores omitted secret2FA and merges a trimmed 
     assert.equal(fileConfig.SSO.cookieValue, undefined);
     assert.equal(fileConfig.secret2FA, 'live-totp-seed');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -328,7 +324,6 @@ test('updateApplicationSettings tolerates a request body without an SSO object',
     assert.equal(responseStatus, 201);
     assert.equal(typeof Common.appConfig.SSO, 'object');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -396,7 +391,6 @@ test('updateApplicationSettings leaves the runtime config untouched when the fil
     const onDisk = JSON.parse(readFileSync(confPath, 'utf-8'));
     assert.equal(onDisk.nodes.length, 1);
   } finally {
-    clearInterval(WSServer.pingInterval);
     chmodSync(confPath, 0o644);
     chmodSync(tempDir, 0o755);
     rmSync(tempDir, { force: true, recursive: true });
@@ -449,7 +443,6 @@ test('updateApplicationSettings preserves the config file mode across the atomic
     assert.equal(responseStatus, 201);
     assert.equal(statSync(confPath).mode & 0o777, 0o600);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -503,7 +496,6 @@ test('updateApplicationSettings falls back to an in-place write when the rename 
     assert.equal(statSync(confPath).mode & 0o777, 0o600); // in-place write keeps the inode
     assert.deepEqual(JSON.parse(readFileSync(confPath, 'utf-8')).nodes.length, 1);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -637,7 +629,6 @@ test('updateApplicationSettings strips untrusted credential paths and un-allowli
     assert.equal(responseBody.nodes[0].macaroonPath, undefined);
     assert.equal(responseBody.nodes[0].settings.lnServerUrl, 'https://server:8080');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -721,7 +712,6 @@ test('updateApplicationSettings normalizes string node indexes when merging', ()
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
     assert.deepEqual(fileConfig.nodes.map((node) => node.index), [0, 2]);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -804,7 +794,6 @@ test('updateApplicationSettings drops unknown-index nodes instead of provisionin
     assert.equal(fileConfig.nodes.some((node) => JSON.stringify(node).includes('evil')), false);
     assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -855,7 +844,6 @@ test('updateNodeSettings pins channelBackupPath to the server-held value', () =>
     assert.equal(fileNode.settings.themeMode, 'NIGHT'); // other settings still merge
     assert.equal(Common.nodes[0].settings.channelBackupPath, '/server/backups');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -916,7 +904,6 @@ test('updateNodeSettings allowlists settings and pins every server URL and path 
     assert.equal(Common.nodes[0].settings.swapServerUrl, 'https://swap:8081');
     assert.equal(Common.nodes[0].settings.boltzServerUrl, 'https://boltz:9003');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1038,7 +1025,6 @@ test('updateApplicationSettings validates blockExplorerUrl format and rejects ma
     assert.equal(Common.appConfig.nodes[0].settings.boltzServerUrl, 'https://boltz:9003');
     assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1094,7 +1080,6 @@ test('updateApplicationSettings filters unknown top-level payload keys', () => {
     assert.equal(fileConfig.evilTopLevel, undefined);
     assert.equal(fileConfig.dbDirectoryPath, '/db');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1163,7 +1148,6 @@ test('updateApplicationSettings preserves runtime-only auth state when all paylo
     assert.deepEqual(Common.appConfig.nodes.map((n) => n.index), [0]);
     assert.deepEqual(Common.appConfig.nodes[0].authentication.options, { headers: { 'Grpc-Metadata-macaroon': 'runtime-lnd-macaroon' } });
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1221,7 +1205,6 @@ test('updateApplicationSettings drops a caller-supplied multiPass', () => {
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
     assert.equal(fileConfig.multiPass, undefined);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1292,7 +1275,6 @@ test('updateApplicationSettings rebuilds and filters against the runtime node li
     // The payload edit is applied.
     assert.equal(Common.appConfig.nodes[0].settings.themeMode, 'DAY');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1365,7 +1347,6 @@ test('updateApplicationSettings drops invalid defaultNodeIndex and selectedNodeI
     const normalized = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
     assert.strictEqual(normalized.defaultNodeIndex, 0);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1426,7 +1407,6 @@ test('updateApplicationSettings keeps the on-disk node list when the runtime nod
     const fileConfig = JSON.parse(readFileSync(join(tempDir, 'RTL-Config.json'), 'utf-8'));
     assert.deepEqual(fileConfig.nodes, staleFile.nodes);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1506,7 +1486,6 @@ test('updateApplicationSettings publishes allowlisted node edits to the live run
     assert.equal(persisted.nodes[0].settings.themeMode, 'NIGHT');
     assert.equal(persisted.nodes[0].settings.userPersona, 'MERCHANT');
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1576,7 +1555,6 @@ test('updateApplicationSettings treats empty, null, boolean and array indexes as
     assert.equal(Common.appConfig.nodes[0].lnNode, 'lnd-main');
     assert.deepEqual(Common.appConfig.nodes.map((n) => n.index), [0]);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1635,7 +1613,6 @@ test('updateNodeSettings never applies any authentication field from the request
       assert.deepEqual(Common.nodes[0].authentication, serverAuth);
     }
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1701,7 +1678,6 @@ test('getFile contains caller paths to the channel backup directory', async () =
     assert.equal(channelTraversal.statusCode, 500);
     assert.equal(JSON.stringify(channelTraversal.body).includes('top-secret'), false);
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1743,7 +1719,6 @@ test('getFile refuses an empty backup root and a non-string channel instead of w
       assert.equal(rejected.statusCode, 400);
     }
   } finally {
-    clearInterval(WSServer.pingInterval);
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
@@ -1767,7 +1742,6 @@ test('getExplorerTransaction URL-encodes the txid path segment', async () => {
     assert.deepEqual(body, { ok: true });
     assert.deepEqual(seen, ['/api/tx/' + encodeURIComponent('abc/../../api/v1/fees?x=1#f')]);
   } finally {
-    clearInterval(WSServer.pingInterval);
     await new Promise((resolve) => server.close(resolve));
   }
 });

--- a/test/backend/websocket-server.test.mjs
+++ b/test/backend/websocket-server.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { WSServer } from '../../backend/utils/webSocketServer.js';
+
+// Importing this module is enough to create the ping timer, and the LND invoice controller
+// pulls it in transitively (invoices -> webSocketClient -> webSocketServer). If the timer holds
+// a reference, every test file that touches that path keeps `node --test` alive for the full
+// hour rather than exiting when its tests finish.
+test('the ping timer does not hold the event loop open', () => {
+  assert.equal(WSServer.pingInterval.hasRef(), false);
+});


### PR DESCRIPTION
Fixes #1697.

### The problem

`RTLWebSocketServer.pingInterval` is created in a class-field initializer, so the hourly timer
starts as a side effect of *importing* `server/utils/webSocketServer.ts` — and it was never
`unref()`'d. Any process that merely pulled the module in stayed alive for the full hour.

That does not affect the running server, which its own HTTP listener keeps up. It does hang
`npm run testbackend`. The import path is not visible from the test that suffers it:

```
test/backend/lnd-invoices.test.mjs
  → server/controllers/lnd/invoices.ts
    → server/controllers/lnd/webSocketClient.ts   (LNDWSClient)
      → server/utils/webSocketServer.ts           (WSServer, pingInterval)
```

Nothing in that test mentions websockets, so the symptom is a suite whose tests all pass and
which then simply never exits — no failing assertion, no output to point at. It cost a full
review round on #1687 to trace, and every test that touched `WSServer` had accumulated a manual
`clearInterval` to work around it.

### The fix

`unref()` the timer in the constructor, so it can never be the sole reason a process stays up:

```ts
constructor() {
  this.pingInterval.unref();
}
```

This matches what `server/controllers/shared/authenticate.ts:35` already does for the
login-lockout sweeper (added in #1691). An `unref()`'d timer still fires normally in the running
server. It is done in the constructor rather than on the exported singleton so the class is safe
wherever it is instantiated — this adds the first constructor to a class that had none.

`test/backend/websocket-server.test.mjs` asserts `WSServer.pingInterval.hasRef() === false`, so
the trap cannot come back. Written first: before the fix it reported `hasRef() = true`, and the
test file itself hung — the bug demonstrating itself.

With that in place the 28 manual `clearInterval(WSServer.pingInterval)` calls are no longer
needed and are removed — 25 in `rtlconf.test.mjs`, 2 in `route-guards.test.mjs`, and the
`after()` hook in `lnd-invoices.test.mjs`. All were bare cleanup lines in `finally` blocks; no
assertion changed, and the now-unused `WSServer` imports went with them.

### Verification

- `npm run testbackend` — 133/133 pass, and the suite terminates on its own.
- `npm run lint` — clean.
- `npm run test` (Karma) — 230/230 pass. No `src/` change in this PR.
- `npm run buildbackend` — `backend/utils/webSocketServer.js` regenerated and committed.

Release note added under `## Code Health` with `#TBD`; will follow up with the PR number once
this is open.
