### PR TITLE
Key the login lockout on the socket peer unless a trusted proxy is configured

### DIFF
--- a/.github/docs/Application_configurations.md
+++ b/.github/docs/Application_configurations.md
@@ -9,6 +9,7 @@ parameters have `default` values for initial setup and can be updated after RTL 
   "disableAuth": "<The flag to disable application authentication, default 'false', Optional>",
   "port": "<port number for the rtl node server, default '3000', Required>",
   "host": "<host for the rtl node server, default 'all IPs', Optional>",
+  "trustedProxies": "<Comma-separated list of reverse-proxy addresses or CIDR ranges (or the named ranges loopback, linklocal, uniquelocal) whose X-Forwarded-For header names the client, so that the login lockout counts failed attempts per client rather than per proxy. List only your own proxies. Default none: the connecting address is the client, Optional>",
   "defaultNodeIndex": <Default index to load when rtl server starts, default 1, Optional>,
   "dbDirectoryPath": "<Complete path of the folder where rtl database file should be saved, defults to RTL root, Optional>",
   "SSO": {
@@ -55,6 +56,7 @@ If the environment variables are set, it will take precedence over the parameter
 <br />
 PORT (port number for the rtl node server, default 3000, Optional)<br />
 HOST (host for the rtl node server, default localhost, Optional)<br />
+TRUSTED_PROXIES (Comma-separated list of reverse-proxy addresses or CIDR ranges, or loopback/linklocal/uniquelocal, whose X-Forwarded-For header names the client for the login lockout. Default none, Optional)<br />
 DB_DIRECTORY_PATH (Path for the folder where rtl database file should be saved, default RTL root directory, Optional)
 APP_PASSWORD (Plaintext password to be provided by the parent container, NOT suggested for standalone RTL applications, only to be used by Vendors providing their own authentication service) (Optional)<br />
 DISABLE_AUTH (Flag to disable authentication, NOT recommended for standalone RTL applications, only to be used by Vendors providing their own authentication service) (Optional)<br /

--- a/.github/docs/Application_configurations.md
+++ b/.github/docs/Application_configurations.md
@@ -9,7 +9,7 @@ parameters have `default` values for initial setup and can be updated after RTL 
   "disableAuth": "<The flag to disable application authentication, default 'false', Optional>",
   "port": "<port number for the rtl node server, default '3000', Required>",
   "host": "<host for the rtl node server, default 'all IPs', Optional>",
-  "trustedProxies": "<Comma-separated list of reverse-proxy addresses or CIDR ranges (or the named ranges loopback, linklocal, uniquelocal) whose X-Forwarded-For header names the client, so that the login lockout counts failed attempts per client rather than per proxy. List only your own proxies. Default none: the connecting address is the client, Optional>",
+  "trustedProxies": "<Comma-separated addresses of the reverse proxies in front of RTL, whose X-Forwarded-For header then names the client so the login lockout counts failed attempts per client rather than per proxy, e.g. '127.0.0.1' for a proxy on the same host or '172.18.0.5' for a container. Use exact addresses: every hop whose address is inside this list is trusted, so a range that also contains clients (a LAN range, or the loopback/linklocal/uniquelocal names) lets those clients forge their address and defeat the lockout. Default none: the connecting address is the client, Optional>",
   "defaultNodeIndex": <Default index to load when rtl server starts, default 1, Optional>,
   "dbDirectoryPath": "<Complete path of the folder where rtl database file should be saved, defults to RTL root, Optional>",
   "SSO": {
@@ -56,7 +56,7 @@ If the environment variables are set, it will take precedence over the parameter
 <br />
 PORT (port number for the rtl node server, default 3000, Optional)<br />
 HOST (host for the rtl node server, default localhost, Optional)<br />
-TRUSTED_PROXIES (Comma-separated list of reverse-proxy addresses or CIDR ranges, or loopback/linklocal/uniquelocal, whose X-Forwarded-For header names the client for the login lockout. Default none, Optional)<br />
+TRUSTED_PROXIES (Comma-separated addresses of the reverse proxies in front of RTL, whose X-Forwarded-For header names the client for the login lockout; exact addresses, not ranges that also contain clients. Set empty to switch off a list from the config file. Default none, Optional)<br />
 DB_DIRECTORY_PATH (Path for the folder where rtl database file should be saved, default RTL root directory, Optional)
 APP_PASSWORD (Plaintext password to be provided by the parent container, NOT suggested for standalone RTL applications, only to be used by Vendors providing their own authentication service) (Optional)<br />
 DISABLE_AUTH (Flag to disable authentication, NOT recommended for standalone RTL applications, only to be used by Vendors providing their own authentication service) (Optional)<br /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ The fixture also carries a **BTCPay Server SSO harness** behind a compose profil
 standalone login never exercises: a rotating cookie file, an unregistered
 `/rtl/api/authenticate/cookie` URL that is not a route at all and falls through to the
 catch-all in `server/utils/app.ts`, and a reverse proxy serving it under `/rtl`. Run
-`docker/scripts/verify-sso.sh` (11 assertions, exits non-zero) after touching
+`docker/scripts/verify-sso.sh` (16 assertions, exits non-zero) after touching
 authentication, CSRF or static serving — none of that path is covered by logging into the
 fixture's own RTL. One trap it encodes: `GET /rtl/` is served by `express.static`, which
 sits above the catch-all and mints no `XSRF-TOKEN`, so a client entering there gets a 403

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -26,24 +26,34 @@ export const sweepExpiredAttempts = (currentTime) => {
 };
 export const clearFailedAttempts = () => failedLoginAttempts.clear();
 export const trackedAddresses = () => failedLoginAttempts.size;
-// One-shot: with no trustedProxies configured, req.ip is the socket peer, so every client
-// behind a reverse proxy shares the proxy's counter. The first login request that arrives
-// carrying X-Forwarded-For is the earliest evidence of that setup, and this is the log an
-// operator would read after an unexplained lockout. Logged at ERROR because that is the
-// only level the logger prints before a node's log file is selected.
-let forwardedHeaderWarned = false;
-export const resetForwardedHeaderWarning = () => { forwardedHeaderWarned = false; };
+// Diagnostic for the shared-counter setup: a login request carried X-Forwarded-For but the
+// lockout was keyed on the connecting address anyway, so every client behind that proxy
+// shares one counter. Detected at the call site (the key equals the socket peer) rather
+// than from the config, so a list that names the wrong proxy is caught too. Logged once
+// per keyed address, bounded, so a direct caller cannot spend the warning for everyone
+// else's proxy. ERROR level because that is the only level the logger prints before a
+// node's log file is selected.
+const MAX_WARNED_ADDRESSES = 100;
+const warnedAddresses = new Set();
+export const resetForwardedHeaderWarning = () => warnedAddresses.clear();
 const warnIfForwardedHeaderIgnored = (req, reqIP) => {
-    // A unix-socket listener (string port) has no peer address for any list to match, so the
-    // setting cannot apply there and the advice would be wrong.
-    if (forwardedHeaderWarned || common.trustedProxies || typeof common.port === 'string' || typeof req.headers['x-forwarded-for'] !== 'string') {
+    if (typeof req.headers['x-forwarded-for'] !== 'string') {
         return;
     }
-    forwardedHeaderWarned = true;
-    const msg = 'Configuration warning: a login request carried X-Forwarded-For but no trustedProxies is configured, so the header is ignored ' +
-        'and the login lockout keys on the connecting address ' + reqIP + ' for every client behind it. ' +
+    const keyedOnPeer = reqIP === 'unix-socket' || reqIP === req.socket?.remoteAddress;
+    if (!keyedOnPeer || warnedAddresses.has(reqIP) || warnedAddresses.size >= MAX_WARNED_ADDRESSES) {
+        return;
+    }
+    warnedAddresses.add(reqIP);
+    const reason = (reqIP === 'unix-socket') ?
+        'RTL is listening on a unix socket path, where no connection has a peer address for trustedProxies to match' :
+        (common.trustedProxies ? 'no entry in trustedProxies ("' + common.trustedProxies + '") matches the connecting address ' + reqIP : 'no trustedProxies is configured');
+    const remedy = (reqIP === 'unix-socket') ?
+        'Listen on a TCP loopback port and set trustedProxies to the proxy\'s address for per-client counters.' :
         'If RTL runs behind a reverse proxy, set trustedProxies (or TRUSTED_PROXIES) to that proxy\'s address.';
-    logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: msg, error: { error: 'X-Forwarded-For ignored: no trusted proxy configured.' } });
+    const msg = 'Configuration warning: a login request carried X-Forwarded-For but ' + reason + ', so the header is ignored ' +
+        'and the login lockout keys on ' + reqIP + ' for every client behind it. ' + remedy;
+    logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: msg, error: { error: 'X-Forwarded-For ignored: no trusted proxy matched.' } });
 };
 const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime()), LOCKING_PERIOD);
 // The sweeper must not hold the event loop open on its own (it would keep
@@ -150,7 +160,7 @@ export const authenticateUser = (req, res, next) => {
     }
     else if (+common.appConfig.SSO.rtlSSO) {
         if (authenticateWith === 'JWT' && isSessionToken(authenticationValue)) {
-            logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
+            logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'Password login refused with SSO enabled' });
             res.status(406).json({ message: 'SSO Authentication Error', error: 'Login with Password is not allowed with SSO.' });
         }
         else if (authenticateWith === 'PASSWORD' && matchesSSOCookie(authenticationValue)) {
@@ -178,9 +188,9 @@ export const authenticateUser = (req, res, next) => {
         const currentTime = new Date().getTime();
         const reqIP = common.getRequestIP(req);
         if (!reqIP) {
-            // No socket address (the connection is already gone). The lockout cannot be applied
-            // to an unknown client, so the login is refused rather than counted under a shared
-            // null key.
+            // Either no socket address (the connection is already gone) or a trusted proxy
+            // forwarded something that is not an address. The lockout cannot be applied to an
+            // unknown client, so the login is refused rather than counted under a shared key.
             logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Login refused: client address could not be determined', error: { error: 'No client address.' } });
             return res.status(401).json({ message: 'Authentication Failed!', error: 'Client address could not be determined.' });
         }

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -26,6 +26,23 @@ export const sweepExpiredAttempts = (currentTime) => {
 };
 export const clearFailedAttempts = () => failedLoginAttempts.clear();
 export const trackedAddresses = () => failedLoginAttempts.size;
+// One-shot: with no trustedProxies configured, req.ip is the socket peer, so every client
+// behind a reverse proxy shares the proxy's counter. The first login request that arrives
+// carrying X-Forwarded-For is the earliest evidence of that setup, and this is the log an
+// operator would read after an unexplained lockout. Logged at ERROR because that is the
+// only level the logger prints before a node's log file is selected.
+let forwardedHeaderWarned = false;
+export const resetForwardedHeaderWarning = () => { forwardedHeaderWarned = false; };
+const warnIfForwardedHeaderIgnored = (req, reqIP) => {
+    if (forwardedHeaderWarned || common.trustedProxies || typeof req.headers['x-forwarded-for'] !== 'string') {
+        return;
+    }
+    forwardedHeaderWarned = true;
+    const msg = 'Configuration warning: a login request carried X-Forwarded-For but no trustedProxies is configured, so the header is ignored ' +
+        'and the login lockout keys on the connecting address ' + reqIP + ' for every client behind it. ' +
+        'If RTL runs behind a reverse proxy, set trustedProxies (or TRUSTED_PROXIES) to that proxy\'s address.';
+    logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: msg, error: { error: 'X-Forwarded-For ignored: no trusted proxy configured.' } });
+};
 const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime()), LOCKING_PERIOD);
 // The sweeper must not hold the event loop open on its own (it would keep
 // `node --test` or a CLI invocation alive for the full 30-minute period).
@@ -146,15 +163,26 @@ export const authenticateUser = (req, res, next) => {
         else {
             // Also the reply for a JWT that does not verify and for an unrecognised
             // authenticateWith, which used to end in a 400 from the error handler and in no response
-            // at all, respectively.
+            // at all, respectively. The client gets one message for all three; the server log
+            // names the cause (without echoing the client-supplied mode value).
             const errMsg = 'SSO Authentication Failed! Access key too short or does not match.';
-            const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', errMsg, req.session.selectedNode);
+            const cause = (authenticateWith === 'PASSWORD') ? 'access key too short or does not match' :
+                (authenticateWith === 'JWT') ? 'session token did not verify' : 'authenticateWith is neither PASSWORD nor JWT';
+            const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', 'SSO Authentication Failed! ' + cause, req.session.selectedNode);
             return res.status(err.statusCode).json({ message: err.message, error: err.error });
         }
     }
     else {
         const currentTime = new Date().getTime();
         const reqIP = common.getRequestIP(req);
+        if (!reqIP) {
+            // No socket address (the connection is already gone). The lockout cannot be applied
+            // to an unknown client, so the login is refused rather than counted under a shared
+            // null key.
+            logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Login refused: client address could not be determined', error: { error: 'No client address.' } });
+            return res.status(401).json({ message: 'Authentication Failed!', error: 'Client address could not be determined.' });
+        }
+        warnIfForwardedHeaderIgnored(req, reqIP);
         const failed = getFailedInfo(reqIP, currentTime);
         const password = authenticationValue;
         // When a second factor is required, neither 401 may say which credential failed:

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -34,7 +34,9 @@ export const trackedAddresses = () => failedLoginAttempts.size;
 let forwardedHeaderWarned = false;
 export const resetForwardedHeaderWarning = () => { forwardedHeaderWarned = false; };
 const warnIfForwardedHeaderIgnored = (req, reqIP) => {
-    if (forwardedHeaderWarned || common.trustedProxies || typeof req.headers['x-forwarded-for'] !== 'string') {
+    // A unix-socket listener (string port) has no peer address for any list to match, so the
+    // setting cannot apply there and the advice would be wrong.
+    if (forwardedHeaderWarned || common.trustedProxies || typeof common.port === 'string' || typeof req.headers['x-forwarded-for'] !== 'string') {
         return;
     }
     forwardedHeaderWarned = true;

--- a/backend/controllers/shared/authenticate.js
+++ b/backend/controllers/shared/authenticate.js
@@ -85,20 +85,38 @@ const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
     }
 };
 export const verifyToken = (twoFAToken) => !!(common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && otplib.authenticator.check(twoFAToken, common.appConfig.secret2FA));
-// Mirrors isAuthenticated: a request carrying a valid session JWT has already
-// completed 2FA at login, since tokens are only minted after verification when
-// 2FA is enabled. Used to exempt in-app re-authorization (e.g. the password
-// prompt before on-chain sends) from the TOTP requirement without opening a
-// password-only path.
-const hasValidAuthToken = (req) => {
+// True only for a session JWT this process minted. jwt.verify throws on everything else
+// (missing, malformed, expired, wrong key); a throw from a controller reaches the catch-all
+// error handler, which answers 400 with the serialised error -- never the right reply to a
+// bad credential.
+const isSessionToken = (token) => {
     try {
-        const token = req.headers.authorization.split(' ')[1];
         jwt.verify(token, common.secret_key);
         return true;
     }
     catch (error) {
         return false;
     }
+};
+// Mirrors isAuthenticated: a request carrying a valid session JWT has already
+// completed 2FA at login, since tokens are only minted after verification when
+// 2FA is enabled. Used to exempt in-app re-authorization (e.g. the password
+// prompt before on-chain sends) from the TOTP requirement without opening a
+// password-only path.
+const hasValidAuthToken = (req) => isSessionToken(req.headers.authorization?.split(' ')[1]);
+// SSO access key check. The key is the hex SHA-256 digest of the cookie file, so a value
+// that is not a string of exactly that byte length can never match -- and must be refused
+// before the comparison: crypto.timingSafeEqual throws on unequal lengths and Buffer.from on
+// a non-string, which the catch-all error handler turned into a 400 carrying the error text
+// instead of the 406 an unauthenticated caller is meant to get (issue #1656).
+const matchesSSOCookie = (accessKey) => {
+    const cookieValue = common.appConfig.SSO.cookieValue;
+    if (typeof cookieValue !== 'string' || cookieValue.trim().length < 32 || typeof accessKey !== 'string') {
+        return false;
+    }
+    const expected = Buffer.from(crypto.createHash('sha256').update(cookieValue).digest('hex'), 'utf-8');
+    const offered = Buffer.from(accessKey, 'utf-8');
+    return offered.length === expected.length && crypto.timingSafeEqual(expected, offered);
 };
 export const authenticateUser = (req, res, next) => {
     const { authenticateWith, authenticationValue, twoFAToken } = req.body;
@@ -112,25 +130,26 @@ export const authenticateUser = (req, res, next) => {
         res.status(200).json({ token: token });
     }
     else if (+common.appConfig.SSO.rtlSSO) {
-        if (authenticateWith === 'JWT' && jwt.verify(authenticationValue, common.secret_key)) {
+        if (authenticateWith === 'JWT' && isSessionToken(authenticationValue)) {
             logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
             res.status(406).json({ message: 'SSO Authentication Error', error: 'Login with Password is not allowed with SSO.' });
         }
-        else if (authenticateWith === 'PASSWORD') {
-            if (common.appConfig.SSO.cookieValue.trim().length >= 32 && crypto.timingSafeEqual(Buffer.from(crypto.createHash('sha256').update(common.appConfig.SSO.cookieValue).digest('hex'), 'utf-8'), Buffer.from(authenticationValue, 'utf-8'))) {
-                common.refreshCookie();
-                if (!req.session.selectedNode) {
-                    req.session.selectedNode = common.selectedNode;
-                }
-                const token = jwt.sign({ user: 'SSO_USER' }, common.secret_key);
-                logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
-                res.status(200).json({ token: token });
+        else if (authenticateWith === 'PASSWORD' && matchesSSOCookie(authenticationValue)) {
+            common.refreshCookie();
+            if (!req.session.selectedNode) {
+                req.session.selectedNode = common.selectedNode;
             }
-            else {
-                const errMsg = 'SSO Authentication Failed! Access key too short or does not match.';
-                const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', errMsg, req.session.selectedNode);
-                return res.status(err.statusCode).json({ message: err.message, error: err.error });
-            }
+            const token = jwt.sign({ user: 'SSO_USER' }, common.secret_key);
+            logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
+            res.status(200).json({ token: token });
+        }
+        else {
+            // Also the reply for a JWT that does not verify and for an unrecognised
+            // authenticateWith, which used to end in a 400 from the error handler and in no response
+            // at all, respectively.
+            const errMsg = 'SSO Authentication Failed! Access key too short or does not match.';
+            const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', errMsg, req.session.selectedNode);
+            return res.status(err.statusCode).json({ message: err.message, error: err.error });
         }
     }
     else {

--- a/backend/models/config.model.js
+++ b/backend/models/config.model.js
@@ -40,12 +40,13 @@ export class Authentication {
     }
 }
 export class ApplicationConfig {
-    constructor(defaultNodeIndex, selectedNodeIndex, dbDirectoryPath, rtlConfFilePath, disableAuth, rtlPass, multiPass, multiPassHashed, allowPasswordUpdate, enable2FA, secret2FA, SSO, nodes) {
+    constructor(defaultNodeIndex, selectedNodeIndex, dbDirectoryPath, rtlConfFilePath, disableAuth, trustedProxies, rtlPass, multiPass, multiPassHashed, allowPasswordUpdate, enable2FA, secret2FA, SSO, nodes) {
         this.defaultNodeIndex = defaultNodeIndex;
         this.selectedNodeIndex = selectedNodeIndex;
         this.dbDirectoryPath = dbDirectoryPath;
         this.rtlConfFilePath = rtlConfFilePath;
         this.disableAuth = disableAuth;
+        this.trustedProxies = trustedProxies;
         this.rtlPass = rtlPass;
         this.multiPass = multiPass;
         this.multiPassHashed = multiPassHashed;

--- a/backend/utils/app.js
+++ b/backend/utils/app.js
@@ -97,6 +97,13 @@ export class ExpressApplication {
             this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'App', msg: 'Invalid trustedProxies value "' + this.common.trustedProxies + '": ' + err.message });
             throw err;
         }
+        const overBroad = this.common.overBroadTrustedProxies(this.common.trustedProxies);
+        if (overBroad.length > 0) {
+            // Logged at ERROR: the only level the logger prints before a node's log is selected.
+            const msg = 'Configuration warning: trustedProxies entries "' + overBroad.join('", "') + '" cover more than one host. ' +
+                'Every client whose address is inside a trusted entry can forge its own address and defeat the login lockout; list the proxy\'s exact address instead';
+            this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'App', msg: msg });
+        }
         this.app.use(sessions({ secret: this.common.secret_key, saveUninitialized: true, cookie: { secure: false, maxAge: ONE_DAY }, resave: false }));
         this.app.use(cookieParser(this.common.secret_key));
         this.app.use(bodyParser.json({ limit: '25mb' }));

--- a/backend/utils/app.js
+++ b/backend/utils/app.js
@@ -87,7 +87,9 @@ export class ExpressApplication {
         // Only the configured proxies may speak for the client: with none, req.ip is the socket
         // peer. Trusting every hop (the previous `true`) let any client rotate X-Forwarded-For
         // to dodge the login lockout (issue #1656). express compiles the list here, so a
-        // malformed entry fails at startup rather than on the first request.
+        // malformed entry fails at startup rather than on the first request. The setting also
+        // governs req.protocol/req.secure/req.hostname/req.ips, none of which server/ reads;
+        // both cookies (session, CSRF) are secure:false, so nothing else changes behind TLS.
         try {
             this.app.set('trust proxy', this.common.trustedProxies ? this.common.trustedProxies : false);
         }

--- a/backend/utils/app.js
+++ b/backend/utils/app.js
@@ -84,7 +84,17 @@ export class ExpressApplication {
             }
         };
         this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'App', msg: 'Starting Express Application..' });
-        this.app.set('trust proxy', true);
+        // Only the configured proxies may speak for the client: with none, req.ip is the socket
+        // peer. Trusting every hop (the previous `true`) let any client rotate X-Forwarded-For
+        // to dodge the login lockout (issue #1656). express compiles the list here, so a
+        // malformed entry fails at startup rather than on the first request.
+        try {
+            this.app.set('trust proxy', this.common.trustedProxies ? this.common.trustedProxies : false);
+        }
+        catch (err) {
+            this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'App', msg: 'Invalid trustedProxies value "' + this.common.trustedProxies + '": ' + err.message });
+            throw err;
+        }
         this.app.use(sessions({ secret: this.common.secret_key, saveUninitialized: true, cookie: { secure: false, maxAge: ONE_DAY }, resave: false }));
         this.app.use(cookieParser(this.common.secret_key));
         this.app.use(bodyParser.json({ limit: '25mb' }));

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -510,23 +510,40 @@ export class CommonService {
         // trustedProxies, the X-Forwarded-For chain -- so a client cannot pick its own key by
         // sending the header (issue #1656). Whatever comes back is still checked to be a
         // well-formed address before it is used: a misconfigured proxy that forwards the
-        // client's header verbatim would otherwise let arbitrary text reach the log, and the
-        // fallback for anything else is the socket peer. The length cap keeps an IPv6 zone id,
-        // which net.isIP does not bound, from carrying a header-sized string into the log. A
-        // server listening on a unix socket path (a non-numeric port) has no peer addresses at
-        // all, so every client there shares one fixed key, as before this check existed. Returns
-        // null only when a TCP connection has no address left (it is already gone); the caller
-        // refuses that login.
+        // client's header verbatim would otherwise let arbitrary text reach the log, so the
+        // result is null and the caller refuses the login: falling back to the socket peer would
+        // let a client behind such a proxy fill the proxy's shared counter with junk requests
+        // that cost it nothing. (With a proxy that appends its own entry the junk is never
+        // reached, and with no proxy trusted the header is never read.) The length cap keeps an
+        // IPv6 zone id, which net.isIP does not bound, from carrying a header-sized string into
+        // the log. A server listening on a unix socket path (a non-numeric port) has no peer
+        // address on any connection, so no list can match a hop there and every client shares
+        // one fixed key. Null also covers a TCP connection with no address left (already gone).
         this.getRequestIP = (req) => {
             const ip = req.ip;
-            if (typeof ip === 'string' && ip.length <= 64 && net.isIP(ip)) {
-                return ip;
+            if (typeof ip === 'string') {
+                return (ip.length <= 64 && net.isIP(ip)) ? ip : null;
             }
             if (req.socket?.remoteAddress) {
                 return req.socket.remoteAddress;
             }
             return (typeof this.port === 'string') ? 'unix-socket' : null;
         };
+        // Entries of a trustedProxies list that cover more than one host. express trusts every
+        // hop inside the list, so an entry that also contains clients lets them forge their
+        // address; the list is still accepted (it is express's own syntax), but app.ts flags it.
+        this.overBroadTrustedProxies = (list) => list.split(',').map((entry) => entry.trim()).filter((entry) => entry !== '').filter((entry) => {
+            if (entry === 'loopback' || entry === 'linklocal' || entry === 'uniquelocal') {
+                return true;
+            }
+            const slash = entry.indexOf('/');
+            if (slash < 0) {
+                return false;
+            }
+            const bits = parseInt(entry.slice(slash + 1), 10);
+            const family = net.isIP(entry.slice(0, slash));
+            return (family === 4 && bits < 32) || (family === 6 && bits < 128);
+        });
         this.getDummyData = (dataKey, lnImplementation) => {
             const dummyDataFile = this.appConfig.rtlConfFilePath + sep + 'ECLDummyData.log';
             return new Promise((resolve, reject) => {

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -104,6 +104,14 @@ export class CommonService {
             config.disableAuth = this.appConfig.disableAuth;
             config.allowPasswordUpdate = this.appConfig.allowPasswordUpdate;
             config.dbDirectoryPath = this.appConfig.dbDirectoryPath;
+            // trustedProxies decides whose X-Forwarded-For keys the login lockout: a deployment
+            // switch like the ones above, so a settings save can neither set nor drop it.
+            if (this.appConfig.trustedProxies !== undefined) {
+                config.trustedProxies = this.appConfig.trustedProxies;
+            }
+            else {
+                delete config.trustedProxies;
+            }
             config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
             if (this.appConfig.multiPass) {
                 config.multiPass = this.appConfig.multiPass;
@@ -503,7 +511,8 @@ export class CommonService {
         // sending the header (issue #1656). Whatever comes back is still checked to be a
         // well-formed address before it is used: a misconfigured proxy that forwards the
         // client's header verbatim would otherwise let arbitrary text reach the log, and the
-        // fallback for anything else is the socket peer, which always is one.
+        // fallback for anything else is the socket peer. Returns null only when there is no
+        // socket address at all (the connection is already gone); the caller refuses the login.
         this.getRequestIP = (req) => {
             const ip = req.ip;
             if (typeof ip === 'string' && net.isIP(ip)) {

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -511,14 +511,21 @@ export class CommonService {
         // sending the header (issue #1656). Whatever comes back is still checked to be a
         // well-formed address before it is used: a misconfigured proxy that forwards the
         // client's header verbatim would otherwise let arbitrary text reach the log, and the
-        // fallback for anything else is the socket peer. Returns null only when there is no
-        // socket address at all (the connection is already gone); the caller refuses the login.
+        // fallback for anything else is the socket peer. The length cap keeps an IPv6 zone id,
+        // which net.isIP does not bound, from carrying a header-sized string into the log. A
+        // server listening on a unix socket path (a non-numeric port) has no peer addresses at
+        // all, so every client there shares one fixed key, as before this check existed. Returns
+        // null only when a TCP connection has no address left (it is already gone); the caller
+        // refuses that login.
         this.getRequestIP = (req) => {
             const ip = req.ip;
-            if (typeof ip === 'string' && net.isIP(ip)) {
+            if (typeof ip === 'string' && ip.length <= 64 && net.isIP(ip)) {
                 return ip;
             }
-            return req.socket?.remoteAddress || req.connection?.remoteAddress || null;
+            if (req.socket?.remoteAddress) {
+                return req.socket.remoteAddress;
+            }
+            return (typeof this.port === 'string') ? 'unix-socket' : null;
         };
         this.getDummyData = (dataKey, lnImplementation) => {
             const dummyDataFile = this.appConfig.rtlConfFilePath + sep + 'ECLDummyData.log';

--- a/backend/utils/common.js
+++ b/backend/utils/common.js
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as net from 'net';
 import { join, dirname, isAbsolute, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 import * as crypto from 'crypto';
@@ -13,6 +14,9 @@ export class CommonService {
         this.appConfig = { defaultNodeIndex: 0, selectedNodeIndex: 0, rtlConfFilePath: '', dbDirectoryPath: join(dirname(fileURLToPath(import.meta.url)), '..', '..'), rtlPass: '', allowPasswordUpdate: true, enable2FA: false, secret2FA: '', SSO: this.ssoInit, nodes: [] };
         this.port = 3000;
         this.host = '';
+        // Proxies whose X-Forwarded-For header is trusted for the client address (issue #1656).
+        // Empty means none: the socket peer is the client.
+        this.trustedProxies = '';
         this.secret_key = crypto.randomBytes(64).toString('hex');
         this.read_dummy_data = false;
         this.baseHref = '/rtl';
@@ -493,11 +497,20 @@ export class CommonService {
             }
             return newErrorObj;
         };
-        this.getRequestIP = (req) => ((typeof req.headers['x-forwarded-for'] === 'string' && req.headers['x-forwarded-for'].split(',').shift()) ||
-            req.ip ||
-            req.connection.remoteAddress ||
-            req.socket.remoteAddress ||
-            (req.connection.socket ? req.connection.socket.remoteAddress : null));
+        // The client address for the login-lockout counter and its log line. req.ip is what
+        // express derives from the socket peer and, only for the proxies listed in
+        // trustedProxies, the X-Forwarded-For chain -- so a client cannot pick its own key by
+        // sending the header (issue #1656). Whatever comes back is still checked to be a
+        // well-formed address before it is used: a misconfigured proxy that forwards the
+        // client's header verbatim would otherwise let arbitrary text reach the log, and the
+        // fallback for anything else is the socket peer, which always is one.
+        this.getRequestIP = (req) => {
+            const ip = req.ip;
+            if (typeof ip === 'string' && net.isIP(ip)) {
+                return ip;
+            }
+            return req.socket?.remoteAddress || req.connection?.remoteAddress || null;
+        };
         this.getDummyData = (dataKey, lnImplementation) => {
             const dummyDataFile = this.appConfig.rtlConfFilePath + sep + 'ECLDummyData.log';
             return new Promise((resolve, reject) => {

--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -149,6 +149,15 @@ export class ConfigService {
             }
             this.common.port = (process?.env?.PORT) ? this.normalizePort(process?.env?.PORT) : (config.port) ? this.normalizePort(config.port) : 3000;
             this.common.host = (process?.env?.HOST) ? process?.env?.HOST : (config.host) ? config.host : null;
+            // Optional comma-separated list of proxy addresses/CIDRs (or the named ranges express
+            // accepts: loopback, linklocal, uniquelocal) whose X-Forwarded-For header identifies the
+            // client. Absent or empty means the socket peer is the client, the safe default for the
+            // login-lockout counter; anything that is not a string is a configuration error.
+            const trustedProxies = (process?.env?.TRUSTED_PROXIES) ? process?.env?.TRUSTED_PROXIES : config.trustedProxies;
+            if (trustedProxies !== undefined && trustedProxies !== null && typeof trustedProxies !== 'string') {
+                this.errMsg = this.errMsg + '\ntrustedProxies must be a comma-separated list of proxy addresses (e.g. "127.0.0.1" or "loopback, 10.0.0.0/8").';
+            }
+            this.common.trustedProxies = (typeof trustedProxies === 'string') ? trustedProxies.trim() : '';
             config.dbDirectoryPath = (process?.env?.DB_DIRECTORY_PATH) ? process?.env?.DB_DIRECTORY_PATH : (config.dbDirectoryPath) ? config.dbDirectoryPath : join(dirname(fileURLToPath(import.meta.url)), '..', '..');
             if (config.nodes && config.nodes.length > 0) {
                 config.nodes.forEach((node, idx) => {

--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -149,11 +149,13 @@ export class ConfigService {
             }
             this.common.port = (process?.env?.PORT) ? this.normalizePort(process?.env?.PORT) : (config.port) ? this.normalizePort(config.port) : 3000;
             this.common.host = (process?.env?.HOST) ? process?.env?.HOST : (config.host) ? config.host : null;
-            // Optional comma-separated list of proxy addresses/CIDRs (or the named ranges express
-            // accepts: loopback, linklocal, uniquelocal) whose X-Forwarded-For header identifies the
-            // client. Absent or empty means the socket peer is the client, the safe default for the
-            // login-lockout counter; anything that is not a string is a configuration error.
-            const trustedProxies = (process?.env?.TRUSTED_PROXIES) ? process?.env?.TRUSTED_PROXIES : config.trustedProxies;
+            // Optional comma-separated list of proxy addresses/CIDRs (express's trust-proxy list
+            // form, which also accepts the named ranges loopback, linklocal and uniquelocal) whose
+            // X-Forwarded-For header identifies the client. Absent or empty means the socket peer
+            // is the client, the safe default for the login-lockout counter; anything that is not a
+            // string is a configuration error. The environment variable wins whenever it is set,
+            // including set to empty: that is how a deployment switches the file's list off.
+            const trustedProxies = (process?.env?.TRUSTED_PROXIES !== undefined) ? process?.env?.TRUSTED_PROXIES : config.trustedProxies;
             if (trustedProxies !== undefined && trustedProxies !== null && typeof trustedProxies !== 'string') {
                 this.errMsg = this.errMsg + '\ntrustedProxies must be a comma-separated list of proxy addresses (e.g. "127.0.0.1" or "loopback, 10.0.0.0/8").';
             }

--- a/docker/scripts/verify-sso.sh
+++ b/docker/scripts/verify-sso.sh
@@ -101,7 +101,23 @@ code=$(curl -s -o /dev/null -w '%{http_code}' -b "$JAR2" -X POST "$BASE/rtl/api/
 [ "$code" = "406" ] && ok "wrong access-key -> 406" || bad "wrong access-key -> $code (want 406)"
 
 echo
-echo "7. the standalone fixture RTL is unaffected"
+echo "7. a malformed login body is refused the same way, not thrown"
+# A value that is not a 64-byte string used to throw inside the comparison (or inside
+# jwt.verify) and surface as a 400 from the catch-all error handler, and an unknown
+# authenticateWith got no reply at all (issue #1656).
+for body in \
+  '{"authenticateWith":"PASSWORD","authenticationValue":"short"}' \
+  '{"authenticateWith":"PASSWORD","authenticationValue":123}' \
+  '{"authenticateWith":"PASSWORD"}' \
+  '{"authenticateWith":"JWT","authenticationValue":"not-a-jwt"}' \
+  '{"authenticateWith":"NOAUTH","authenticationValue":"x"}'; do
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -b "$JAR2" -X POST "$BASE/rtl/api/authenticate" \
+    -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $x2" -d "$body")
+  [ "$code" = "406" ] && ok "$body -> 406" || bad "$body -> $code (want 406)"
+done
+
+echo
+echo "8. the standalone fixture RTL is unaffected"
 code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${RTL_PORT:-3000}/rtl/")
 [ "$code" = "200" ] && ok "standalone RTL still serving on ${RTL_PORT:-3000}" || bad "standalone RTL -> $code"
 

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -69,10 +69,12 @@ this release should add its entry under the appropriate section below.
   forwarded chain only past listed proxies. A malformed list fails at startup. Whatever the
   derivation returns is checked to be a well-formed address before it is used as the key
   or logged (an IPv6 zone id is capped at a sane length, since `net.isIP` does not bound
-  it); anything else falls back to the socket peer. A server listening on a unix socket
-  path, where no connection has a peer address, keeps one shared counter for all its
-  clients as before, and a TCP request whose connection is already gone is refused rather
-  than counted under a shared key. **Operators running RTL
+  it); a login whose forwarded value is not an address, or whose connection has no address
+  left, is refused rather than counted under the proxy's shared key, so a client behind a
+  pass-through proxy cannot fill that counter for free. A server listening on a unix socket
+  path has no peer address on any connection for a list to match, so every client there
+  shares one counter (previously the forgeable header keyed them apart); listening on a TCP
+  loopback port with `trustedProxies` set restores per-client counters. **Operators running RTL
   behind a reverse proxy with RTL's own login should set `trustedProxies` to the proxy's
   exact address** (`"127.0.0.1"` for a proxy on the same host, the container's address for
   one on a container network). Exact addresses matter: express trusts every hop whose
@@ -81,8 +83,11 @@ this release should add its entry under the appropriate section below.
   bypass back. Without the setting every client behind the proxy shares one counter, so
   five failed attempts by anyone lock the proxy's address out for 30 minutes; that is the
   same exposure the old code had to a client who simply named the operator's address, now
-  without the bypass, and the first login request that arrives carrying `X-Forwarded-For`
-  while no proxy is trusted logs a configuration warning saying so. SSO deployments
+  without the bypass, and a login request that arrives carrying `X-Forwarded-For` but is
+  keyed on the connecting address anyway (no list, a list that names the wrong proxy, or a
+  unix-socket listener) logs a configuration warning saying so, once per address. A list
+  entry that covers more than one host (a named range or a CIDR wider than a single
+  address) is flagged at startup for the same reason. SSO deployments
   (BTCPay) are unaffected, as the lockout does not apply to the cookie login. Nothing else
   read `trust proxy`: neither cookie is marked secure and no code consults `req.protocol`,
   `req.secure`, `req.hostname` or `req.ips`. The setting is a deployment switch, pinned to

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -56,7 +56,7 @@ this release should add its entry under the appropriate section below.
   next entry.
 
 - **Login lockout could be dodged with `X-Forwarded-For`; malformed SSO logins threw**
-  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), closes
+  ([#1700](https://github.com/Ride-The-Lightning/RTL/pull/1700), closes
   [#1656](https://github.com/Ride-The-Lightning/RTL/issues/1656)).
   The lockout counter was keyed on the first `X-Forwarded-For` address, and the app
   trusted that header from every hop (`trust proxy: true`), so any client could send a

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -68,8 +68,11 @@ this release should add its entry under the appropriate section below.
   counter on `req.ip`, which express derives from the socket peer and walks through the
   forwarded chain only past listed proxies. A malformed list fails at startup. Whatever the
   derivation returns is checked to be a well-formed address before it is used as the key
-  or logged; anything else falls back to the socket peer, and a request with no socket
-  address at all is refused rather than counted under a shared key. **Operators running RTL
+  or logged (an IPv6 zone id is capped at a sane length, since `net.isIP` does not bound
+  it); anything else falls back to the socket peer. A server listening on a unix socket
+  path, where no connection has a peer address, keeps one shared counter for all its
+  clients as before, and a TCP request whose connection is already gone is refused rather
+  than counted under a shared key. **Operators running RTL
   behind a reverse proxy with RTL's own login should set `trustedProxies` to the proxy's
   exact address** (`"127.0.0.1"` for a proxy on the same host, the container's address for
   one on a container network). Exact addresses matter: express trusts every hop whose

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -56,7 +56,7 @@ this release should add its entry under the appropriate section below.
   next entry.
 
 - **Login lockout could be dodged with `X-Forwarded-For`; malformed SSO logins threw**
-  ([#1700](https://github.com/Ride-The-Lightning/RTL/pull/1700), closes
+  ([#1701](https://github.com/Ride-The-Lightning/RTL/pull/1701), reviewed on [#1700](https://github.com/Ride-The-Lightning/RTL/pull/1700), closes
   [#1656](https://github.com/Ride-The-Lightning/RTL/issues/1656)).
   The lockout counter was keyed on the first `X-Forwarded-For` address, and the app
   trusted that header from every hop (`trust proxy: true`), so any client could send a

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -52,8 +52,42 @@ this release should add its entry under the appropriate section below.
   "Invalid Password or 2FA Token!" (the server log still records which); without 2FA the
   message is unchanged. Covered by backend tests in `test/backend/authenticate.test.mjs`,
   including the sweep pass, the eviction policy and the locked-state and 2FA responses. The third finding in #1656 — the counter keys on
-  `X-Forwarded-For`, which a client can rotate to dodge the limit — needs a decision on
-  trusted-proxy configuration and is left open.
+  `X-Forwarded-For`, which a client can rotate to dodge the limit — is addressed in the
+  next entry.
+
+- **Login lockout could be dodged with `X-Forwarded-For`; malformed SSO logins threw**
+  ([#TBD](https://github.com/Ride-The-Lightning/RTL/pull/TBD), closes
+  [#1656](https://github.com/Ride-The-Lightning/RTL/issues/1656)).
+  The lockout counter was keyed on the first `X-Forwarded-For` address, and the app
+  trusted that header from every hop (`trust proxy: true`), so any client could send a
+  different value on each request and get a fresh five-attempt budget every time — or name
+  another address and lock *it* out. The same header reached the failed-login log line
+  unsanitised. RTL now leaves express's `trust proxy` off unless the new
+  `trustedProxies` config key (or `TRUSTED_PROXIES` environment variable) lists the
+  reverse proxies allowed to speak for the client — addresses, CIDR ranges, or the named
+  ranges `loopback`, `linklocal` and `uniquelocal` — and keys the counter on `req.ip`,
+  which express derives from the socket peer and walks through the forwarded chain only
+  past listed proxies. A malformed list fails at startup. Whatever the derivation returns
+  is checked to be a well-formed address before it is used as the key or logged; anything
+  else falls back to the socket peer. **Operators running RTL behind a reverse proxy with
+  RTL's own login should set `trustedProxies`** (e.g. `"loopback"` for a proxy on the same
+  host, `"uniquelocal"` for one on a private/container network): without it every client
+  behind the proxy shares one counter, so five failed attempts by anyone lock the proxy's
+  address out for 30 minutes. That is the same exposure the old code had to a client who
+  simply named the operator's address, now without the bypass. SSO deployments (BTCPay) are
+  unaffected, as the lockout does not apply to the cookie login. Nothing else read `trust
+  proxy`: session cookies are not marked secure and no code consults `req.protocol` or
+  `req.hostname`. In the SSO branch, the access key from the request body was handed to
+  `crypto.timingSafeEqual` with no type or length check, and `timingSafeEqual` throws on
+  unequal lengths (as `Buffer.from` does on a non-string), so any value that was not
+  exactly 64 bytes got a 400 from the catch-all error handler, carrying the thrown error's
+  text, instead of the intended 406;
+  the JWT re-login path had the same shape (`jwt.verify` throws on a bad token), and an
+  `authenticateWith` the branch did not recognise got no reply at all. All three now answer
+  406. Covered by `test/backend/common.test.mjs` (the trust settings, over a real socket)
+  and `test/backend/authenticate.test.mjs` (header ignored for the counter, every malformed
+  SSO input, and cookie rotation on success); `docker/scripts/verify-sso.sh` gains the
+  malformed-body checks against the BTCPay harness.
 
 - **Hardening: application-settings save can no longer re-point credentials or server URLs**
   ([#1683](https://github.com/Ride-The-Lightning/RTL/pull/1683), fixes

--- a/release-notes/Release-notes-0.15.12.md
+++ b/release-notes/Release-notes-0.15.12.md
@@ -63,31 +63,41 @@ this release should add its entry under the appropriate section below.
   different value on each request and get a fresh five-attempt budget every time — or name
   another address and lock *it* out. The same header reached the failed-login log line
   unsanitised. RTL now leaves express's `trust proxy` off unless the new
-  `trustedProxies` config key (or `TRUSTED_PROXIES` environment variable) lists the
-  reverse proxies allowed to speak for the client — addresses, CIDR ranges, or the named
-  ranges `loopback`, `linklocal` and `uniquelocal` — and keys the counter on `req.ip`,
-  which express derives from the socket peer and walks through the forwarded chain only
-  past listed proxies. A malformed list fails at startup. Whatever the derivation returns
-  is checked to be a well-formed address before it is used as the key or logged; anything
-  else falls back to the socket peer. **Operators running RTL behind a reverse proxy with
-  RTL's own login should set `trustedProxies`** (e.g. `"loopback"` for a proxy on the same
-  host, `"uniquelocal"` for one on a private/container network): without it every client
-  behind the proxy shares one counter, so five failed attempts by anyone lock the proxy's
-  address out for 30 minutes. That is the same exposure the old code had to a client who
-  simply named the operator's address, now without the bypass. SSO deployments (BTCPay) are
-  unaffected, as the lockout does not apply to the cookie login. Nothing else read `trust
-  proxy`: session cookies are not marked secure and no code consults `req.protocol` or
-  `req.hostname`. In the SSO branch, the access key from the request body was handed to
+  `trustedProxies` config key (or `TRUSTED_PROXIES` environment variable, which wins even
+  when set empty) lists the reverse proxies allowed to speak for the client, and keys the
+  counter on `req.ip`, which express derives from the socket peer and walks through the
+  forwarded chain only past listed proxies. A malformed list fails at startup. Whatever the
+  derivation returns is checked to be a well-formed address before it is used as the key
+  or logged; anything else falls back to the socket peer, and a request with no socket
+  address at all is refused rather than counted under a shared key. **Operators running RTL
+  behind a reverse proxy with RTL's own login should set `trustedProxies` to the proxy's
+  exact address** (`"127.0.0.1"` for a proxy on the same host, the container's address for
+  one on a container network). Exact addresses matter: express trusts every hop whose
+  address is in the list, so a range that also contains clients (a LAN range, or the named
+  `uniquelocal`/`linklocal` ranges) lets those clients forge their address and brings the
+  bypass back. Without the setting every client behind the proxy shares one counter, so
+  five failed attempts by anyone lock the proxy's address out for 30 minutes; that is the
+  same exposure the old code had to a client who simply named the operator's address, now
+  without the bypass, and the first login request that arrives carrying `X-Forwarded-For`
+  while no proxy is trusted logs a configuration warning saying so. SSO deployments
+  (BTCPay) are unaffected, as the lockout does not apply to the cookie login. Nothing else
+  read `trust proxy`: neither cookie is marked secure and no code consults `req.protocol`,
+  `req.secure`, `req.hostname` or `req.ips`. The setting is a deployment switch, pinned to
+  the server-held value on an application-settings save like `disableAuth` and the SSO
+  block. In the SSO branch, the access key from the request body was handed to
   `crypto.timingSafeEqual` with no type or length check, and `timingSafeEqual` throws on
   unequal lengths (as `Buffer.from` does on a non-string), so any value that was not
   exactly 64 bytes got a 400 from the catch-all error handler, carrying the thrown error's
   text, instead of the intended 406;
   the JWT re-login path had the same shape (`jwt.verify` throws on a bad token), and an
   `authenticateWith` the branch did not recognise got no reply at all. All three now answer
-  406. Covered by `test/backend/common.test.mjs` (the trust settings, over a real socket)
-  and `test/backend/authenticate.test.mjs` (header ignored for the counter, every malformed
-  SSO input, and cookie rotation on success); `docker/scripts/verify-sso.sh` gains the
-  malformed-body checks against the BTCPay harness.
+  406 with one client message, while the server log names which of the three it was.
+  Covered by `test/backend/common.test.mjs` (the trust settings, over a real socket),
+  `test/backend/authenticate.test.mjs` (header ignored for the counter, the one-shot
+  warning, every malformed SSO input, and cookie rotation on success) and
+  `test/backend/boot-config.test.mjs`, which boots `rtl.js` in a child process to assert
+  that a non-string or malformed `trustedProxies` refuses to start;
+  `docker/scripts/verify-sso.sh` gains the malformed-body checks against the BTCPay harness.
 
 - **Hardening: application-settings save can no longer re-point credentials or server URLs**
   ([#1683](https://github.com/Ride-The-Lightning/RTL/pull/1683), fixes

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -37,7 +37,9 @@ export const trackedAddresses = () => failedLoginAttempts.size;
 let forwardedHeaderWarned = false;
 export const resetForwardedHeaderWarning = () => { forwardedHeaderWarned = false; };
 const warnIfForwardedHeaderIgnored = (req, reqIP) => {
-  if (forwardedHeaderWarned || common.trustedProxies || typeof req.headers['x-forwarded-for'] !== 'string') { return; }
+  // A unix-socket listener (string port) has no peer address for any list to match, so the
+  // setting cannot apply there and the advice would be wrong.
+  if (forwardedHeaderWarned || common.trustedProxies || typeof common.port === 'string' || typeof req.headers['x-forwarded-for'] !== 'string') { return; }
   forwardedHeaderWarned = true;
   const msg = 'Configuration warning: a login request carried X-Forwarded-For but no trustedProxies is configured, so the header is ignored ' +
     'and the login lockout keys on the connecting address ' + reqIP + ' for every client behind it. ' +

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -87,19 +87,37 @@ const handleMultipleFailedAttemptsError = (failed, currentTime, errMsg) => {
 
 export const verifyToken = (twoFAToken) => !!(common.appConfig.secret2FA && common.appConfig.secret2FA !== '' && (otplib as any).authenticator.check(twoFAToken, common.appConfig.secret2FA));
 
-// Mirrors isAuthenticated: a request carrying a valid session JWT has already
-// completed 2FA at login, since tokens are only minted after verification when
-// 2FA is enabled. Used to exempt in-app re-authorization (e.g. the password
-// prompt before on-chain sends) from the TOTP requirement without opening a
-// password-only path.
-const hasValidAuthToken = (req) => {
+// True only for a session JWT this process minted. jwt.verify throws on everything else
+// (missing, malformed, expired, wrong key); a throw from a controller reaches the catch-all
+// error handler, which answers 400 with the serialised error -- never the right reply to a
+// bad credential.
+const isSessionToken = (token) => {
   try {
-    const token = req.headers.authorization.split(' ')[1];
     jwt.verify(token, common.secret_key);
     return true;
   } catch (error) {
     return false;
   }
+};
+
+// Mirrors isAuthenticated: a request carrying a valid session JWT has already
+// completed 2FA at login, since tokens are only minted after verification when
+// 2FA is enabled. Used to exempt in-app re-authorization (e.g. the password
+// prompt before on-chain sends) from the TOTP requirement without opening a
+// password-only path.
+const hasValidAuthToken = (req) => isSessionToken(req.headers.authorization?.split(' ')[1]);
+
+// SSO access key check. The key is the hex SHA-256 digest of the cookie file, so a value
+// that is not a string of exactly that byte length can never match -- and must be refused
+// before the comparison: crypto.timingSafeEqual throws on unequal lengths and Buffer.from on
+// a non-string, which the catch-all error handler turned into a 400 carrying the error text
+// instead of the 406 an unauthenticated caller is meant to get (issue #1656).
+const matchesSSOCookie = (accessKey) => {
+  const cookieValue = common.appConfig.SSO.cookieValue;
+  if (typeof cookieValue !== 'string' || cookieValue.trim().length < 32 || typeof accessKey !== 'string') { return false; }
+  const expected = Buffer.from(crypto.createHash('sha256').update(cookieValue).digest('hex'), 'utf-8');
+  const offered = Buffer.from(accessKey, 'utf-8');
+  return offered.length === expected.length && crypto.timingSafeEqual(expected, offered);
 };
 
 export const authenticateUser = (req, res, next) => {
@@ -111,21 +129,22 @@ export const authenticateUser = (req, res, next) => {
     logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Disabled Authentication' });
     res.status(200).json({ token: token });
   } else if (+common.appConfig.SSO.rtlSSO) {
-    if (authenticateWith === 'JWT' && jwt.verify(authenticationValue, common.secret_key)) {
+    if (authenticateWith === 'JWT' && isSessionToken(authenticationValue)) {
       logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
       res.status(406).json({ message: 'SSO Authentication Error', error: 'Login with Password is not allowed with SSO.' });
-    } else if (authenticateWith === 'PASSWORD') {
-      if (common.appConfig.SSO.cookieValue.trim().length >= 32 && crypto.timingSafeEqual(Buffer.from(crypto.createHash('sha256').update(common.appConfig.SSO.cookieValue).digest('hex'), 'utf-8'), Buffer.from(authenticationValue, 'utf-8'))) {
-        common.refreshCookie();
-        if (!req.session.selectedNode) { req.session.selectedNode = common.selectedNode; }
-        const token = jwt.sign({ user: 'SSO_USER' }, common.secret_key);
-        logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
-        res.status(200).json({ token: token });
-      } else {
-        const errMsg = 'SSO Authentication Failed! Access key too short or does not match.';
-        const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', errMsg, req.session.selectedNode);
-        return res.status(err.statusCode).json({ message: err.message, error: err.error });
-      }
+    } else if (authenticateWith === 'PASSWORD' && matchesSSOCookie(authenticationValue)) {
+      common.refreshCookie();
+      if (!req.session.selectedNode) { req.session.selectedNode = common.selectedNode; }
+      const token = jwt.sign({ user: 'SSO_USER' }, common.secret_key);
+      logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
+      res.status(200).json({ token: token });
+    } else {
+      // Also the reply for a JWT that does not verify and for an unrecognised
+      // authenticateWith, which used to end in a 400 from the error handler and in no response
+      // at all, respectively.
+      const errMsg = 'SSO Authentication Failed! Access key too short or does not match.';
+      const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', errMsg, req.session.selectedNode);
+      return res.status(err.statusCode).json({ message: err.message, error: err.error });
     }
   } else {
     const currentTime = new Date().getTime();

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -29,22 +29,30 @@ export const sweepExpiredAttempts = (currentTime) => {
 export const clearFailedAttempts = () => failedLoginAttempts.clear();
 export const trackedAddresses = () => failedLoginAttempts.size;
 
-// One-shot: with no trustedProxies configured, req.ip is the socket peer, so every client
-// behind a reverse proxy shares the proxy's counter. The first login request that arrives
-// carrying X-Forwarded-For is the earliest evidence of that setup, and this is the log an
-// operator would read after an unexplained lockout. Logged at ERROR because that is the
-// only level the logger prints before a node's log file is selected.
-let forwardedHeaderWarned = false;
-export const resetForwardedHeaderWarning = () => { forwardedHeaderWarned = false; };
+// Diagnostic for the shared-counter setup: a login request carried X-Forwarded-For but the
+// lockout was keyed on the connecting address anyway, so every client behind that proxy
+// shares one counter. Detected at the call site (the key equals the socket peer) rather
+// than from the config, so a list that names the wrong proxy is caught too. Logged once
+// per keyed address, bounded, so a direct caller cannot spend the warning for everyone
+// else's proxy. ERROR level because that is the only level the logger prints before a
+// node's log file is selected.
+const MAX_WARNED_ADDRESSES = 100;
+const warnedAddresses = new Set<string>();
+export const resetForwardedHeaderWarning = () => warnedAddresses.clear();
 const warnIfForwardedHeaderIgnored = (req, reqIP) => {
-  // A unix-socket listener (string port) has no peer address for any list to match, so the
-  // setting cannot apply there and the advice would be wrong.
-  if (forwardedHeaderWarned || common.trustedProxies || typeof common.port === 'string' || typeof req.headers['x-forwarded-for'] !== 'string') { return; }
-  forwardedHeaderWarned = true;
-  const msg = 'Configuration warning: a login request carried X-Forwarded-For but no trustedProxies is configured, so the header is ignored ' +
-    'and the login lockout keys on the connecting address ' + reqIP + ' for every client behind it. ' +
+  if (typeof req.headers['x-forwarded-for'] !== 'string') { return; }
+  const keyedOnPeer = reqIP === 'unix-socket' || reqIP === req.socket?.remoteAddress;
+  if (!keyedOnPeer || warnedAddresses.has(reqIP) || warnedAddresses.size >= MAX_WARNED_ADDRESSES) { return; }
+  warnedAddresses.add(reqIP);
+  const reason = (reqIP === 'unix-socket') ?
+    'RTL is listening on a unix socket path, where no connection has a peer address for trustedProxies to match' :
+    (common.trustedProxies ? 'no entry in trustedProxies ("' + common.trustedProxies + '") matches the connecting address ' + reqIP : 'no trustedProxies is configured');
+  const remedy = (reqIP === 'unix-socket') ?
+    'Listen on a TCP loopback port and set trustedProxies to the proxy\'s address for per-client counters.' :
     'If RTL runs behind a reverse proxy, set trustedProxies (or TRUSTED_PROXIES) to that proxy\'s address.';
-  logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: msg, error: { error: 'X-Forwarded-For ignored: no trusted proxy configured.' } });
+  const msg = 'Configuration warning: a login request carried X-Forwarded-For but ' + reason + ', so the header is ignored ' +
+    'and the login lockout keys on ' + reqIP + ' for every client behind it. ' + remedy;
+  logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: msg, error: { error: 'X-Forwarded-For ignored: no trusted proxy matched.' } });
 };
 
 const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime()), LOCKING_PERIOD);
@@ -148,7 +156,7 @@ export const authenticateUser = (req, res, next) => {
     res.status(200).json({ token: token });
   } else if (+common.appConfig.SSO.rtlSSO) {
     if (authenticateWith === 'JWT' && isSessionToken(authenticationValue)) {
-      logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'User Authenticated' });
+      logger.log({ selectedNode: req.session.selectedNode, level: 'INFO', fileName: 'Authenticate', msg: 'Password login refused with SSO enabled' });
       res.status(406).json({ message: 'SSO Authentication Error', error: 'Login with Password is not allowed with SSO.' });
     } else if (authenticateWith === 'PASSWORD' && matchesSSOCookie(authenticationValue)) {
       common.refreshCookie();
@@ -171,9 +179,9 @@ export const authenticateUser = (req, res, next) => {
     const currentTime = new Date().getTime();
     const reqIP = common.getRequestIP(req);
     if (!reqIP) {
-      // No socket address (the connection is already gone). The lockout cannot be applied
-      // to an unknown client, so the login is refused rather than counted under a shared
-      // null key.
+      // Either no socket address (the connection is already gone) or a trusted proxy
+      // forwarded something that is not an address. The lockout cannot be applied to an
+      // unknown client, so the login is refused rather than counted under a shared key.
       logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Login refused: client address could not be determined', error: { error: 'No client address.' } });
       return res.status(401).json({ message: 'Authentication Failed!', error: 'Client address could not be determined.' });
     }

--- a/server/controllers/shared/authenticate.ts
+++ b/server/controllers/shared/authenticate.ts
@@ -29,6 +29,22 @@ export const sweepExpiredAttempts = (currentTime) => {
 export const clearFailedAttempts = () => failedLoginAttempts.clear();
 export const trackedAddresses = () => failedLoginAttempts.size;
 
+// One-shot: with no trustedProxies configured, req.ip is the socket peer, so every client
+// behind a reverse proxy shares the proxy's counter. The first login request that arrives
+// carrying X-Forwarded-For is the earliest evidence of that setup, and this is the log an
+// operator would read after an unexplained lockout. Logged at ERROR because that is the
+// only level the logger prints before a node's log file is selected.
+let forwardedHeaderWarned = false;
+export const resetForwardedHeaderWarning = () => { forwardedHeaderWarned = false; };
+const warnIfForwardedHeaderIgnored = (req, reqIP) => {
+  if (forwardedHeaderWarned || common.trustedProxies || typeof req.headers['x-forwarded-for'] !== 'string') { return; }
+  forwardedHeaderWarned = true;
+  const msg = 'Configuration warning: a login request carried X-Forwarded-For but no trustedProxies is configured, so the header is ignored ' +
+    'and the login lockout keys on the connecting address ' + reqIP + ' for every client behind it. ' +
+    'If RTL runs behind a reverse proxy, set trustedProxies (or TRUSTED_PROXIES) to that proxy\'s address.';
+  logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: msg, error: { error: 'X-Forwarded-For ignored: no trusted proxy configured.' } });
+};
+
 const loginInterval = setInterval(() => sweepExpiredAttempts(new Date().getTime()), LOCKING_PERIOD);
 // The sweeper must not hold the event loop open on its own (it would keep
 // `node --test` or a CLI invocation alive for the full 30-minute period).
@@ -141,14 +157,25 @@ export const authenticateUser = (req, res, next) => {
     } else {
       // Also the reply for a JWT that does not verify and for an unrecognised
       // authenticateWith, which used to end in a 400 from the error handler and in no response
-      // at all, respectively.
+      // at all, respectively. The client gets one message for all three; the server log
+      // names the cause (without echoing the client-supplied mode value).
       const errMsg = 'SSO Authentication Failed! Access key too short or does not match.';
-      const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', errMsg, req.session.selectedNode);
+      const cause = (authenticateWith === 'PASSWORD') ? 'access key too short or does not match' :
+        (authenticateWith === 'JWT') ? 'session token did not verify' : 'authenticateWith is neither PASSWORD nor JWT';
+      const err = common.handleError({ statusCode: 406, message: 'SSO Authentication Error', error: errMsg }, 'Authenticate', 'SSO Authentication Failed! ' + cause, req.session.selectedNode);
       return res.status(err.statusCode).json({ message: err.message, error: err.error });
     }
   } else {
     const currentTime = new Date().getTime();
     const reqIP = common.getRequestIP(req);
+    if (!reqIP) {
+      // No socket address (the connection is already gone). The lockout cannot be applied
+      // to an unknown client, so the login is refused rather than counted under a shared
+      // null key.
+      logger.log({ selectedNode: req.session.selectedNode, level: 'ERROR', fileName: 'Authenticate', msg: 'Login refused: client address could not be determined', error: { error: 'No client address.' } });
+      return res.status(401).json({ message: 'Authentication Failed!', error: 'Client address could not be determined.' });
+    }
+    warnIfForwardedHeaderIgnored(req, reqIP);
     const failed = getFailedInfo(reqIP, currentTime);
     const password = authenticationValue;
     // When a second factor is required, neither 401 may say which credential failed:

--- a/server/models/config.model.ts
+++ b/server/models/config.model.ts
@@ -56,6 +56,7 @@ export class ApplicationConfig {
     public dbDirectoryPath?: string,
     public rtlConfFilePath?: string,
     public disableAuth?: boolean,
+    public trustedProxies?: string,
     public rtlPass?: string,
     public multiPass?: string,
     public multiPassHashed?: string,

--- a/server/utils/app.ts
+++ b/server/utils/app.ts
@@ -36,7 +36,9 @@ export class ExpressApplication {
     // Only the configured proxies may speak for the client: with none, req.ip is the socket
     // peer. Trusting every hop (the previous `true`) let any client rotate X-Forwarded-For
     // to dodge the login lockout (issue #1656). express compiles the list here, so a
-    // malformed entry fails at startup rather than on the first request.
+    // malformed entry fails at startup rather than on the first request. The setting also
+    // governs req.protocol/req.secure/req.hostname/req.ips, none of which server/ reads;
+    // both cookies (session, CSRF) are secure:false, so nothing else changes behind TLS.
     try {
       this.app.set('trust proxy', this.common.trustedProxies ? this.common.trustedProxies : false);
     } catch (err) {

--- a/server/utils/app.ts
+++ b/server/utils/app.ts
@@ -45,6 +45,13 @@ export class ExpressApplication {
       this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'App', msg: 'Invalid trustedProxies value "' + this.common.trustedProxies + '": ' + err.message });
       throw err;
     }
+    const overBroad = this.common.overBroadTrustedProxies(this.common.trustedProxies);
+    if (overBroad.length > 0) {
+      // Logged at ERROR: the only level the logger prints before a node's log is selected.
+      const msg = 'Configuration warning: trustedProxies entries "' + overBroad.join('", "') + '" cover more than one host. ' +
+        'Every client whose address is inside a trusted entry can forge its own address and defeat the login lockout; list the proxy\'s exact address instead';
+      this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'App', msg: msg });
+    }
     this.app.use(sessions({ secret: this.common.secret_key, saveUninitialized: true, cookie: { secure: false, maxAge: ONE_DAY }, resave: false }));
     this.app.use(cookieParser(this.common.secret_key));
     this.app.use(bodyParser.json({ limit: '25mb' }));

--- a/server/utils/app.ts
+++ b/server/utils/app.ts
@@ -33,7 +33,16 @@ export class ExpressApplication {
 
   constructor() {
     this.logger.log({ selectedNode: this.common.selectedNode, level: 'INFO', fileName: 'App', msg: 'Starting Express Application..' });
-    this.app.set('trust proxy', true);
+    // Only the configured proxies may speak for the client: with none, req.ip is the socket
+    // peer. Trusting every hop (the previous `true`) let any client rotate X-Forwarded-For
+    // to dodge the login lockout (issue #1656). express compiles the list here, so a
+    // malformed entry fails at startup rather than on the first request.
+    try {
+      this.app.set('trust proxy', this.common.trustedProxies ? this.common.trustedProxies : false);
+    } catch (err) {
+      this.logger.log({ selectedNode: this.common.selectedNode, level: 'ERROR', fileName: 'App', msg: 'Invalid trustedProxies value "' + this.common.trustedProxies + '": ' + err.message });
+      throw err;
+    }
     this.app.use(sessions({ secret: this.common.secret_key, saveUninitialized: true, cookie: { secure: false, maxAge: ONE_DAY }, resave: false }));
     this.app.use(cookieParser(this.common.secret_key));
     this.app.use(bodyParser.json({ limit: '25mb' }));

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -517,12 +517,17 @@ export class CommonService {
   // sending the header (issue #1656). Whatever comes back is still checked to be a
   // well-formed address before it is used: a misconfigured proxy that forwards the
   // client's header verbatim would otherwise let arbitrary text reach the log, and the
-  // fallback for anything else is the socket peer. Returns null only when there is no
-  // socket address at all (the connection is already gone); the caller refuses the login.
+  // fallback for anything else is the socket peer. The length cap keeps an IPv6 zone id,
+  // which net.isIP does not bound, from carrying a header-sized string into the log. A
+  // server listening on a unix socket path (a non-numeric port) has no peer addresses at
+  // all, so every client there shares one fixed key, as before this check existed. Returns
+  // null only when a TCP connection has no address left (it is already gone); the caller
+  // refuses that login.
   public getRequestIP = (req) => {
     const ip = req.ip;
-    if (typeof ip === 'string' && net.isIP(ip)) { return ip; }
-    return req.socket?.remoteAddress || req.connection?.remoteAddress || null;
+    if (typeof ip === 'string' && ip.length <= 64 && net.isIP(ip)) { return ip; }
+    if (req.socket?.remoteAddress) { return req.socket.remoteAddress; }
+    return (typeof this.port === 'string') ? 'unix-socket' : null;
   };
 
   public getDummyData = (dataKey, lnImplementation) => {

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -516,19 +516,33 @@ export class CommonService {
   // trustedProxies, the X-Forwarded-For chain -- so a client cannot pick its own key by
   // sending the header (issue #1656). Whatever comes back is still checked to be a
   // well-formed address before it is used: a misconfigured proxy that forwards the
-  // client's header verbatim would otherwise let arbitrary text reach the log, and the
-  // fallback for anything else is the socket peer. The length cap keeps an IPv6 zone id,
-  // which net.isIP does not bound, from carrying a header-sized string into the log. A
-  // server listening on a unix socket path (a non-numeric port) has no peer addresses at
-  // all, so every client there shares one fixed key, as before this check existed. Returns
-  // null only when a TCP connection has no address left (it is already gone); the caller
-  // refuses that login.
+  // client's header verbatim would otherwise let arbitrary text reach the log, so the
+  // result is null and the caller refuses the login: falling back to the socket peer would
+  // let a client behind such a proxy fill the proxy's shared counter with junk requests
+  // that cost it nothing. (With a proxy that appends its own entry the junk is never
+  // reached, and with no proxy trusted the header is never read.) The length cap keeps an
+  // IPv6 zone id, which net.isIP does not bound, from carrying a header-sized string into
+  // the log. A server listening on a unix socket path (a non-numeric port) has no peer
+  // address on any connection, so no list can match a hop there and every client shares
+  // one fixed key. Null also covers a TCP connection with no address left (already gone).
   public getRequestIP = (req) => {
     const ip = req.ip;
-    if (typeof ip === 'string' && ip.length <= 64 && net.isIP(ip)) { return ip; }
+    if (typeof ip === 'string') { return (ip.length <= 64 && net.isIP(ip)) ? ip : null; }
     if (req.socket?.remoteAddress) { return req.socket.remoteAddress; }
     return (typeof this.port === 'string') ? 'unix-socket' : null;
   };
+
+  // Entries of a trustedProxies list that cover more than one host. express trusts every
+  // hop inside the list, so an entry that also contains clients lets them forge their
+  // address; the list is still accepted (it is express's own syntax), but app.ts flags it.
+  public overBroadTrustedProxies = (list: string) => list.split(',').map((entry) => entry.trim()).filter((entry) => entry !== '').filter((entry) => {
+    if (entry === 'loopback' || entry === 'linklocal' || entry === 'uniquelocal') { return true; }
+    const slash = entry.indexOf('/');
+    if (slash < 0) { return false; }
+    const bits = parseInt(entry.slice(slash + 1), 10);
+    const family = net.isIP(entry.slice(0, slash));
+    return (family === 4 && bits < 32) || (family === 6 && bits < 128);
+  });
 
   public getDummyData = (dataKey, lnImplementation) => {
     const dummyDataFile = this.appConfig.rtlConfFilePath + sep + 'ECLDummyData.log';

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -109,6 +109,13 @@ export class CommonService {
     config.disableAuth = this.appConfig.disableAuth;
     config.allowPasswordUpdate = this.appConfig.allowPasswordUpdate;
     config.dbDirectoryPath = this.appConfig.dbDirectoryPath;
+    // trustedProxies decides whose X-Forwarded-For keys the login lockout: a deployment
+    // switch like the ones above, so a settings save can neither set nor drop it.
+    if (this.appConfig.trustedProxies !== undefined) {
+      config.trustedProxies = this.appConfig.trustedProxies;
+    } else {
+      delete config.trustedProxies;
+    }
     config.SSO = JSON.parse(JSON.stringify(this.appConfig.SSO || {}));
     if (this.appConfig.multiPass) {
       config.multiPass = this.appConfig.multiPass;
@@ -510,7 +517,8 @@ export class CommonService {
   // sending the header (issue #1656). Whatever comes back is still checked to be a
   // well-formed address before it is used: a misconfigured proxy that forwards the
   // client's header verbatim would otherwise let arbitrary text reach the log, and the
-  // fallback for anything else is the socket peer, which always is one.
+  // fallback for anything else is the socket peer. Returns null only when there is no
+  // socket address at all (the connection is already gone); the caller refuses the login.
   public getRequestIP = (req) => {
     const ip = req.ip;
     if (typeof ip === 'string' && net.isIP(ip)) { return ip; }

--- a/server/utils/common.ts
+++ b/server/utils/common.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as net from 'net';
 import { join, dirname, isAbsolute, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 import * as crypto from 'crypto';
@@ -15,6 +16,9 @@ export class CommonService {
   public appConfig: ApplicationConfig = { defaultNodeIndex: 0, selectedNodeIndex: 0, rtlConfFilePath: '', dbDirectoryPath: join(dirname(fileURLToPath(import.meta.url)), '..', '..'), rtlPass: '', allowPasswordUpdate: true, enable2FA: false, secret2FA: '', SSO: this.ssoInit, nodes: [] };
   public port = 3000;
   public host = '';
+  // Proxies whose X-Forwarded-For header is trusted for the client address (issue #1656).
+  // Empty means none: the socket peer is the client.
+  public trustedProxies = '';
   public secret_key = crypto.randomBytes(64).toString('hex');
   public read_dummy_data = false;
   public baseHref = '/rtl';
@@ -500,11 +504,18 @@ export class CommonService {
     return newErrorObj;
   };
 
-  public getRequestIP = (req) => ((typeof req.headers['x-forwarded-for'] === 'string' && req.headers['x-forwarded-for'].split(',').shift()) ||
-    req.ip ||
-    req.connection.remoteAddress ||
-    req.socket.remoteAddress ||
-    (req.connection.socket ? req.connection.socket.remoteAddress : null));
+  // The client address for the login-lockout counter and its log line. req.ip is what
+  // express derives from the socket peer and, only for the proxies listed in
+  // trustedProxies, the X-Forwarded-For chain -- so a client cannot pick its own key by
+  // sending the header (issue #1656). Whatever comes back is still checked to be a
+  // well-formed address before it is used: a misconfigured proxy that forwards the
+  // client's header verbatim would otherwise let arbitrary text reach the log, and the
+  // fallback for anything else is the socket peer, which always is one.
+  public getRequestIP = (req) => {
+    const ip = req.ip;
+    if (typeof ip === 'string' && net.isIP(ip)) { return ip; }
+    return req.socket?.remoteAddress || req.connection?.remoteAddress || null;
+  };
 
   public getDummyData = (dataKey, lnImplementation) => {
     const dummyDataFile = this.appConfig.rtlConfFilePath + sep + 'ECLDummyData.log';

--- a/server/utils/config.ts
+++ b/server/utils/config.ts
@@ -152,11 +152,13 @@ export class ConfigService {
     }
     this.common.port = (process?.env?.PORT) ? this.normalizePort(process?.env?.PORT) : (config.port) ? this.normalizePort(config.port) : 3000;
     this.common.host = (process?.env?.HOST) ? process?.env?.HOST : (config.host) ? config.host : null;
-    // Optional comma-separated list of proxy addresses/CIDRs (or the named ranges express
-    // accepts: loopback, linklocal, uniquelocal) whose X-Forwarded-For header identifies the
-    // client. Absent or empty means the socket peer is the client, the safe default for the
-    // login-lockout counter; anything that is not a string is a configuration error.
-    const trustedProxies = (process?.env?.TRUSTED_PROXIES) ? process?.env?.TRUSTED_PROXIES : config.trustedProxies;
+    // Optional comma-separated list of proxy addresses/CIDRs (express's trust-proxy list
+    // form, which also accepts the named ranges loopback, linklocal and uniquelocal) whose
+    // X-Forwarded-For header identifies the client. Absent or empty means the socket peer
+    // is the client, the safe default for the login-lockout counter; anything that is not a
+    // string is a configuration error. The environment variable wins whenever it is set,
+    // including set to empty: that is how a deployment switches the file's list off.
+    const trustedProxies = (process?.env?.TRUSTED_PROXIES !== undefined) ? process?.env?.TRUSTED_PROXIES : config.trustedProxies;
     if (trustedProxies !== undefined && trustedProxies !== null && typeof trustedProxies !== 'string') {
       this.errMsg = this.errMsg + '\ntrustedProxies must be a comma-separated list of proxy addresses (e.g. "127.0.0.1" or "loopback, 10.0.0.0/8").';
     }

--- a/server/utils/config.ts
+++ b/server/utils/config.ts
@@ -152,6 +152,15 @@ export class ConfigService {
     }
     this.common.port = (process?.env?.PORT) ? this.normalizePort(process?.env?.PORT) : (config.port) ? this.normalizePort(config.port) : 3000;
     this.common.host = (process?.env?.HOST) ? process?.env?.HOST : (config.host) ? config.host : null;
+    // Optional comma-separated list of proxy addresses/CIDRs (or the named ranges express
+    // accepts: loopback, linklocal, uniquelocal) whose X-Forwarded-For header identifies the
+    // client. Absent or empty means the socket peer is the client, the safe default for the
+    // login-lockout counter; anything that is not a string is a configuration error.
+    const trustedProxies = (process?.env?.TRUSTED_PROXIES) ? process?.env?.TRUSTED_PROXIES : config.trustedProxies;
+    if (trustedProxies !== undefined && trustedProxies !== null && typeof trustedProxies !== 'string') {
+      this.errMsg = this.errMsg + '\ntrustedProxies must be a comma-separated list of proxy addresses (e.g. "127.0.0.1" or "loopback, 10.0.0.0/8").';
+    }
+    this.common.trustedProxies = (typeof trustedProxies === 'string') ? trustedProxies.trim() : '';
     config.dbDirectoryPath = (process?.env?.DB_DIRECTORY_PATH) ? process?.env?.DB_DIRECTORY_PATH : (config.dbDirectoryPath) ? config.dbDirectoryPath : join(dirname(fileURLToPath(import.meta.url)), '..', '..');
     if (config.nodes && config.nodes.length > 0) {
       config.nodes.forEach((node, idx) => {

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -521,6 +521,11 @@ test('on a unix-socket listener every client shares one fixed key instead of bei
     authenticateUser(mockRequest({ noAddress: true }), locked, null);
     assert.equal(locked.statusCode, 401);
     assert.match(locked.body.error, /locked/);
+    // trustedProxies cannot apply here (no peer address to match), so the one-shot advice
+    // to set it stays silent.
+    resetForwardedHeaderWarning();
+    const lines = captureLog(() => authenticateUser(mockRequest({ noAddress: true, forwardedFor: '203.0.113.7' }), mockResponse(), null));
+    assert.equal(lines.filter((e) => /trustedProxies/.test(e.msg)).length, 0);
   } finally {
     Common.port = savedPort;
     clearFailedAttempts();

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -502,9 +502,35 @@ test('a login with no determinable client address is refused, not counted under 
   assert.equal(right.statusCode, 401, 'the right password is refused too: the lockout cannot be applied');
 });
 
+test('on a unix-socket listener every client shares one fixed key instead of being refused', () => {
+  // A path-based listener (non-numeric port) has no peer address on any connection; the
+  // lockout still has to work there, so the key is a constant rather than a refusal.
+  clearFailedAttempts();
+  setupAppConfig(false, '');
+  const savedPort = Common.port;
+  Common.port = '/tmp/rtl.sock';
+  try {
+    const res = mockResponse();
+    authenticateUser(mockRequest({ noAddress: true }), res, null);
+    assert.equal(res.statusCode, 200);
+    for (let i = 0; i < ALLOWED_LOGIN_ATTEMPTS; i++) {
+      authenticateUser(mockRequest({ noAddress: true, password: 'wrong' }), mockResponse(), null);
+    }
+    assert.equal(trackedAddresses(), 1, 'one shared counter');
+    const locked = mockResponse();
+    authenticateUser(mockRequest({ noAddress: true }), locked, null);
+    assert.equal(locked.statusCode, 401);
+    assert.match(locked.body.error, /locked/);
+  } finally {
+    Common.port = savedPort;
+    clearFailedAttempts();
+  }
+});
+
 test('SSO: the server log names which of the three refusal causes applied', () => {
   setupSSOConfig();
-  const logged = (opts) => captureLog(() => authenticateUser(mockRequest(opts), mockResponse(), null)).map((e) => e.msg).join('\n');
+  // Every field of every log entry, so a mode value smuggled into the error payload shows too.
+  const logged = (opts) => captureLog(() => authenticateUser(mockRequest(opts), mockResponse(), null)).map((e) => JSON.stringify(e)).join('\n');
   assert.match(logged({ authenticationValue: 'short' }), /access key too short or does not match/);
   assert.match(logged({ authenticateWith: 'JWT', authenticationValue: 'not-a-jwt' }), /session token did not verify/);
   const unknown = logged({ authenticateWith: '<script>', authenticationValue: 'x' });

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test, { after } from 'node:test';
 
 import jwt from 'jsonwebtoken';
 import * as otplib from 'otplib';
@@ -29,18 +33,30 @@ const setupAppConfig = (enable2FA, secret2FA) => {
 };
 
 // failedLoginAttempts is module-level state in authenticate.js, keyed by the request IP
-// from common.getRequestIP, which prefers x-forwarded-for (server/utils/common.ts).
-// Unique IPs give each call a fresh counter; tests exercising the counter itself pass an
-// explicit ip to share one key across calls.
+// from common.getRequestIP, which reads req.ip -- what express derives from the socket peer
+// and, only through configured trusted proxies, X-Forwarded-For (see common.test.mjs for
+// that derivation). Unique IPs give each call a fresh counter; tests exercising the counter
+// itself pass an explicit ip to share one key across calls.
 let ipCounter = 0;
-const nextIP = () => '10.0.0.' + (ipCounter = ipCounter + 1);
-const mockRequest = ({ twoFAToken, ip, authToken, password } = {}) => {
-  const headers = { 'x-forwarded-for': ip || nextIP() };
+const nextIP = () => {
+  ipCounter = ipCounter + 1;
+  return '10.' + ((ipCounter >> 16) & 255) + '.' + ((ipCounter >> 8) & 255) + '.' + (ipCounter & 255);
+};
+const mockRequest = (opts = {}) => {
+  const { twoFAToken, ip, authToken, password, forwardedFor, authenticateWith } = opts;
+  const headers = {};
   if (authToken) { headers.authorization = 'Bearer ' + authToken; }
+  if (forwardedFor) { headers['x-forwarded-for'] = forwardedFor; }
   return {
-    body: { authenticateWith: 'PASSWORD', authenticationValue: password || PASSWORD_HASH, twoFAToken: twoFAToken },
+    body: {
+      authenticateWith: authenticateWith || 'PASSWORD',
+      // authenticationValue is taken verbatim when given, so a test can send a non-string.
+      authenticationValue: ('authenticationValue' in opts) ? opts.authenticationValue : (password || PASSWORD_HASH),
+      twoFAToken: twoFAToken
+    },
     session: {},
     headers: headers,
+    ip: ip || nextIP(),
     connection: {},
     socket: {}
   };
@@ -298,7 +314,7 @@ test('a lookup or a successful login does not consume a slot in the table', () =
   failTimes(tracked, 1, now);
   for (let i = 0; i < MAX_TRACKED_ADDRESSES + 5; i++) {
     getFailedInfo('lookup-' + i, now);
-    authenticateUser(mockRequest({ ip: 'login-' + i }), mockResponse(), null);
+    authenticateUser(mockRequest(), mockResponse(), null);
   }
   assert.equal(trackedAddresses(), 1, 'lookups and successful logins stored nothing');
   assert.equal(getFailedInfo(tracked, now).count, 1, 'nothing above evicted the tracked entry');
@@ -348,4 +364,95 @@ test('failed-attempt counters are keyed safely against prototype names', () => {
   failTimes('__proto__', 2, now);
   assert.equal(getFailedInfo('__proto__', now).count, 2);
   assert.equal(getFailedInfo('toString', now).count, 0);
+});
+
+test('the lockout counter keys on req.ip and ignores X-Forwarded-For', () => {
+  setupAppConfig(false, '');
+  const ip = nextIP();
+  for (let i = 0; i < ALLOWED_LOGIN_ATTEMPTS; i++) {
+    // Rotating the header used to hand the client a fresh counter per request (issue #1656).
+    authenticateUser(mockRequest({ ip: ip, password: 'wrong', forwardedFor: '203.0.113.' + i }), mockResponse(), null);
+  }
+  const locked = mockResponse();
+  authenticateUser(mockRequest({ ip: ip, forwardedFor: '203.0.113.99' }), locked, null);
+  assert.equal(locked.statusCode, 401);
+  assert.match(locked.body.error, /locked/);
+  // Nor can the header aim a request at another address's counter.
+  const other = mockResponse();
+  authenticateUser(mockRequest({ forwardedFor: ip }), other, null);
+  assert.equal(other.statusCode, 200);
+});
+
+// SSO mode (issue #1656, finding 4). The access key a caller presents is the hex SHA-256 of
+// the cookie file; the tests below drive the same branch verify-sso.sh exercises against
+// the BTCPay harness, with a temporary cookie file so a successful login can rotate it.
+const SSO_COOKIE = 'a'.repeat(64);
+const ssoAccessKey = () => createHash('sha256').update(SSO_COOKIE).digest('hex');
+const ssoTempDirs = [];
+after(() => ssoTempDirs.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+const setupSSOConfig = () => {
+  setupAppConfig(false, '');
+  const dir = mkdtempSync(join(tmpdir(), 'rtl-sso-'));
+  ssoTempDirs.push(dir);
+  const cookiePath = join(dir, '.cookie');
+  writeFileSync(cookiePath, SSO_COOKIE);
+  Common.appConfig.SSO = { rtlSSO: 1, rtlCookiePath: cookiePath, logoutRedirectLink: '', cookieValue: SSO_COOKIE };
+  // The refusal path logs through handleError against the selected node; before login the
+  // session has none and it falls back to the process-wide one, which app startup sets.
+  Common.selectedNode = { index: 1, lnNode: 'node', lnImplementation: 'LND', settings: { logLevel: 'ERROR' } };
+  return cookiePath;
+};
+
+test('SSO: the access key derived from the cookie is accepted and the cookie rotates', () => {
+  const cookiePath = setupSSOConfig();
+  const res = mockResponse();
+  authenticateUser(mockRequest({ authenticationValue: ssoAccessKey() }), res, null);
+  assert.equal(res.statusCode, 200);
+  assert.equal(typeof res.body.token, 'string');
+  const rotated = readFileSync(cookiePath, 'utf-8');
+  assert.notEqual(rotated, SSO_COOKIE, 'a used cookie is replaced');
+  assert.equal(Common.appConfig.SSO.cookieValue, rotated, 'and the replacement is what the next login must match');
+});
+
+test('SSO: an access key that is not a 64-byte string is refused with 406, not thrown', () => {
+  setupSSOConfig();
+  // crypto.timingSafeEqual throws RangeError on a length mismatch and Buffer.from throws
+  // TypeError on a non-string; either used to surface as a 400 from the catch-all handler.
+  const key = ssoAccessKey();
+  for (const bad of [undefined, null, 123, ['a'], { key }, '', 'short', key + '0', key.slice(0, 63) + '\u00e9']) {
+    const res = mockResponse();
+    assert.doesNotThrow(() => authenticateUser(mockRequest({ authenticationValue: bad }), res, null));
+    assert.equal(res.statusCode, 406, 'refused: ' + JSON.stringify(bad));
+    assert.match(res.body.error, /SSO Authentication Failed/);
+  }
+});
+
+test('SSO: a well-formed but wrong access key is refused with 406', () => {
+  setupSSOConfig();
+  const res = mockResponse();
+  authenticateUser(mockRequest({ authenticationValue: 'f'.repeat(64) }), res, null);
+  assert.equal(res.statusCode, 406);
+  assert.match(res.body.error, /SSO Authentication Failed/);
+});
+
+test('SSO: a JWT that does not verify is refused with 406, not thrown', () => {
+  setupSSOConfig();
+  // jwt.verify throws on a missing, malformed or foreign token; that too was a 400.
+  for (const bad of [undefined, '', 'not-a-jwt', jwt.sign({ user: 'NODE_USER' }, 'some-other-secret')]) {
+    const res = mockResponse();
+    assert.doesNotThrow(() => authenticateUser(mockRequest({ authenticateWith: 'JWT', authenticationValue: bad }), res, null));
+    assert.equal(res.statusCode, 406, 'refused: ' + JSON.stringify(bad));
+  }
+  // A token this process minted is recognised, and still told SSO takes no password login.
+  const res = mockResponse();
+  authenticateUser(mockRequest({ authenticateWith: 'JWT', authenticationValue: mockSessionToken() }), res, null);
+  assert.equal(res.statusCode, 406);
+  assert.match(res.body.error, /not allowed with SSO/);
+});
+
+test('SSO: an unrecognised authenticateWith gets a 406 rather than no reply at all', () => {
+  setupSSOConfig();
+  const res = mockResponse();
+  authenticateUser(mockRequest({ authenticateWith: 'NOAUTH', authenticationValue: ssoAccessKey() }), res, null);
+  assert.equal(res.statusCode, 406);
 });

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -55,7 +55,7 @@ const nextIP = () => {
   return '10.' + ((ipCounter >> 16) & 255) + '.' + ((ipCounter >> 8) & 255) + '.' + (ipCounter & 255);
 };
 const mockRequest = (opts = {}) => {
-  const { twoFAToken, ip, authToken, password, forwardedFor, authenticateWith, noAddress } = opts;
+  const { twoFAToken, ip, authToken, password, forwardedFor, authenticateWith, noAddress, peer, rawIP } = opts;
   const headers = {};
   if (authToken) { headers.authorization = 'Bearer ' + authToken; }
   if (forwardedFor) { headers['x-forwarded-for'] = forwardedFor; }
@@ -69,10 +69,18 @@ const mockRequest = (opts = {}) => {
     session: {},
     headers: headers,
     // noAddress models a request whose socket is already gone: no req.ip, no peer address.
-    ip: noAddress ? undefined : (ip || nextIP()),
+    // rawIP is what express would hand over verbatim (a trusted proxy's junk); peer is the
+    // socket address when it differs from req.ip (a trusted proxy that resolved the client).
+    ip: noAddress ? undefined : (rawIP !== undefined ? rawIP : (ip || nextIP())),
     connection: {},
     socket: {}
   };
+};
+// req.ip equals the socket peer unless the test says otherwise.
+const mockRequestWithPeer = (opts = {}) => {
+  const req = mockRequest(opts);
+  if (!opts.noAddress) { req.socket.remoteAddress = opts.peer !== undefined ? opts.peer : req.ip; }
+  return req;
 };
 
 const mockResponse = () => {
@@ -470,23 +478,47 @@ test('SSO: an unrecognised authenticateWith gets a 406 rather than no reply at a
   assert.equal(res.statusCode, 406);
 });
 
-test('the first login carrying X-Forwarded-For while no proxy is trusted logs a configuration warning, once', () => {
+test('a login carrying X-Forwarded-For that was keyed on the socket peer logs a configuration warning, once per address', () => {
   setupAppConfig(false, '');
   resetForwardedHeaderWarning();
-  const isWarning = (entry) => /trustedProxies/.test(entry.msg);
-  const plain = captureLog(() => authenticateUser(mockRequest(), mockResponse(), null));
-  assert.equal(plain.filter(isWarning).length, 0, 'a request without the header says nothing');
-  const first = captureLog(() => authenticateUser(mockRequest({ ip: '10.9.9.1', forwardedFor: '203.0.113.7' }), mockResponse(), null));
-  assert.equal(first.filter(isWarning).length, 1);
-  assert.match(first.find(isWarning).msg, /10\.9\.9\.1/, 'names the address the lockout is keyed on');
-  const second = captureLog(() => authenticateUser(mockRequest({ forwardedFor: '203.0.113.8' }), mockResponse(), null));
-  assert.equal(second.filter(isWarning).length, 0, 'one-shot');
-  // With a proxy trusted, the header is honoured and there is nothing to warn about.
+  const isWarning = (entry) => /Configuration warning/.test(entry.msg);
+  const warnings = (opts) => captureLog(() => authenticateUser(mockRequestWithPeer(opts), mockResponse(), null)).filter(isWarning);
+  assert.equal(warnings({}).length, 0, 'a request without the header says nothing');
+  const first = warnings({ ip: '10.9.9.1', forwardedFor: '203.0.113.7' });
+  assert.equal(first.length, 1);
+  assert.match(first[0].msg, /no trustedProxies is configured/);
+  assert.match(first[0].msg, /10\.9\.9\.1/, 'names the address the lockout is keyed on');
+  assert.equal(warnings({ ip: '10.9.9.1', forwardedFor: '203.0.113.8' }).length, 0, 'once per address');
+  assert.equal(warnings({ ip: '10.9.9.2', forwardedFor: '203.0.113.8' }).length, 1, 'a different peer (another proxy, or a direct caller) does not spend it');
+  // A list that names the wrong proxy is the likelier mistake: the key still equals the
+  // peer, so the warning fires and says which list failed to match.
   resetForwardedHeaderWarning();
   Common.trustedProxies = '127.0.0.1';
-  const trusted = captureLog(() => authenticateUser(mockRequest({ forwardedFor: '203.0.113.9' }), mockResponse(), null));
-  assert.equal(trusted.filter(isWarning).length, 0);
+  const mismatch = warnings({ ip: '172.18.0.5', forwardedFor: '203.0.113.9' });
+  assert.equal(mismatch.length, 1);
+  assert.match(mismatch[0].msg, /no entry in trustedProxies \("127\.0\.0\.1"\) matches the connecting address 172\.18\.0\.5/);
+  // When the proxy did match, express resolved the client and req.ip differs from the peer.
+  assert.equal(warnings({ ip: '203.0.113.9', peer: '127.0.0.1', forwardedFor: '203.0.113.9' }).length, 0);
   Common.trustedProxies = '';
+});
+
+test('a forwarded value that is not an address is refused, not keyed on the proxy', () => {
+  // A trusted proxy that passes the client's own header through hands express junk as
+  // req.ip. Keying that on the proxy's address would let the client fill the proxy's shared
+  // counter for free; refusing costs only that client.
+  clearFailedAttempts();
+  setupAppConfig(false, '');
+  const proxy = '172.18.0.5';
+  for (let i = 0; i < ALLOWED_LOGIN_ATTEMPTS + 1; i++) {
+    const res = mockResponse();
+    authenticateUser(mockRequestWithPeer({ rawIP: 'garbage-' + i, peer: proxy, password: 'wrong' }), res, null);
+    assert.equal(res.statusCode, 401);
+    assert.match(res.body.error, /address could not be determined/);
+  }
+  assert.equal(trackedAddresses(), 0, 'nothing was recorded against anyone');
+  const res = mockResponse();
+  authenticateUser(mockRequestWithPeer({ ip: proxy }), res, null);
+  assert.equal(res.statusCode, 200, 'the proxy address itself is not locked');
 });
 
 test('a login with no determinable client address is refused, not counted under a shared key', () => {
@@ -521,11 +553,14 @@ test('on a unix-socket listener every client shares one fixed key instead of bei
     authenticateUser(mockRequest({ noAddress: true }), locked, null);
     assert.equal(locked.statusCode, 401);
     assert.match(locked.body.error, /locked/);
-    // trustedProxies cannot apply here (no peer address to match), so the one-shot advice
-    // to set it stays silent.
+    // trustedProxies cannot match anything here, so the warning says so instead of
+    // recommending it.
     resetForwardedHeaderWarning();
     const lines = captureLog(() => authenticateUser(mockRequest({ noAddress: true, forwardedFor: '203.0.113.7' }), mockResponse(), null));
-    assert.equal(lines.filter((e) => /trustedProxies/.test(e.msg)).length, 0);
+    const warned = lines.filter((e) => /Configuration warning/.test(e.msg));
+    assert.equal(warned.length, 1);
+    assert.match(warned[0].msg, /unix socket path/);
+    assert.match(warned[0].msg, /Listen on a TCP loopback port/);
   } finally {
     Common.port = savedPort;
     clearFailedAttempts();

--- a/test/backend/authenticate.test.mjs
+++ b/test/backend/authenticate.test.mjs
@@ -7,8 +7,9 @@ import test, { after } from 'node:test';
 
 import jwt from 'jsonwebtoken';
 import * as otplib from 'otplib';
-import { authenticateUser, getFailedInfo, recordFailedAttempt, sweepExpiredAttempts, clearFailedAttempts, trackedAddresses, ALLOWED_LOGIN_ATTEMPTS, LOCKING_PERIOD, MAX_TRACKED_ADDRESSES } from '../../backend/controllers/shared/authenticate.js';
+import { authenticateUser, getFailedInfo, recordFailedAttempt, sweepExpiredAttempts, clearFailedAttempts, trackedAddresses, resetForwardedHeaderWarning, ALLOWED_LOGIN_ATTEMPTS, LOCKING_PERIOD, MAX_TRACKED_ADDRESSES } from '../../backend/controllers/shared/authenticate.js';
 import { Common } from '../../backend/utils/common.js';
+import { Logger } from '../../backend/utils/logger.js';
 
 const { authenticator } = otplib;
 
@@ -30,6 +31,17 @@ const setupAppConfig = (enable2FA, secret2FA) => {
   };
   Common.selectedNode = null;
   Common.nodes = [];
+  Common.trustedProxies = '';
+};
+
+// Captures what the controller logs while fn runs; the controller reads Logger.log at call
+// time, so swapping the method is enough.
+const captureLog = (fn) => {
+  const lines = [];
+  const original = Logger.log;
+  Logger.log = (entry) => lines.push(entry);
+  try { fn(); } finally { Logger.log = original; }
+  return lines;
 };
 
 // failedLoginAttempts is module-level state in authenticate.js, keyed by the request IP
@@ -43,7 +55,7 @@ const nextIP = () => {
   return '10.' + ((ipCounter >> 16) & 255) + '.' + ((ipCounter >> 8) & 255) + '.' + (ipCounter & 255);
 };
 const mockRequest = (opts = {}) => {
-  const { twoFAToken, ip, authToken, password, forwardedFor, authenticateWith } = opts;
+  const { twoFAToken, ip, authToken, password, forwardedFor, authenticateWith, noAddress } = opts;
   const headers = {};
   if (authToken) { headers.authorization = 'Bearer ' + authToken; }
   if (forwardedFor) { headers['x-forwarded-for'] = forwardedFor; }
@@ -56,7 +68,8 @@ const mockRequest = (opts = {}) => {
     },
     session: {},
     headers: headers,
-    ip: ip || nextIP(),
+    // noAddress models a request whose socket is already gone: no req.ip, no peer address.
+    ip: noAddress ? undefined : (ip || nextIP()),
     connection: {},
     socket: {}
   };
@@ -455,4 +468,46 @@ test('SSO: an unrecognised authenticateWith gets a 406 rather than no reply at a
   const res = mockResponse();
   authenticateUser(mockRequest({ authenticateWith: 'NOAUTH', authenticationValue: ssoAccessKey() }), res, null);
   assert.equal(res.statusCode, 406);
+});
+
+test('the first login carrying X-Forwarded-For while no proxy is trusted logs a configuration warning, once', () => {
+  setupAppConfig(false, '');
+  resetForwardedHeaderWarning();
+  const isWarning = (entry) => /trustedProxies/.test(entry.msg);
+  const plain = captureLog(() => authenticateUser(mockRequest(), mockResponse(), null));
+  assert.equal(plain.filter(isWarning).length, 0, 'a request without the header says nothing');
+  const first = captureLog(() => authenticateUser(mockRequest({ ip: '10.9.9.1', forwardedFor: '203.0.113.7' }), mockResponse(), null));
+  assert.equal(first.filter(isWarning).length, 1);
+  assert.match(first.find(isWarning).msg, /10\.9\.9\.1/, 'names the address the lockout is keyed on');
+  const second = captureLog(() => authenticateUser(mockRequest({ forwardedFor: '203.0.113.8' }), mockResponse(), null));
+  assert.equal(second.filter(isWarning).length, 0, 'one-shot');
+  // With a proxy trusted, the header is honoured and there is nothing to warn about.
+  resetForwardedHeaderWarning();
+  Common.trustedProxies = '127.0.0.1';
+  const trusted = captureLog(() => authenticateUser(mockRequest({ forwardedFor: '203.0.113.9' }), mockResponse(), null));
+  assert.equal(trusted.filter(isWarning).length, 0);
+  Common.trustedProxies = '';
+});
+
+test('a login with no determinable client address is refused, not counted under a shared key', () => {
+  clearFailedAttempts();
+  setupAppConfig(false, '');
+  const res = mockResponse();
+  authenticateUser(mockRequest({ noAddress: true, password: 'wrong' }), res, null);
+  assert.equal(res.statusCode, 401);
+  assert.match(res.body.error, /address could not be determined/);
+  assert.equal(trackedAddresses(), 0, 'nothing was recorded');
+  const right = mockResponse();
+  authenticateUser(mockRequest({ noAddress: true }), right, null);
+  assert.equal(right.statusCode, 401, 'the right password is refused too: the lockout cannot be applied');
+});
+
+test('SSO: the server log names which of the three refusal causes applied', () => {
+  setupSSOConfig();
+  const logged = (opts) => captureLog(() => authenticateUser(mockRequest(opts), mockResponse(), null)).map((e) => e.msg).join('\n');
+  assert.match(logged({ authenticationValue: 'short' }), /access key too short or does not match/);
+  assert.match(logged({ authenticateWith: 'JWT', authenticationValue: 'not-a-jwt' }), /session token did not verify/);
+  const unknown = logged({ authenticateWith: '<script>', authenticationValue: 'x' });
+  assert.match(unknown, /neither PASSWORD nor JWT/);
+  assert.doesNotMatch(unknown, /<script>/, 'the client-supplied mode value is not echoed into the log');
 });

--- a/test/backend/boot-config.test.mjs
+++ b/test/backend/boot-config.test.mjs
@@ -51,7 +51,7 @@ const boot = (configDir, env = {}) => new Promise((resolve) => {
   // The developer's own RTL variables must not reach the child: config.ts honours them,
   // and an exported TRUSTED_PROXIES or PORT would change what is being tested.
   const cleanEnv = { ...process.env };
-  ['TRUSTED_PROXIES', 'PORT', 'HOST', 'RTL_SSO', 'RTL_COOKIE_PATH', 'APP_PASSWORD', 'DISABLE_AUTH', 'LN_IMPLEMENTATION', 'LN_SERVER_URL', 'MACAROON_PATH']
+  ['TRUSTED_PROXIES', 'PORT', 'HOST', 'RTL_SSO', 'RTL_COOKIE_PATH', 'APP_PASSWORD', 'DISABLE_AUTH', 'LN_IMPLEMENTATION', 'LN_SERVER_URL', 'MACAROON_PATH', 'CHANNEL_BACKUP_PATH']
     .forEach((key) => delete cleanEnv[key]);
   const child = spawn(process.execPath, ['rtl.js'], {
     cwd: repoRoot,

--- a/test/backend/boot-config.test.mjs
+++ b/test/backend/boot-config.test.mjs
@@ -48,9 +48,14 @@ const writeConfig = (trustedProxies) => {
 
 // Starts rtl.js and resolves once it exits or prints the listening line (then it is killed).
 const boot = (configDir, env = {}) => new Promise((resolve) => {
+  // The developer's own RTL variables must not reach the child: config.ts honours them,
+  // and an exported TRUSTED_PROXIES or PORT would change what is being tested.
+  const cleanEnv = { ...process.env };
+  ['TRUSTED_PROXIES', 'PORT', 'HOST', 'RTL_SSO', 'RTL_COOKIE_PATH', 'APP_PASSWORD', 'DISABLE_AUTH', 'LN_IMPLEMENTATION', 'LN_SERVER_URL', 'MACAROON_PATH']
+    .forEach((key) => delete cleanEnv[key]);
   const child = spawn(process.execPath, ['rtl.js'], {
     cwd: repoRoot,
-    env: { ...process.env, RTL_CONFIG_PATH: configDir, DB_DIRECTORY_PATH: configDir, ...env }
+    env: { ...cleanEnv, RTL_CONFIG_PATH: configDir, DB_DIRECTORY_PATH: configDir, ...env }
   });
   let stdout = '';
   let stderr = '';
@@ -72,15 +77,14 @@ const boot = (configDir, env = {}) => new Promise((resolve) => {
 
 test('a non-string trustedProxies refuses to start with a message naming the key', async () => {
   const result = await boot(writeConfig(123));
-  assert.notEqual(result.code, 0);
-  assert.notEqual(result.code, 'listening');
+  // Exactly 1: 'timeout' (printed the message, then hung) must not pass either.
+  assert.equal(result.code, 1, 'stderr: ' + result.stderr);
   assert.match(result.stderr, /trustedProxies must be a comma-separated list/);
 });
 
 test('a malformed trustedProxies list refuses to start when express compiles it', async () => {
   const result = await boot(writeConfig('garbage, loopback'));
-  assert.notEqual(result.code, 0);
-  assert.notEqual(result.code, 'listening');
+  assert.equal(result.code, 1, 'stderr: ' + result.stderr);
   assert.match(result.stderr, /Invalid trustedProxies value "garbage, loopback": invalid IP address: garbage/);
 });
 

--- a/test/backend/boot-config.test.mjs
+++ b/test/backend/boot-config.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test, { after } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// Boot-time refusals for a bad trustedProxies value (issue #1656). Both branches sit in code
+// that runs as a side effect of importing the config and app modules, so they are exercised
+// the way an operator meets them: by starting rtl.js in a child process against a throwaway
+// RTL-Config.json and reading what it prints before it exits.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const tempDirs = [];
+after(() => tempDirs.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+const writeConfig = (trustedProxies) => {
+  const dir = mkdtempSync(join(tmpdir(), 'rtl-boot-'));
+  tempDirs.push(dir);
+  // Enough of a config to get past validateNodeConfig without touching a node: a macaroon
+  // file to read, and an existing channel-all.bak so no backup request is attempted.
+  mkdirSync(join(dir, 'macaroon'));
+  writeFileSync(join(dir, 'macaroon', 'admin.macaroon'), 'not-a-real-macaroon');
+  mkdirSync(join(dir, 'backup'));
+  writeFileSync(join(dir, 'backup', 'channel-all.bak'), '');
+  const config = {
+    multiPass: 'password',
+    port: '0',
+    defaultNodeIndex: 1,
+    dbDirectoryPath: dir,
+    SSO: { rtlSSO: 0, rtlCookiePath: '', logoutRedirectLink: '' },
+    nodes: [{
+      index: 1,
+      lnNode: 'Node 1',
+      lnImplementation: 'LND',
+      authentication: { macaroonPath: join(dir, 'macaroon'), configPath: '' },
+      settings: {
+        userPersona: 'MERCHANT', themeMode: 'DAY', themeColor: 'PURPLE', logLevel: 'ERROR',
+        channelBackupPath: join(dir, 'backup'), lnServerUrl: 'https://127.0.0.1:1',
+        fiatConversion: false, unannouncedChannels: false, blockExplorerUrl: 'https://mempool.space'
+      }
+    }]
+  };
+  if (trustedProxies !== undefined) { config.trustedProxies = trustedProxies; }
+  writeFileSync(join(dir, 'RTL-Config.json'), JSON.stringify(config, null, 2));
+  return dir;
+};
+
+// Starts rtl.js and resolves once it exits or prints the listening line (then it is killed).
+const boot = (configDir, env = {}) => new Promise((resolve) => {
+  const child = spawn(process.execPath, ['rtl.js'], {
+    cwd: repoRoot,
+    env: { ...process.env, RTL_CONFIG_PATH: configDir, DB_DIRECTORY_PATH: configDir, ...env }
+  });
+  let stdout = '';
+  let stderr = '';
+  let settled = false;
+  const finish = (code) => {
+    if (settled) { return; }
+    settled = true;
+    clearTimeout(timer);
+    resolve({ code, stdout, stderr });
+  };
+  const timer = setTimeout(() => { child.kill(); finish('timeout'); }, 20000);
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+    if (/Server is up and running/.test(stdout)) { child.kill(); finish('listening'); }
+  });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  child.on('exit', (code) => finish(code));
+});
+
+test('a non-string trustedProxies refuses to start with a message naming the key', async () => {
+  const result = await boot(writeConfig(123));
+  assert.notEqual(result.code, 0);
+  assert.notEqual(result.code, 'listening');
+  assert.match(result.stderr, /trustedProxies must be a comma-separated list/);
+});
+
+test('a malformed trustedProxies list refuses to start when express compiles it', async () => {
+  const result = await boot(writeConfig('garbage, loopback'));
+  assert.notEqual(result.code, 0);
+  assert.notEqual(result.code, 'listening');
+  assert.match(result.stderr, /Invalid trustedProxies value "garbage, loopback": invalid IP address: garbage/);
+});
+
+test('an empty TRUSTED_PROXIES switches off the config file list rather than falling through to it', async () => {
+  // The file's list is malformed, so if the empty variable fell through to it the boot would
+  // refuse; reaching the listening line proves the variable took precedence.
+  const result = await boot(writeConfig('garbage, loopback'), { TRUSTED_PROXIES: '' });
+  assert.equal(result.code, 'listening', 'stderr: ' + result.stderr);
+});
+
+test('a well-formed trustedProxies list boots (control for the refusals above)', async () => {
+  const result = await boot(writeConfig('127.0.0.1, 10.0.0.0/8'));
+  assert.equal(result.code, 'listening', 'stderr: ' + result.stderr);
+});

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -395,11 +395,19 @@ test('getRequestIP takes the client from X-Forwarded-For only through a trusted 
   assert.equal(await requestIPWith('10.0.0.0/8', { 'x-forwarded-for': '203.0.113.7' }), '127.0.0.1', 'a peer outside the trusted range is the client');
 });
 
-test('getRequestIP falls back to the socket peer when the forwarded value is not an address', async () => {
+test('getRequestIP yields no address when a trusted proxy forwards something that is not one', async () => {
   // A proxy that passes the client's own header through unchanged would otherwise let
-  // arbitrary text into the lockout key and the failed-login log line.
+  // arbitrary text into the lockout key and the failed-login log line; and falling back to
+  // the proxy's own address would let that client fill the proxy's shared counter for free.
   // net.isIP accepts an IPv6 zone id of any length, so an over-long one is also rejected.
   for (const junk of ['not an address', '<script>alert(1)</script>', '203.0.113.7:4444', 'unknown', '::1%' + 'z'.repeat(100)]) {
-    assert.equal(await requestIPWith('loopback', { 'x-forwarded-for': junk }), '127.0.0.1', JSON.stringify(junk));
+    assert.equal(await requestIPWith('loopback', { 'x-forwarded-for': junk }), null, JSON.stringify(junk));
   }
+});
+
+test('overBroadTrustedProxies flags entries that cover more than one host', () => {
+  assert.deepEqual(Common.overBroadTrustedProxies(''), []);
+  assert.deepEqual(Common.overBroadTrustedProxies('127.0.0.1, 172.18.0.5, 10.0.0.1/32, ::1/128'), []);
+  assert.deepEqual(Common.overBroadTrustedProxies('uniquelocal'), ['uniquelocal']);
+  assert.deepEqual(Common.overBroadTrustedProxies('127.0.0.1, loopback, 10.0.0.0/8, fd00::/8, linklocal'), ['loopback', '10.0.0.0/8', 'fd00::/8', 'linklocal']);
 });

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
 import test from 'node:test';
+
+import express from 'express';
 
 import { Common } from '../../backend/utils/common.js';
 
@@ -347,4 +350,44 @@ test('maskPasswords does not mutate its input', () => {
   const config = { authentication: { options: { headers: { 'Grpc-Metadata-macaroon': 'deadbeef' } } } };
   Common.maskPasswords(config);
   assert.equal(config.authentication.options.headers['Grpc-Metadata-macaroon'], 'deadbeef');
+});
+
+// getRequestIP keys the login-lockout counter, so it is exercised over a real socket with
+// express computing req.ip under each trust setting app.ts can apply: the question is when
+// the socket peer and when the X-Forwarded-For chain names the client (issue #1656).
+const requestIPWith = async (trustProxy, headers) => {
+  const app = express();
+  app.set('trust proxy', trustProxy);
+  app.get('/', (req, res) => res.json({ ip: Common.getRequestIP(req) }));
+  const server = createServer(app);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const res = await fetch('http://127.0.0.1:' + server.address().port + '/', { headers: headers });
+    return (await res.json()).ip;
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+};
+
+test('getRequestIP ignores X-Forwarded-For when no proxy is trusted', async () => {
+  assert.equal(await requestIPWith(false, {}), '127.0.0.1');
+  assert.equal(await requestIPWith(false, { 'x-forwarded-for': '203.0.113.7' }), '127.0.0.1');
+});
+
+test('getRequestIP takes the client from X-Forwarded-For only through a trusted proxy', async () => {
+  // The connection comes from 127.0.0.1, the trusted proxy here, so the address it appended
+  // is the client; a hop the client itself prepended is not walked past.
+  assert.equal(await requestIPWith('loopback', { 'x-forwarded-for': '203.0.113.7' }), '203.0.113.7');
+  assert.equal(await requestIPWith('loopback', { 'x-forwarded-for': '198.51.100.1, 203.0.113.7' }), '203.0.113.7');
+  assert.equal(await requestIPWith('127.0.0.1', { 'x-forwarded-for': '203.0.113.7' }), '203.0.113.7');
+  assert.equal(await requestIPWith('10.0.0.0/8', { 'x-forwarded-for': '203.0.113.7' }), '127.0.0.1', 'a peer outside the trusted range is the client');
+});
+
+test('getRequestIP falls back to the socket peer when the forwarded value is not an address', async () => {
+  // A proxy that passes the client's own header through unchanged would otherwise let
+  // arbitrary text into the lockout key and the failed-login log line.
+  for (const junk of ['not an address', '<script>alert(1)</script>', '203.0.113.7:4444', 'unknown']) {
+    assert.equal(await requestIPWith('loopback', { 'x-forwarded-for': junk }), '127.0.0.1', JSON.stringify(junk));
+  }
 });

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -142,6 +142,17 @@ test('addSecureData pins disableAuth and the SSO object to server-held values', 
   assert.equal(config.enable2FA, true);
 });
 
+test('addSecureData pins trustedProxies to the server-held value, and drops it when the server holds none', () => {
+  // Whose X-Forwarded-For keys the login lockout is a deployment switch like disableAuth:
+  // a settings save can neither widen the list nor silently lose it.
+  seedAppConfig();
+  Common.appConfig.trustedProxies = '127.0.0.1';
+  assert.equal(Common.addSecureData({ trustedProxies: '0.0.0.0/0, ::/0', nodes: [] }).trustedProxies, '127.0.0.1');
+  assert.equal(Common.addSecureData({ nodes: [] }).trustedProxies, '127.0.0.1', 'an omitted key does not drop the list');
+  delete Common.appConfig.trustedProxies;
+  assert.equal('trustedProxies' in Common.addSecureData({ trustedProxies: '0.0.0.0/0', nodes: [] }), false);
+});
+
 test('addSecureData honors a fresh seed only when the server holds no live seed', () => {
   // The settings UI's enable flow sends a non-empty seed and only ever runs while 2FA is
   // off; with no live seed server-side, the client seed is the enable flow and is honored.

--- a/test/backend/common.test.mjs
+++ b/test/backend/common.test.mjs
@@ -398,7 +398,8 @@ test('getRequestIP takes the client from X-Forwarded-For only through a trusted 
 test('getRequestIP falls back to the socket peer when the forwarded value is not an address', async () => {
   // A proxy that passes the client's own header through unchanged would otherwise let
   // arbitrary text into the lockout key and the failed-login log line.
-  for (const junk of ['not an address', '<script>alert(1)</script>', '203.0.113.7:4444', 'unknown']) {
+  // net.isIP accepts an IPv6 zone id of any length, so an over-long one is also rejected.
+  for (const junk of ['not an address', '<script>alert(1)</script>', '203.0.113.7:4444', 'unknown', '::1%' + 'z'.repeat(100)]) {
     assert.equal(await requestIPWith('loopback', { 'x-forwarded-for': junk }), '127.0.0.1', JSON.stringify(junk));
   }
 });


### PR DESCRIPTION
Supersedes #1700, which was closed by mistake during a local squash merge (the PR head was rewritten to a commit already on the base branch, so GitHub closed it instead of marking it merged). The branch is unchanged from the state the reviews approved: the same six signed commits, head 2dc25bb9. All review discussion, including two rtlreviewbot rounds and an independent adversarial pass, is on #1700.

Closes the remaining findings (3, 4 and 5) of #1656 — see #1700 for the full description and verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5fbLes4f1GmfEsqxNWicr
